### PR TITLE
Take board center into account in initial camera position and grid

### DIFF
--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -50,15 +50,21 @@ export const CadViewer = forwardRef<
       try {
         const board = su(circuitJson as any).pcb_board.list()[0]
         if (!board) return [5, 5, 5] as const
-        const { width, height } = board
+        const { width, height, center } = board
 
         if (!width && !height) {
           return [5, 5, 5] as const
         }
 
         const minCameraDistance = 5
-        const adjustedBoardWidth = Math.max(width, minCameraDistance)
-        const adjustedBoardHeight = Math.max(height, minCameraDistance)
+        const adjustedBoardWidth = Math.max(
+          width + Math.abs(center.x),
+          minCameraDistance,
+        )
+        const adjustedBoardHeight = Math.max(
+          height + Math.abs(center.y),
+          minCameraDistance,
+        )
         const largestDim = Math.max(adjustedBoardWidth, adjustedBoardHeight)
         return [largestDim / 2, largestDim / 2, largestDim] as const
       } catch (e) {

--- a/src/CadViewerContainer.tsx
+++ b/src/CadViewerContainer.tsx
@@ -89,6 +89,7 @@ export const CadViewerContainer = forwardRef<
             infiniteGrid={true}
             cellSize={1}
             sectionSize={10}
+            fadeDistance={Math.max(initialCameraPosition[2] * 2, 100)}
           />
           <object3D ref={ref}>{children}</object3D>
           {hoveredComponent && (


### PR DESCRIPTION
The idea is simple. Add the value of board center coordinates to the initial value of camera position to get an effect similar to camera panning/zooming out. Also extend the grid to contain the entirety of the board by setting its fade distance to largest dimension provided.

Before (after zooming out)
![image](https://github.com/user-attachments/assets/06b71d88-4ea5-42d5-ba3d-70794aaf463d)

After (No zooming, that's the initial view after it auto rotated a bit)
![image](https://github.com/user-attachments/assets/de80c7fa-c9d3-407c-a06e-095ec7bad1c1)

/claim #182