### PR TITLE
optimise cutting the board

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -462,7 +462,7 @@ export class BoardGeomBuilder {
         pcb_plated_hole_id: `via_${via.pcb_via_id}`, // Create a unique-ish ID
       },
       {
-        dontCutBoard: true, // Board cut should happen via trace logic or dedicated via cut
+        dontCutBoard: false,
       },
     )
   }

--- a/stories/Keyboard.stories.tsx
+++ b/stories/Keyboard.stories.tsx
@@ -1,6 +1,7 @@
 import { fn } from "@storybook/test"
 import { CadViewer } from "src/CadViewer"
 import keyboard60 from "./assets/keyboard-default60.json"
+import keyboardWith9Keys from "./assets/9-key-keyboard.json"
 
 /**
  * A switch shaft you can use to connect a pluggable Kailh socket.
@@ -92,6 +93,10 @@ export const Default = () => (
 )
 
 export const Default60 = () => <CadViewer circuitJson={keyboard60} />
+
+export const KeyboardWith9Keys = () => (
+  <CadViewer circuitJson={keyboardWith9Keys as any} />
+)
 
 export default {
   title: "Keyboard",

--- a/stories/assets/9-key-keyboard.json
+++ b/stories/assets/9-key-keyboard.json
@@ -1,0 +1,16820 @@
+[
+  {
+    "type": "source_project_metadata",
+    "source_project_metadata_id": "source_project_metadata_0",
+    "software_used_string": "@tscircuit/core@0.0.361"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "GP0",
+    "pin_number": 1,
+    "port_hints": ["GP0", "pin1", "1"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "GP1",
+    "pin_number": 2,
+    "port_hints": ["GP1", "pin2", "2"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_2",
+    "name": "GND1",
+    "pin_number": 3,
+    "port_hints": ["GND1", "pin3", "3"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_3",
+    "name": "GP2",
+    "pin_number": 4,
+    "port_hints": ["GP2", "pin4", "4"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "name": "GP3",
+    "pin_number": 5,
+    "port_hints": ["GP3", "pin5", "5"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "name": "GP4",
+    "pin_number": 6,
+    "port_hints": ["GP4", "pin6", "6"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "name": "GP5",
+    "pin_number": 7,
+    "port_hints": ["GP5", "pin7", "7"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "name": "GND",
+    "pin_number": 8,
+    "port_hints": ["GND", "pin8", "8"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_8",
+    "name": "GP6",
+    "pin_number": 9,
+    "port_hints": ["GP6", "pin9", "9"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_9",
+    "name": "GP7",
+    "pin_number": 10,
+    "port_hints": ["GP7", "pin10", "10"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_10",
+    "name": "GP8",
+    "pin_number": 11,
+    "port_hints": ["GP8", "pin11", "11"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_11",
+    "name": "GP9",
+    "pin_number": 12,
+    "port_hints": ["GP9", "pin12", "12"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_12",
+    "name": "GND2",
+    "pin_number": 13,
+    "port_hints": ["GND2", "pin13", "13"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_13",
+    "name": "GP10",
+    "pin_number": 14,
+    "port_hints": ["GP10", "pin14", "14"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_14",
+    "name": "GP11",
+    "pin_number": 15,
+    "port_hints": ["GP11", "pin15", "15"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_15",
+    "name": "GP12",
+    "pin_number": 16,
+    "port_hints": ["GP12", "pin16", "16"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_16",
+    "name": "GP13",
+    "pin_number": 17,
+    "port_hints": ["GP13", "pin17", "17"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_17",
+    "name": "GND3",
+    "pin_number": 18,
+    "port_hints": ["GND3", "pin18", "18"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_18",
+    "name": "GP14",
+    "pin_number": 19,
+    "port_hints": ["GP14", "pin19", "19"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_19",
+    "name": "GP15",
+    "pin_number": 20,
+    "port_hints": ["GP15", "pin20", "20"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_20",
+    "name": "GP16",
+    "pin_number": 21,
+    "port_hints": ["GP16", "pin21", "21"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_21",
+    "name": "GP17",
+    "pin_number": 22,
+    "port_hints": ["GP17", "pin22", "22"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_22",
+    "name": "GND4",
+    "pin_number": 23,
+    "port_hints": ["GND4", "pin23", "23"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_23",
+    "name": "GP18",
+    "pin_number": 24,
+    "port_hints": ["GP18", "pin24", "24"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_24",
+    "name": "GP19",
+    "pin_number": 25,
+    "port_hints": ["GP19", "pin25", "25"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_25",
+    "name": "GP20",
+    "pin_number": 26,
+    "port_hints": ["GP20", "pin26", "26"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_26",
+    "name": "GP21",
+    "pin_number": 27,
+    "port_hints": ["GP21", "pin27", "27"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_27",
+    "name": "GND5",
+    "pin_number": 28,
+    "port_hints": ["GND5", "pin28", "28"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_28",
+    "name": "GP22",
+    "pin_number": 29,
+    "port_hints": ["GP22", "pin29", "29"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_29",
+    "name": "RUN",
+    "pin_number": 30,
+    "port_hints": ["RUN", "pin30", "30"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_30",
+    "name": "GP26",
+    "pin_number": 31,
+    "port_hints": ["GP26", "pin31", "31"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_31",
+    "name": "GP27",
+    "pin_number": 32,
+    "port_hints": ["GP27", "pin32", "32"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_32",
+    "name": "GND6",
+    "pin_number": 33,
+    "port_hints": ["GND6", "pin33", "33"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_33",
+    "name": "GP28",
+    "pin_number": 34,
+    "port_hints": ["GP28", "pin34", "34"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_34",
+    "name": "ADC_VREF",
+    "pin_number": 35,
+    "port_hints": ["ADC_VREF", "pin35", "35"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_35",
+    "name": "V3V3",
+    "pin_number": 36,
+    "port_hints": ["V3V3", "pin36", "36"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_36",
+    "name": "V3V3_EN",
+    "pin_number": 37,
+    "port_hints": ["V3V3_EN", "pin37", "37"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_37",
+    "name": "GND7",
+    "pin_number": 38,
+    "port_hints": ["GND7", "pin38", "38"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_38",
+    "name": "VSYS",
+    "pin_number": 39,
+    "port_hints": ["VSYS", "pin39", "39"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_39",
+    "name": "VBUS",
+    "pin_number": 40,
+    "port_hints": ["VBUS", "pin40", "40"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_chip",
+    "name": "U1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_40",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_41",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "name": "K1",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_42",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_43",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "ftype": "simple_chip",
+    "name": "K1_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_44",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_45",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "ftype": "simple_diode",
+    "name": "D1",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_1",
+    "subcircuit_id": "subcircuit_source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_46",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_47",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_4",
+    "name": "K2",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_48",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_49",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_5",
+    "ftype": "simple_chip",
+    "name": "K2_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_2",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_50",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_51",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_6",
+    "ftype": "simple_diode",
+    "name": "D2",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_3",
+    "subcircuit_id": "subcircuit_source_group_3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_52",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_53",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_7",
+    "name": "K3",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_54",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_55",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_8",
+    "ftype": "simple_chip",
+    "name": "K3_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_4",
+    "subcircuit_id": "subcircuit_source_group_4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_56",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_57",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_9",
+    "ftype": "simple_diode",
+    "name": "D3",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_5",
+    "subcircuit_id": "subcircuit_source_group_5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_58",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_59",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_10",
+    "name": "K4",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_60",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_61",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_11",
+    "ftype": "simple_chip",
+    "name": "K4_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_6",
+    "subcircuit_id": "subcircuit_source_group_6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_62",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_63",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_12",
+    "ftype": "simple_diode",
+    "name": "D4",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_7",
+    "subcircuit_id": "subcircuit_source_group_7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_64",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_65",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_13",
+    "name": "K5",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_66",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_67",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_14",
+    "ftype": "simple_chip",
+    "name": "K5_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_8",
+    "subcircuit_id": "subcircuit_source_group_8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_68",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_69",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_15",
+    "ftype": "simple_diode",
+    "name": "D5",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_9",
+    "subcircuit_id": "subcircuit_source_group_9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_70",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_71",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_16",
+    "name": "K6",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_72",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_73",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_17",
+    "ftype": "simple_chip",
+    "name": "K6_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_10",
+    "subcircuit_id": "subcircuit_source_group_10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_74",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_75",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_18",
+    "ftype": "simple_diode",
+    "name": "D6",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_11",
+    "subcircuit_id": "subcircuit_source_group_11"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_76",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_77",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_19",
+    "name": "K7",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_78",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_79",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_20",
+    "ftype": "simple_chip",
+    "name": "K7_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_12",
+    "subcircuit_id": "subcircuit_source_group_12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_80",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_81",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_21",
+    "ftype": "simple_diode",
+    "name": "D7",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_13",
+    "subcircuit_id": "subcircuit_source_group_13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_82",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_83",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_22",
+    "name": "K8",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_84",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_85",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_23",
+    "ftype": "simple_chip",
+    "name": "K8_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_14",
+    "subcircuit_id": "subcircuit_source_group_14"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_86",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_87",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_24",
+    "ftype": "simple_diode",
+    "name": "D8",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_15",
+    "subcircuit_id": "subcircuit_source_group_15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_88",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["side1", "pin1", "1"],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_89",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_25",
+    "name": "K9",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C41430893"]
+    }
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_90",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_91",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "2"],
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_26",
+    "ftype": "simple_chip",
+    "name": "K9_shaft"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_16",
+    "subcircuit_id": "subcircuit_source_group_16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_92",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pos", "anode", "left", "pin1", "1"],
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_93",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["neg", "cathode", "right", "pin2", "2"],
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_27",
+    "ftype": "simple_diode",
+    "name": "D9",
+    "supplier_part_numbers": {
+      "jlcpcb": ["C57759"]
+    }
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_17",
+    "subcircuit_id": "subcircuit_source_group_17"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_18",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_0",
+    "connected_source_port_ids": ["source_port_44", "source_port_40"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D1 .pin1 to .K1 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_1",
+    "connected_source_port_ids": ["source_port_45", "source_port_0"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D1 .pin2 to .U1 .GP0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_2",
+    "connected_source_port_ids": ["source_port_41", "source_port_24"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K1 .pin2 to .U1 .GP19",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_3",
+    "connected_source_port_ids": ["source_port_50", "source_port_46"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D2 .pin1 to .K2 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_4",
+    "connected_source_port_ids": ["source_port_51", "source_port_0"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D2 .pin2 to .U1 .GP0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_5",
+    "connected_source_port_ids": ["source_port_47", "source_port_21"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K2 .pin2 to .U1 .GP17",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_6",
+    "connected_source_port_ids": ["source_port_56", "source_port_52"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D3 .pin1 to .K3 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_7",
+    "connected_source_port_ids": ["source_port_57", "source_port_0"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D3 .pin2 to .U1 .GP0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_8",
+    "connected_source_port_ids": ["source_port_53", "source_port_6"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K3 .pin2 to .U1 .GP5",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_9",
+    "connected_source_port_ids": ["source_port_62", "source_port_58"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D4 .pin1 to .K4 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_10",
+    "connected_source_port_ids": ["source_port_63", "source_port_1"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D4 .pin2 to .U1 .GP1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net8"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_11",
+    "connected_source_port_ids": ["source_port_59", "source_port_24"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K4 .pin2 to .U1 .GP19",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_12",
+    "connected_source_port_ids": ["source_port_68", "source_port_64"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D5 .pin1 to .K5 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net9"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_13",
+    "connected_source_port_ids": ["source_port_69", "source_port_1"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D5 .pin2 to .U1 .GP1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net8"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_14",
+    "connected_source_port_ids": ["source_port_65", "source_port_21"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K5 .pin2 to .U1 .GP17",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_15",
+    "connected_source_port_ids": ["source_port_74", "source_port_70"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D6 .pin1 to .K6 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net10"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_16",
+    "connected_source_port_ids": ["source_port_75", "source_port_1"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D6 .pin2 to .U1 .GP1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net8"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_17",
+    "connected_source_port_ids": ["source_port_71", "source_port_6"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K6 .pin2 to .U1 .GP5",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_18",
+    "connected_source_port_ids": ["source_port_80", "source_port_76"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D7 .pin1 to .K7 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net11"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_19",
+    "connected_source_port_ids": ["source_port_81", "source_port_13"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D7 .pin2 to .U1 .GP10",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net12"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_20",
+    "connected_source_port_ids": ["source_port_77", "source_port_24"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K7 .pin2 to .U1 .GP19",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_21",
+    "connected_source_port_ids": ["source_port_86", "source_port_82"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D8 .pin1 to .K8 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net13"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_22",
+    "connected_source_port_ids": ["source_port_87", "source_port_13"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D8 .pin2 to .U1 .GP10",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net12"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_23",
+    "connected_source_port_ids": ["source_port_83", "source_port_21"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K8 .pin2 to .U1 .GP17",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_24",
+    "connected_source_port_ids": ["source_port_92", "source_port_88"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D9 .pin1 to .K9 .pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net14"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_25",
+    "connected_source_port_ids": ["source_port_93", "source_port_13"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".D9 .pin2 to .U1 .GP10",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net12"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_26",
+    "connected_source_port_ids": ["source_port_89", "source_port_6"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "display_name": ".K9 .pin2 to .U1 .GP5",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit1907_connectivity_net6"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.9000000000000001,
+      "height": 4.200000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "1": "GP0",
+      "2": "GP1",
+      "3": "GND1",
+      "4": "GP2",
+      "5": "GP3",
+      "6": "GP4",
+      "7": "GP5",
+      "8": "GND",
+      "9": "GP6",
+      "10": "GP7",
+      "11": "GP8",
+      "12": "GP9",
+      "13": "GND2",
+      "14": "GP10",
+      "15": "GP11",
+      "16": "GP12",
+      "17": "GP13",
+      "18": "GND3",
+      "19": "GP14",
+      "20": "GP15",
+      "21": "GP16",
+      "22": "GP17",
+      "23": "GND4",
+      "24": "GP18",
+      "25": "GP19",
+      "26": "GP20",
+      "27": "GP21",
+      "28": "GND5",
+      "29": "GP22",
+      "30": "RUN",
+      "31": "GP26",
+      "32": "GP27",
+      "33": "GND6",
+      "34": "GP28",
+      "35": "ADC_VREF",
+      "36": "V3V3",
+      "37": "V3V3_EN",
+      "38": "GND7",
+      "39": "VSYS",
+      "40": "VBUS"
+    },
+    "source_component_id": "source_component_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "text": "",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.9500000000000001,
+      "y": -2.2300000000000004
+    },
+    "color": "#006464"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "text": "U1",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.9500000000000001,
+      "y": 2.2300000000000004
+    },
+    "color": "#006464"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 5.158333333333333,
+      "y": 2.88125
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_1",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 5.158333333333333,
+      "y": 2.38125
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_3",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 8.333333333333334,
+      "y": 2.88125
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_4",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 8.333333333333334,
+      "y": 2.38125
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_6",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": 11.508333333333333,
+      "y": 2.88125
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_7",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 11.508333333333333,
+      "y": 2.38125
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_9",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 5.158333333333333,
+      "y": 0.5
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_10",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 5.158333333333333,
+      "y": 0
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_12",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 8.333333333333334,
+      "y": 0.5
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_13",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 8.333333333333334,
+      "y": 0
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_15",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 11.508333333333333,
+      "y": 0.5
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_16",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 11.508333333333333,
+      "y": 0
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_18",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 5.158333333333333,
+      "y": -1.88125
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_19",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 5.158333333333333,
+      "y": -2.38125
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_21",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 8.333333333333334,
+      "y": -1.88125
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_22",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 8.333333333333334,
+      "y": -2.38125
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_24",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 11.508333333333333,
+      "y": -1.88125
+    },
+    "size": {
+      "width": 1.0011537820000012,
+      "height": 0.44923699999999833
+    },
+    "source_component_id": "source_component_25",
+    "symbol_name": "push_button_normally_open_momentary_horz"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 11.508333333333333,
+      "y": -2.38125
+    },
+    "size": {
+      "width": 1.0402490999999996,
+      "height": 0.5476905999999993
+    },
+    "source_component_id": "source_component_27",
+    "symbol_name": "diode_right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 1.9000000000000006
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "GP0"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 1.7000000000000006
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "GP1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 1.5000000000000004
+    },
+    "source_port_id": "source_port_2",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "GND1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 1.3000000000000005
+    },
+    "source_port_id": "source_port_3",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "GP2"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 1.1000000000000005
+    },
+    "source_port_id": "source_port_4",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "GP3"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 0.9000000000000006
+    },
+    "source_port_id": "source_port_5",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "GP4"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 0.7000000000000006
+    },
+    "source_port_id": "source_port_6",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "GP5"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 0.5000000000000007
+    },
+    "source_port_id": "source_port_7",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "GND"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 0.3000000000000007
+    },
+    "source_port_id": "source_port_8",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "GP6"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": 0.10000000000000075
+    },
+    "source_port_id": "source_port_9",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "GP7"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_10",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -0.0999999999999992
+    },
+    "source_port_id": "source_port_10",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "display_pin_label": "GP8"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_11",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -0.29999999999999916
+    },
+    "source_port_id": "source_port_11",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "display_pin_label": "GP9"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_12",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -0.49999999999999933
+    },
+    "source_port_id": "source_port_12",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "GND2"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_13",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -0.6999999999999995
+    },
+    "source_port_id": "source_port_13",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "GP10"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_14",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -0.8999999999999997
+    },
+    "source_port_id": "source_port_14",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "GP11"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_15",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -1.0999999999999999
+    },
+    "source_port_id": "source_port_15",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "GP12"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_16",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -1.3
+    },
+    "source_port_id": "source_port_16",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 17,
+    "true_ccw_index": 16,
+    "display_pin_label": "GP13"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_17",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -1.5000000000000002
+    },
+    "source_port_id": "source_port_17",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 18,
+    "true_ccw_index": 17,
+    "display_pin_label": "GND3"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_18",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -1.7000000000000004
+    },
+    "source_port_id": "source_port_18",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 19,
+    "true_ccw_index": 18,
+    "display_pin_label": "GP14"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_19",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1.35,
+      "y": -1.9000000000000006
+    },
+    "source_port_id": "source_port_19",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 20,
+    "true_ccw_index": 19,
+    "display_pin_label": "GP15"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_20",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -1.9000000000000006
+    },
+    "source_port_id": "source_port_20",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 21,
+    "true_ccw_index": 20,
+    "display_pin_label": "GP16"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_21",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -1.7000000000000006
+    },
+    "source_port_id": "source_port_21",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 22,
+    "true_ccw_index": 21,
+    "display_pin_label": "GP17"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_22",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -1.5000000000000004
+    },
+    "source_port_id": "source_port_22",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 23,
+    "true_ccw_index": 22,
+    "display_pin_label": "GND4"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_23",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -1.3000000000000005
+    },
+    "source_port_id": "source_port_23",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 24,
+    "true_ccw_index": 23,
+    "display_pin_label": "GP18"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_24",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -1.1000000000000005
+    },
+    "source_port_id": "source_port_24",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 25,
+    "true_ccw_index": 24,
+    "display_pin_label": "GP19"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_25",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -0.9000000000000006
+    },
+    "source_port_id": "source_port_25",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 26,
+    "true_ccw_index": 25,
+    "display_pin_label": "GP20"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_26",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -0.7000000000000006
+    },
+    "source_port_id": "source_port_26",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 27,
+    "true_ccw_index": 26,
+    "display_pin_label": "GP21"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_27",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -0.5000000000000007
+    },
+    "source_port_id": "source_port_27",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 28,
+    "true_ccw_index": 27,
+    "display_pin_label": "GND5"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_28",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -0.3000000000000007
+    },
+    "source_port_id": "source_port_28",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 29,
+    "true_ccw_index": 28,
+    "display_pin_label": "GP22"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_29",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": -0.10000000000000075
+    },
+    "source_port_id": "source_port_29",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 30,
+    "true_ccw_index": 29,
+    "display_pin_label": "RUN"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_30",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 0.0999999999999992
+    },
+    "source_port_id": "source_port_30",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 31,
+    "true_ccw_index": 30,
+    "display_pin_label": "GP26"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_31",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 0.29999999999999916
+    },
+    "source_port_id": "source_port_31",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 32,
+    "true_ccw_index": 31,
+    "display_pin_label": "GP27"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_32",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 0.49999999999999933
+    },
+    "source_port_id": "source_port_32",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 33,
+    "true_ccw_index": 32,
+    "display_pin_label": "GND6"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_33",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 0.6999999999999995
+    },
+    "source_port_id": "source_port_33",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 34,
+    "true_ccw_index": 33,
+    "display_pin_label": "GP28"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_34",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 0.8999999999999997
+    },
+    "source_port_id": "source_port_34",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 35,
+    "true_ccw_index": 34,
+    "display_pin_label": "ADC_VREF"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_35",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 1.0999999999999999
+    },
+    "source_port_id": "source_port_35",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 36,
+    "true_ccw_index": 35,
+    "display_pin_label": "V3V3"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_36",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 1.3
+    },
+    "source_port_id": "source_port_36",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 37,
+    "true_ccw_index": 36,
+    "display_pin_label": "V3V3_EN"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_37",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 1.5000000000000002
+    },
+    "source_port_id": "source_port_37",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 38,
+    "true_ccw_index": 37,
+    "display_pin_label": "GND7"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_38",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 1.7000000000000004
+    },
+    "source_port_id": "source_port_38",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 39,
+    "true_ccw_index": 38,
+    "display_pin_label": "VSYS"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_39",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1.35,
+      "y": 1.9000000000000006
+    },
+    "source_port_id": "source_port_39",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 40,
+    "true_ccw_index": 39,
+    "display_pin_label": "VBUS"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_40",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 4.685914883333332,
+      "y": 2.8302065000000005
+    },
+    "source_port_id": "source_port_40",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_41",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 5.630751783333333,
+      "y": 2.8297675000000004
+    },
+    "source_port_id": "source_port_41",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_42",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 4.639186233333334,
+      "y": 2.4261707000000006
+    },
+    "source_port_id": "source_port_44",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_43",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 5.677480433333333,
+      "y": 2.425146100000003
+    },
+    "source_port_id": "source_port_45",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_44",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 7.860914883333333,
+      "y": 2.8302065000000005
+    },
+    "source_port_id": "source_port_46",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_45",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": 8.805751783333335,
+      "y": 2.8297675000000004
+    },
+    "source_port_id": "source_port_47",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_46",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 7.814186233333334,
+      "y": 2.4261707000000006
+    },
+    "source_port_id": "source_port_50",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_47",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 8.852480433333334,
+      "y": 2.425146100000003
+    },
+    "source_port_id": "source_port_51",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_48",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": 11.035914883333332,
+      "y": 2.8302065000000005
+    },
+    "source_port_id": "source_port_52",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_49",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": 11.980751783333332,
+      "y": 2.8297675000000004
+    },
+    "source_port_id": "source_port_53",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_50",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 10.989186233333333,
+      "y": 2.4261707000000006
+    },
+    "source_port_id": "source_port_56",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_51",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 12.027480433333332,
+      "y": 2.425146100000003
+    },
+    "source_port_id": "source_port_57",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_52",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 4.685914883333332,
+      "y": 0.4489565000000004
+    },
+    "source_port_id": "source_port_58",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_53",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 5.630751783333333,
+      "y": 0.44851750000000035
+    },
+    "source_port_id": "source_port_59",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_54",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 4.639186233333334,
+      "y": 0.04492070000000048
+    },
+    "source_port_id": "source_port_62",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_55",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 5.677480433333333,
+      "y": 0.0438961000000031
+    },
+    "source_port_id": "source_port_63",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_56",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 7.860914883333333,
+      "y": 0.4489565000000004
+    },
+    "source_port_id": "source_port_64",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_57",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 8.805751783333335,
+      "y": 0.44851750000000035
+    },
+    "source_port_id": "source_port_65",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_58",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 7.814186233333334,
+      "y": 0.04492070000000048
+    },
+    "source_port_id": "source_port_68",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_59",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 8.852480433333334,
+      "y": 0.0438961000000031
+    },
+    "source_port_id": "source_port_69",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_60",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 11.035914883333332,
+      "y": 0.4489565000000004
+    },
+    "source_port_id": "source_port_70",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_61",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 11.980751783333332,
+      "y": 0.44851750000000035
+    },
+    "source_port_id": "source_port_71",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_62",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 10.989186233333333,
+      "y": 0.04492070000000048
+    },
+    "source_port_id": "source_port_74",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_63",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 12.027480433333332,
+      "y": 0.0438961000000031
+    },
+    "source_port_id": "source_port_75",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_64",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 4.685914883333332,
+      "y": -1.9322934999999997
+    },
+    "source_port_id": "source_port_76",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_65",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 5.630751783333333,
+      "y": -1.9327324999999997
+    },
+    "source_port_id": "source_port_77",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_66",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 4.639186233333334,
+      "y": -2.3363292999999996
+    },
+    "source_port_id": "source_port_80",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_67",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 5.677480433333333,
+      "y": -2.337353899999997
+    },
+    "source_port_id": "source_port_81",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_68",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 7.860914883333333,
+      "y": -1.9322934999999997
+    },
+    "source_port_id": "source_port_82",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_69",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 8.805751783333335,
+      "y": -1.9327324999999997
+    },
+    "source_port_id": "source_port_83",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_70",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 7.814186233333334,
+      "y": -2.3363292999999996
+    },
+    "source_port_id": "source_port_86",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_71",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 8.852480433333334,
+      "y": -2.337353899999997
+    },
+    "source_port_id": "source_port_87",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_72",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 11.035914883333332,
+      "y": -1.9322934999999997
+    },
+    "source_port_id": "source_port_88",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "side1"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_73",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 11.980751783333332,
+      "y": -1.9327324999999997
+    },
+    "source_port_id": "source_port_89",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_74",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 10.989186233333333,
+      "y": -2.3363292999999996
+    },
+    "source_port_id": "source_port_92",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_75",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 12.027480433333332,
+      "y": -2.337353899999997
+    },
+    "source_port_id": "source_port_93",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_0",
+    "source_trace_id": "source_trace_0",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 4.639186233333334,
+          "y": 2.4261707000000006,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 4.639186233333334,
+          "y": 2.8302065000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 4.639186233333334,
+          "y": 2.8302065000000005
+        },
+        "to": {
+          "x": 4.685914883333332,
+          "y": 2.8302065000000005
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_1",
+    "source_trace_id": "source_trace_1",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.677480433333333,
+          "y": 2.425146100000003,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 5.677480433333333,
+          "y": 1.9000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.677480433333333,
+          "y": 1.9000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": 1.9000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": 1.9000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": 2.6000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": 2.6000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": -1.35,
+          "y": 2.6000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": -1.35,
+          "y": 2.6000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": -1.35,
+          "y": 1.9000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_2",
+    "source_trace_id": "source_trace_2",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": 2.8297675000000004,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": 2.675146100000003,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": 2.675146100000003,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": 2.675146100000003,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": 2.675146100000003,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.3499999999999996,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_3",
+    "source_trace_id": "source_trace_3",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 7.814186233333334,
+          "y": 2.4261707000000006,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 7.814186233333334,
+          "y": 2.8302065000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 7.814186233333334,
+          "y": 2.8302065000000005
+        },
+        "to": {
+          "x": 7.860914883333333,
+          "y": 2.8302065000000005
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_0",
+    "text": "U1_GP0",
+    "source_net_id": "source_port_0",
+    "anchor_position": {
+      "x": -1.35,
+      "y": 1.9000000000000006
+    },
+    "center": {
+      "x": -1.35,
+      "y": 1.9000000000000006
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_1",
+    "text": "U1_GP0",
+    "source_net_id": "source_port_51",
+    "anchor_position": {
+      "x": 8.852480433333334,
+      "y": 2.425146100000003
+    },
+    "center": {
+      "x": 8.852480433333334,
+      "y": 2.425146100000003
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_2",
+    "text": "U1_GP17",
+    "source_net_id": "source_port_21",
+    "anchor_position": {
+      "x": 1.35,
+      "y": -1.7000000000000006
+    },
+    "center": {
+      "x": 1.35,
+      "y": -1.7000000000000006
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_3",
+    "text": "U1_GP17",
+    "source_net_id": "source_port_47",
+    "anchor_position": {
+      "x": 8.805751783333335,
+      "y": 2.8297675000000004
+    },
+    "center": {
+      "x": 8.805751783333335,
+      "y": 2.8297675000000004
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_4",
+    "source_trace_id": "source_trace_6",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 10.989186233333333,
+          "y": 2.4261707000000006,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 10.989186233333333,
+          "y": 2.8302065000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 10.989186233333333,
+          "y": 2.8302065000000005
+        },
+        "to": {
+          "x": 11.035914883333332,
+          "y": 2.8302065000000005
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_4",
+    "text": "U1_GP0",
+    "source_net_id": "source_port_57",
+    "anchor_position": {
+      "x": 12.027480433333332,
+      "y": 2.425146100000003
+    },
+    "center": {
+      "x": 12.027480433333332,
+      "y": 2.425146100000003
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_5",
+    "text": "U1_GP5",
+    "source_net_id": "source_port_6",
+    "anchor_position": {
+      "x": -1.35,
+      "y": 0.7000000000000006
+    },
+    "center": {
+      "x": -1.35,
+      "y": 0.7000000000000006
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_6",
+    "text": "U1_GP5",
+    "source_net_id": "source_port_53",
+    "anchor_position": {
+      "x": 11.980751783333332,
+      "y": 2.8297675000000004
+    },
+    "center": {
+      "x": 11.980751783333332,
+      "y": 2.8297675000000004
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_5",
+    "source_trace_id": "source_trace_9",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 4.639186233333334,
+          "y": 0.04492070000000048,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 4.639186233333334,
+          "y": 0.4489565000000004,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 4.639186233333334,
+          "y": 0.4489565000000004
+        },
+        "to": {
+          "x": 4.685914883333332,
+          "y": 0.4489565000000004
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_7",
+    "text": "U1_GP1",
+    "source_net_id": "source_port_1",
+    "anchor_position": {
+      "x": -1.35,
+      "y": 1.7000000000000006
+    },
+    "center": {
+      "x": -1.35,
+      "y": 1.7000000000000006
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_8",
+    "text": "U1_GP1",
+    "source_net_id": "source_port_63",
+    "anchor_position": {
+      "x": 5.677480433333333,
+      "y": 0.0438961000000031
+    },
+    "center": {
+      "x": 5.677480433333333,
+      "y": 0.0438961000000031
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_6",
+    "source_trace_id": "source_trace_11",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": 0.44851750000000035,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": 0.2938961000000031,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": 0.2938961000000031,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": 0.2938961000000031,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": 0.2938961000000031,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 6.077480433333333,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.3499999999999996,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.630751783333333,
+        "y": 2.675146100000003
+      }
+    ]
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_7",
+    "source_trace_id": "source_trace_12",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 7.814186233333334,
+          "y": 0.04492070000000048,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 7.814186233333334,
+          "y": 0.4489565000000004,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 7.814186233333334,
+          "y": 0.4489565000000004
+        },
+        "to": {
+          "x": 7.860914883333333,
+          "y": 0.4489565000000004
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_9",
+    "text": "U1_GP1",
+    "source_net_id": "source_port_69",
+    "anchor_position": {
+      "x": 8.852480433333334,
+      "y": 0.0438961000000031
+    },
+    "center": {
+      "x": 8.852480433333334,
+      "y": 0.0438961000000031
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_10",
+    "text": "U1_GP17",
+    "source_net_id": "source_port_65",
+    "anchor_position": {
+      "x": 8.805751783333335,
+      "y": 0.44851750000000035
+    },
+    "center": {
+      "x": 8.805751783333335,
+      "y": 0.44851750000000035
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_8",
+    "source_trace_id": "source_trace_15",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 10.989186233333333,
+          "y": 0.04492070000000048,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 10.989186233333333,
+          "y": 0.4489565000000004,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 10.989186233333333,
+          "y": 0.4489565000000004
+        },
+        "to": {
+          "x": 11.035914883333332,
+          "y": 0.4489565000000004
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_11",
+    "text": "U1_GP1",
+    "source_net_id": "source_port_75",
+    "anchor_position": {
+      "x": 12.027480433333332,
+      "y": 0.0438961000000031
+    },
+    "center": {
+      "x": 12.027480433333332,
+      "y": 0.0438961000000031
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_12",
+    "text": "U1_GP5",
+    "source_net_id": "source_port_71",
+    "anchor_position": {
+      "x": 11.980751783333332,
+      "y": 0.44851750000000035
+    },
+    "center": {
+      "x": 11.980751783333332,
+      "y": 0.44851750000000035
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_9",
+    "source_trace_id": "source_trace_18",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 4.639186233333334,
+          "y": -2.3363292999999996,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 4.639186233333334,
+          "y": -1.9322934999999997,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 4.639186233333334,
+          "y": -1.9322934999999997
+        },
+        "to": {
+          "x": 4.685914883333332,
+          "y": -1.9322934999999997
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_13",
+    "text": "U1_GP10",
+    "source_net_id": "source_port_13",
+    "anchor_position": {
+      "x": -1.35,
+      "y": -0.6999999999999995
+    },
+    "center": {
+      "x": -1.35,
+      "y": -0.6999999999999995
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_14",
+    "text": "U1_GP10",
+    "source_net_id": "source_port_81",
+    "anchor_position": {
+      "x": 5.677480433333333,
+      "y": -2.337353899999997
+    },
+    "center": {
+      "x": 5.677480433333333,
+      "y": -2.337353899999997
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_10",
+    "source_trace_id": "source_trace_20",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": -1.9327324999999997,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 5.630751783333333,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.3500000000000005,
+          "y": -1.1000000000000005,
+          "width": 0.1,
+          "layer": "top"
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.630751783333333,
+        "y": 2.675146100000003
+      }
+    ]
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_11",
+    "source_trace_id": "source_trace_21",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 7.814186233333334,
+          "y": -2.3363292999999996,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 7.814186233333334,
+          "y": -1.9322934999999997,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 7.814186233333334,
+          "y": -1.9322934999999997
+        },
+        "to": {
+          "x": 7.860914883333333,
+          "y": -1.9322934999999997
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_15",
+    "text": "U1_GP10",
+    "source_net_id": "source_port_87",
+    "anchor_position": {
+      "x": 8.852480433333334,
+      "y": -2.337353899999997
+    },
+    "center": {
+      "x": 8.852480433333334,
+      "y": -2.337353899999997
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_12",
+    "source_trace_id": "source_trace_23",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 8.805751783333335,
+          "y": -1.9327324999999997,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 8.805751783333335,
+          "y": -1.3566315000000009,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 8.805751783333335,
+          "y": -1.3566315000000009,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "x": 5.668251783333333,
+          "y": -1.3566315000000009
+        }
+      },
+      {
+        "from": {
+          "x": 5.668251783333333,
+          "y": -1.3566315000000009
+        },
+        "to": {
+          "x": 5.593251783333334,
+          "y": -1.3566315000000009
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 5.593251783333334,
+          "y": -1.3566315000000009
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": -1.3566315000000009,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": -1.3566315000000009,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": -1.7000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 1.75,
+          "y": -1.7000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 1.35,
+          "y": -1.7000000000000006,
+          "width": 0.1,
+          "layer": "top"
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_13",
+    "source_trace_id": "source_trace_24",
+    "edges": [
+      {
+        "from": {
+          "route_type": "wire",
+          "x": 10.989186233333333,
+          "y": -2.3363292999999996,
+          "width": 0.1,
+          "layer": "top"
+        },
+        "to": {
+          "route_type": "wire",
+          "x": 10.989186233333333,
+          "y": -1.9322934999999997,
+          "width": 0.1,
+          "layer": "top"
+        }
+      },
+      {
+        "from": {
+          "x": 10.989186233333333,
+          "y": -1.9322934999999997
+        },
+        "to": {
+          "x": 11.035914883333332,
+          "y": -1.9322934999999997
+        }
+      }
+    ],
+    "junctions": []
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_16",
+    "text": "U1_GP10",
+    "source_net_id": "source_port_93",
+    "anchor_position": {
+      "x": 12.027480433333332,
+      "y": -2.337353899999997
+    },
+    "center": {
+      "x": 12.027480433333332,
+      "y": -2.337353899999997
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_17",
+    "text": "U1_GP5",
+    "source_net_id": "source_port_89",
+    "anchor_position": {
+      "x": 11.980751783333332,
+      "y": -1.9327324999999997
+    },
+    "center": {
+      "x": 11.980751783333332,
+      "y": -1.9327324999999997
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_0",
+    "center": {
+      "x": -30,
+      "y": 0
+    },
+    "width": 22.58,
+    "height": 50.54,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "center": {
+      "x": 0.9499999999999988,
+      "y": -19.049999999999944
+    },
+    "width": 16.349802200000074,
+    "height": 5.539994000000078,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "center": {
+      "x": 1.5849999999999902,
+      "y": -22.684998799999967
+    },
+    "width": 4.1999916,
+    "height": 4.199991599999997,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "center": {
+      "x": 0.9499999999999993,
+      "y": -19.05
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_3",
+    "center": {
+      "x": 0.9499999999999993,
+      "y": -32.05
+    },
+    "width": 3.3451800000000222,
+    "height": 0.750011200000003,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_1",
+    "subcircuit_id": "subcircuit_source_group_1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_4",
+    "center": {
+      "x": 20,
+      "y": -19.049999999999944
+    },
+    "width": 16.349802200000077,
+    "height": 5.539994000000078,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_5",
+    "center": {
+      "x": 20.63499999999999,
+      "y": -22.684998799999967
+    },
+    "width": 4.199991599999997,
+    "height": 4.199991599999997,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_2",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "center": {
+      "x": 20,
+      "y": -19.05
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_6",
+    "center": {
+      "x": 20,
+      "y": -32.05
+    },
+    "width": 3.3451800000000205,
+    "height": 0.750011200000003,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_3",
+    "subcircuit_id": "subcircuit_source_group_3",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_3"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_7",
+    "center": {
+      "x": 39.05,
+      "y": -19.049999999999944
+    },
+    "width": 16.349802200000074,
+    "height": 5.539994000000078,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_8",
+    "center": {
+      "x": 39.68499999999999,
+      "y": -22.684998799999967
+    },
+    "width": 4.199991600000004,
+    "height": 4.199991599999997,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_4",
+    "subcircuit_id": "subcircuit_source_group_4",
+    "center": {
+      "x": 39.05,
+      "y": -19.05
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_4"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_9",
+    "center": {
+      "x": 39.05,
+      "y": -32.05
+    },
+    "width": 3.3451800000000276,
+    "height": 0.750011200000003,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_5",
+    "subcircuit_id": "subcircuit_source_group_5",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_5"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_10",
+    "center": {
+      "x": 0.9499999999999988,
+      "y": 5.684341886080802e-14
+    },
+    "width": 16.349802200000074,
+    "height": 5.5399940000000765,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_11",
+    "center": {
+      "x": 1.5849999999999902,
+      "y": -3.6349987999999667
+    },
+    "width": 4.1999916,
+    "height": 4.1999916,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_6",
+    "subcircuit_id": "subcircuit_source_group_6",
+    "center": {
+      "x": 0.9499999999999993,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_6"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_12",
+    "center": {
+      "x": 0.9499999999999993,
+      "y": -13
+    },
+    "width": 3.3451800000000222,
+    "height": 0.7500111999999994,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_7",
+    "subcircuit_id": "subcircuit_source_group_7",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_7"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_13",
+    "center": {
+      "x": 20,
+      "y": 5.684341886080802e-14
+    },
+    "width": 16.349802200000077,
+    "height": 5.5399940000000765,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_14",
+    "center": {
+      "x": 20.63499999999999,
+      "y": -3.6349987999999667
+    },
+    "width": 4.199991599999997,
+    "height": 4.1999916,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_8",
+    "subcircuit_id": "subcircuit_source_group_8",
+    "center": {
+      "x": 20,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_8"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_15",
+    "center": {
+      "x": 20,
+      "y": -13
+    },
+    "width": 3.3451800000000205,
+    "height": 0.7500111999999994,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_9",
+    "subcircuit_id": "subcircuit_source_group_9",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_9"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_16",
+    "center": {
+      "x": 39.05,
+      "y": 5.684341886080802e-14
+    },
+    "width": 16.349802200000074,
+    "height": 5.5399940000000765,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_17",
+    "center": {
+      "x": 39.68499999999999,
+      "y": -3.6349987999999667
+    },
+    "width": 4.199991600000004,
+    "height": 4.1999916,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_10",
+    "subcircuit_id": "subcircuit_source_group_10",
+    "center": {
+      "x": 39.05,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_10"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_18",
+    "center": {
+      "x": 39.05,
+      "y": -13
+    },
+    "width": 3.3451800000000276,
+    "height": 0.7500111999999994,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_11",
+    "subcircuit_id": "subcircuit_source_group_11",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_11"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_19",
+    "center": {
+      "x": 0.9499999999999988,
+      "y": 19.050000000000058
+    },
+    "width": 16.349802200000074,
+    "height": 5.539994000000078,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_20",
+    "center": {
+      "x": 1.5849999999999902,
+      "y": 15.415001200000034
+    },
+    "width": 4.1999916,
+    "height": 4.199991599999999,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_12",
+    "subcircuit_id": "subcircuit_source_group_12",
+    "center": {
+      "x": 0.9499999999999993,
+      "y": 19.05
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_12"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_21",
+    "center": {
+      "x": 0.9499999999999993,
+      "y": 6.050000000000001
+    },
+    "width": 3.3451800000000222,
+    "height": 0.7500111999999994,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_13",
+    "subcircuit_id": "subcircuit_source_group_13",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_13"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_22",
+    "center": {
+      "x": 20,
+      "y": 19.050000000000058
+    },
+    "width": 16.349802200000077,
+    "height": 5.539994000000078,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_23",
+    "center": {
+      "x": 20.63499999999999,
+      "y": 15.415001200000034
+    },
+    "width": 4.199991599999997,
+    "height": 4.199991599999999,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_14",
+    "subcircuit_id": "subcircuit_source_group_14",
+    "center": {
+      "x": 20,
+      "y": 19.05
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_14"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_24",
+    "center": {
+      "x": 20,
+      "y": 6.050000000000001
+    },
+    "width": 3.3451800000000205,
+    "height": 0.7500111999999994,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_15",
+    "subcircuit_id": "subcircuit_source_group_15",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_15"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_25",
+    "center": {
+      "x": 39.05,
+      "y": 19.050000000000058
+    },
+    "width": 16.349802200000074,
+    "height": 5.539994000000078,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_26",
+    "center": {
+      "x": 39.68499999999999,
+      "y": 15.415001200000034
+    },
+    "width": 4.199991600000004,
+    "height": 4.199991599999999,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_16",
+    "subcircuit_id": "subcircuit_source_group_16",
+    "center": {
+      "x": 39.05,
+      "y": 19.05
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_16"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_27",
+    "center": {
+      "x": 39.05,
+      "y": 6.050000000000001
+    },
+    "width": 3.3451800000000276,
+    "height": 0.7500111999999994,
+    "layer": "bottom",
+    "rotation": 0,
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_17",
+    "subcircuit_id": "subcircuit_source_group_17",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_17"
+  },
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_0",
+    "center": {
+      "x": 0,
+      "y": -4
+    },
+    "thickness": 1.4,
+    "num_layers": 4,
+    "width": 100,
+    "height": 60
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_0",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["1"],
+    "x": -39.39,
+    "y": 24.13,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_0",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 24.13,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_1",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["2"],
+    "x": -39.39,
+    "y": 21.59,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_1",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 21.59,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_2",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["3"],
+    "x": -39.39,
+    "y": 19.049999999999997,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_2",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 19.049999999999997,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_3",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["4"],
+    "x": -39.39,
+    "y": 16.509999999999998,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_3",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 16.509999999999998,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["5"],
+    "x": -39.39,
+    "y": 13.969999999999999,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 13.969999999999999,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["6"],
+    "x": -39.39,
+    "y": 11.43,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 11.43,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["7"],
+    "x": -39.39,
+    "y": 8.889999999999999,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 8.889999999999999,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["8"],
+    "x": -39.39,
+    "y": 6.349999999999998,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 6.349999999999998,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["9"],
+    "x": -39.39,
+    "y": 3.8099999999999987,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 3.8099999999999987,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["10"],
+    "x": -39.39,
+    "y": 1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": 1.2699999999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["11"],
+    "x": -39.39,
+    "y": -1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -1.2699999999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["12"],
+    "x": -39.39,
+    "y": -3.8100000000000023,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -3.8100000000000023,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["13"],
+    "x": -39.39,
+    "y": -6.350000000000001,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -6.350000000000001,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["14"],
+    "x": -39.39,
+    "y": -8.890000000000004,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -8.890000000000004,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["15"],
+    "x": -39.39,
+    "y": -11.430000000000003,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -11.430000000000003,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["16"],
+    "x": -39.39,
+    "y": -13.970000000000002,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -13.970000000000002,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["17"],
+    "x": -39.39,
+    "y": -16.51,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -16.51,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["18"],
+    "x": -39.39,
+    "y": -19.05,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -19.05,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["19"],
+    "x": -39.39,
+    "y": -21.59,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -21.59,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["20"],
+    "x": -39.39,
+    "y": -24.13,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -39.39,
+    "y": -24.13,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["21"],
+    "x": -20.61,
+    "y": -24.13,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -24.13,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["22"],
+    "x": -20.61,
+    "y": -21.59,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -21.59,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["23"],
+    "x": -20.61,
+    "y": -19.049999999999997,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -19.049999999999997,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["24"],
+    "x": -20.61,
+    "y": -16.509999999999998,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -16.509999999999998,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["25"],
+    "x": -20.61,
+    "y": -13.969999999999999,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -13.969999999999999,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["26"],
+    "x": -20.61,
+    "y": -11.43,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -11.43,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["27"],
+    "x": -20.61,
+    "y": -8.889999999999999,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -8.889999999999999,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["28"],
+    "x": -20.61,
+    "y": -6.349999999999998,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -6.349999999999998,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["29"],
+    "x": -20.61,
+    "y": -3.8099999999999987,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -3.8099999999999987,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["30"],
+    "x": -20.61,
+    "y": -1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": -1.2699999999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["31"],
+    "x": -20.61,
+    "y": 1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 1.2699999999999996,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["32"],
+    "x": -20.61,
+    "y": 3.8100000000000023,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 3.8100000000000023,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["33"],
+    "x": -20.61,
+    "y": 6.350000000000001,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 6.350000000000001,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["34"],
+    "x": -20.61,
+    "y": 8.890000000000004,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 8.890000000000004,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["35"],
+    "x": -20.61,
+    "y": 11.430000000000003,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 11.430000000000003,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["36"],
+    "x": -20.61,
+    "y": 13.970000000000002,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 13.970000000000002,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["37"],
+    "x": -20.61,
+    "y": 16.51,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 16.51,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["38"],
+    "x": -20.61,
+    "y": 19.05,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 19.05,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["39"],
+    "x": -20.61,
+    "y": 21.59,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 21.59,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 3.8,
+    "height": 2.28,
+    "port_hints": ["40"],
+    "x": -20.61,
+    "y": 24.13,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 2.6599999999999997,
+    "height": 1.5959999999999999,
+    "x": -20.61,
+    "y": 24.13,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -37.39,
+        "y": -25.77
+      },
+      {
+        "x": -37.39,
+        "y": 25.77
+      },
+      {
+        "x": -32.46333333333333,
+        "y": 25.77
+      },
+      {
+        "x": -32.27582324841947,
+        "y": 24.82732314494066
+      },
+      {
+        "x": -31.741839704322864,
+        "y": 24.028160295677136
+      },
+      {
+        "x": -30.94267685505934,
+        "y": 23.49417675158053
+      },
+      {
+        "x": -30,
+        "y": 23.306666666666665
+      },
+      {
+        "x": -29.05732314494066,
+        "y": 23.49417675158053
+      },
+      {
+        "x": -28.258160295677136,
+        "y": 24.02816029567714
+      },
+      {
+        "x": -27.72417675158053,
+        "y": 24.82732314494066
+      },
+      {
+        "x": -27.536666666666665,
+        "y": 25.77
+      },
+      {
+        "x": -22.61,
+        "y": 25.77
+      },
+      {
+        "x": -22.61,
+        "y": -25.77
+      },
+      {
+        "x": -37.39,
+        "y": -25.77
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_0",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -30,
+      "y": 26.169999999999998
+    },
+    "font": "tscircuit2024",
+    "font_size": 4.495,
+    "layer": "top",
+    "text": "U1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_0",
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_0",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": -2.2249999999999552,
+    "y": -20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_1",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 4.124999999999954,
+    "y": -17.779999999999905,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_41",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": -5.7749040000000385,
+    "y": -20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_40",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": -5.7749040000000385,
+    "y": -20.319999999999983,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_40",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 7.674904000000037,
+    "y": -17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_41",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 7.674904000000037,
+    "y": -17.78000000000002,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_1",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 6.411000000000012,
+        "y": -19.51113700000001
+      },
+      {
+        "x": 6.411000000000012,
+        "y": -21.970999999999936
+      },
+      {
+        "x": 6.411000000000012,
+        "y": -21.970999999999936
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_2",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": -4.500001799999996,
+        "y": -22.00000679999987
+      },
+      {
+        "x": 6.411000000000012,
+        "y": -22.00000679999987
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_3",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.7670184000000511,
+        "y": -17.995011000000023
+      },
+      {
+        "x": -4.500027199999909,
+        "y": -17.995011000000023
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_4",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": -4.500027199999909,
+        "y": -17.995011000000023
+      },
+      {
+        "x": -4.500027199999909,
+        "y": -18.588862999999993
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_5",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 3.894114000000126,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 6.411000000000012,
+        "y": -16.10499699999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_6",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 2.6570069999999752,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 3.894114000000126,
+        "y": -16.10499699999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_7",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 2.6570069999999752,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 2.4103118861290334,
+        "y": -16.121166390735926
+      },
+      {
+        "x": 2.167837866175386,
+        "y": -16.16939789550297
+      },
+      {
+        "x": 1.933733808737724,
+        "y": -16.248866245781006
+      },
+      {
+        "x": 1.7120053675888123,
+        "y": -16.358211692829787
+      },
+      {
+        "x": 1.5064464426572606,
+        "y": -16.49556327376563
+      },
+      {
+        "x": 1.3205742642384841,
+        "y": -16.65857082480061
+      },
+      {
+        "x": 1.1575692111811797,
+        "y": -16.844445193884713
+      },
+      {
+        "x": 1.020220392793771,
+        "y": -17.050005964685443
+      },
+      {
+        "x": 0.9108779255952406,
+        "y": -17.271735875323476
+      },
+      {
+        "x": 0.8314127214827742,
+        "y": -17.505841000726424
+      },
+      {
+        "x": 0.7831844753633952,
+        "y": -17.748315668848637
+      },
+      {
+        "x": 0.7670184000000511,
+        "y": -17.995011000000023
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_2",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 1.5849999999999902,
+    "y": -22.684998799999967,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_8",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 9.385009799999988,
+        "y": -14.884988999999969
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_9",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": -30.48500860000008
+      },
+      {
+        "x": 9.385009799999988,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_10",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": -14.884988999999969
+      },
+      {
+        "x": -6.215009800000008,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_11",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.385009799999988,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 9.385009799999988,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_1",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0.9499999999999993,
+      "y": -14.05
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K1",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_42",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 2.1225910000000106,
+    "y": -32.05,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_42",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 2.1225910000000106,
+    "y": -32.05,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_43",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": -0.22259100000001197,
+    "y": -32.05,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_43",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": -0.22259100000001197,
+    "y": -32.05,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_12",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.04875720000002204,
+        "y": -32.77621140000001
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -32.56998879999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_13",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.04875720000002204,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -31.520003599999924
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_14",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.8012047999998906,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -31.323788599999986
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_15",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.8012047999998906,
+        "y": -32.77621140000001
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -32.77621140000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_16",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.396760599999947,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 1.396760599999947,
+        "y": -32.77621140000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_3",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 16.825000000000045,
+    "y": -20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_4",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 23.174999999999955,
+    "y": -17.779999999999905,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_45",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": 13.275095999999962,
+    "y": -20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_44",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 13.275095999999962,
+    "y": -20.319999999999983,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_44",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 26.724904000000038,
+    "y": -17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_45",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 26.724904000000038,
+    "y": -17.78000000000002,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_17",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 25.461000000000013,
+        "y": -19.51113700000001
+      },
+      {
+        "x": 25.461000000000013,
+        "y": -21.970999999999936
+      },
+      {
+        "x": 25.461000000000013,
+        "y": -21.970999999999936
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_18",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 14.549998200000005,
+        "y": -22.00000679999987
+      },
+      {
+        "x": 25.461000000000013,
+        "y": -22.00000679999987
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_19",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.81701840000005,
+        "y": -17.995011000000023
+      },
+      {
+        "x": 14.549972800000091,
+        "y": -17.995011000000023
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_20",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 14.549972800000091,
+        "y": -17.995011000000023
+      },
+      {
+        "x": 14.549972800000091,
+        "y": -18.588862999999993
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_21",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 22.944114000000127,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 25.461000000000013,
+        "y": -16.10499699999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_22",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 21.707006999999976,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 22.944114000000127,
+        "y": -16.10499699999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_23",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 21.707006999999976,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 21.460311886129034,
+        "y": -16.121166390735926
+      },
+      {
+        "x": 21.217837866175387,
+        "y": -16.16939789550297
+      },
+      {
+        "x": 20.983733808737725,
+        "y": -16.248866245781006
+      },
+      {
+        "x": 20.762005367588813,
+        "y": -16.358211692829787
+      },
+      {
+        "x": 20.55644644265726,
+        "y": -16.49556327376563
+      },
+      {
+        "x": 20.370574264238485,
+        "y": -16.65857082480061
+      },
+      {
+        "x": 20.20756921118118,
+        "y": -16.844445193884713
+      },
+      {
+        "x": 20.07022039279377,
+        "y": -17.050005964685443
+      },
+      {
+        "x": 19.96087792559524,
+        "y": -17.271735875323476
+      },
+      {
+        "x": 19.881412721482775,
+        "y": -17.505841000726424
+      },
+      {
+        "x": 19.833184475363396,
+        "y": -17.748315668848637
+      },
+      {
+        "x": 19.81701840000005,
+        "y": -17.995011000000023
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_5",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 20.63499999999999,
+    "y": -22.684998799999967,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_24",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 28.43500979999999,
+        "y": -14.884988999999969
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_25",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": -30.48500860000008
+      },
+      {
+        "x": 28.43500979999999,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_26",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 12.834990199999993,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_27",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 28.43500979999999,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 28.43500979999999,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_2",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 20,
+      "y": -14.05
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K2",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_46",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 21.17259100000001,
+    "y": -32.05,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_46",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 21.17259100000001,
+    "y": -32.05,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_47",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": 18.82740899999999,
+    "y": -32.05,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_47",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 18.82740899999999,
+    "y": -32.05,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_28",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.098757200000023,
+        "y": -32.77621140000001
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -32.56998879999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_29",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.098757200000023,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -31.520003599999924
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_30",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.85120479999989,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -31.323788599999986
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_31",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.85120479999989,
+        "y": -32.77621140000001
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -32.77621140000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_32",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.446760599999948,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 20.446760599999948,
+        "y": -32.77621140000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_6",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 35.87500000000004,
+    "y": -20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_7",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 42.22499999999995,
+    "y": -17.779999999999905,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_49",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": 32.32509599999996,
+    "y": -20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_48",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 32.32509599999996,
+    "y": -20.319999999999983,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_48",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 45.774904000000035,
+    "y": -17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_49",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 45.774904000000035,
+    "y": -17.78000000000002,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_33",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 44.51100000000001,
+        "y": -19.51113700000001
+      },
+      {
+        "x": 44.51100000000001,
+        "y": -21.970999999999936
+      },
+      {
+        "x": 44.51100000000001,
+        "y": -21.970999999999936
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_34",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 33.5999982,
+        "y": -22.00000679999987
+      },
+      {
+        "x": 44.51100000000001,
+        "y": -22.00000679999987
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_35",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.86701840000005,
+        "y": -17.995011000000023
+      },
+      {
+        "x": 33.59997280000009,
+        "y": -17.995011000000023
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_36",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 33.59997280000009,
+        "y": -17.995011000000023
+      },
+      {
+        "x": 33.59997280000009,
+        "y": -18.588862999999993
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_37",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 41.994114000000124,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 44.51100000000001,
+        "y": -16.10499699999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_38",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 40.75700699999997,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 41.994114000000124,
+        "y": -16.10499699999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_39",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 40.75700699999997,
+        "y": -16.10499699999996
+      },
+      {
+        "x": 40.51031188612903,
+        "y": -16.121166390735926
+      },
+      {
+        "x": 40.267837866175384,
+        "y": -16.16939789550297
+      },
+      {
+        "x": 40.03373380873772,
+        "y": -16.248866245781006
+      },
+      {
+        "x": 39.81200536758881,
+        "y": -16.358211692829787
+      },
+      {
+        "x": 39.60644644265726,
+        "y": -16.49556327376563
+      },
+      {
+        "x": 39.42057426423848,
+        "y": -16.65857082480061
+      },
+      {
+        "x": 39.25756921118118,
+        "y": -16.844445193884713
+      },
+      {
+        "x": 39.12022039279377,
+        "y": -17.050005964685443
+      },
+      {
+        "x": 39.01087792559524,
+        "y": -17.271735875323476
+      },
+      {
+        "x": 38.93141272148277,
+        "y": -17.505841000726424
+      },
+      {
+        "x": 38.88318447536339,
+        "y": -17.748315668848637
+      },
+      {
+        "x": 38.86701840000005,
+        "y": -17.995011000000023
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_8",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 39.68499999999999,
+    "y": -22.684998799999967,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_40",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 47.485009799999986,
+        "y": -14.884988999999969
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_41",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": -30.48500860000008
+      },
+      {
+        "x": 47.485009799999986,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_42",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 31.88499019999999,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_43",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 47.485009799999986,
+        "y": -14.884988999999969
+      },
+      {
+        "x": 47.485009799999986,
+        "y": -30.48500860000008
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_3",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 39.05,
+      "y": -14.05
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K3",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "pcb_component_id": "pcb_component_9",
+    "pcb_port_id": "pcb_port_50",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 40.22259100000001,
+    "y": -32.05,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_50",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 40.22259100000001,
+    "y": -32.05,
+    "pcb_component_id": "pcb_component_9",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "pcb_component_id": "pcb_component_9",
+    "pcb_port_id": "pcb_port_51",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": 37.877408999999986,
+    "y": -32.05,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_51",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 37.877408999999986,
+    "y": -32.05,
+    "pcb_component_id": "pcb_component_9",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_44",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.14875720000002,
+        "y": -32.77621140000001
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -32.56998879999996
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_45",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.14875720000002,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -31.520003599999924
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_46",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.90120479999989,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -31.323788599999986
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_47",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.90120479999989,
+        "y": -32.77621140000001
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -32.77621140000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_48",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.496760599999945,
+        "y": -31.323788599999986
+      },
+      {
+        "x": 39.496760599999945,
+        "y": -32.77621140000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_9",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": -2.2249999999999552,
+    "y": -1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_10",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 4.124999999999954,
+    "y": 1.2700000000000955,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_53",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": -5.7749040000000385,
+    "y": -1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_52",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": -5.7749040000000385,
+    "y": -1.2699999999999818,
+    "pcb_component_id": "pcb_component_10",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_53",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_52",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 7.674904000000037,
+    "y": 1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_53",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 7.674904000000037,
+    "y": 1.2699999999999818,
+    "pcb_component_id": "pcb_component_10",
+    "pcb_smtpad_id": "pcb_smtpad_53",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_49",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 6.411000000000012,
+        "y": -0.4611370000000079
+      },
+      {
+        "x": 6.411000000000012,
+        "y": -2.9209999999999354
+      },
+      {
+        "x": 6.411000000000012,
+        "y": -2.9209999999999354
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_50",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": -4.500001799999996,
+        "y": -2.950006799999869
+      },
+      {
+        "x": 6.411000000000012,
+        "y": -2.950006799999869
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_51",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.7670184000000511,
+        "y": 1.0549889999999778
+      },
+      {
+        "x": -4.500027199999909,
+        "y": 1.0549889999999778
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_52",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": -4.500027199999909,
+        "y": 1.0549889999999778
+      },
+      {
+        "x": -4.500027199999909,
+        "y": 0.4611370000000079
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_53",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 3.894114000000126,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 6.411000000000012,
+        "y": 2.9450030000000424
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_54",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 2.6570069999999752,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 3.894114000000126,
+        "y": 2.9450030000000424
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_55",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 2.6570069999999752,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 2.4103118861290334,
+        "y": 2.9288336092640748
+      },
+      {
+        "x": 2.167837866175386,
+        "y": 2.8806021044970294
+      },
+      {
+        "x": 1.933733808737724,
+        "y": 2.801133754218995
+      },
+      {
+        "x": 1.7120053675888123,
+        "y": 2.6917883071702136
+      },
+      {
+        "x": 1.5064464426572606,
+        "y": 2.5544367262343712
+      },
+      {
+        "x": 1.3205742642384841,
+        "y": 2.3914291751993915
+      },
+      {
+        "x": 1.1575692111811797,
+        "y": 2.2055548061152876
+      },
+      {
+        "x": 1.020220392793771,
+        "y": 1.9999940353145576
+      },
+      {
+        "x": 0.9108779255952406,
+        "y": 1.7782641246765252
+      },
+      {
+        "x": 0.8314127214827742,
+        "y": 1.5441589992735771
+      },
+      {
+        "x": 0.7831844753633952,
+        "y": 1.301684331151364
+      },
+      {
+        "x": 0.7670184000000511,
+        "y": 1.0549889999999778
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_11",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 1.5849999999999902,
+    "y": -3.6349987999999667,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_56",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 9.385009799999988,
+        "y": 4.165011000000032
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_57",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": -11.435008600000078
+      },
+      {
+        "x": 9.385009799999988,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_58",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": 4.165011000000032
+      },
+      {
+        "x": -6.215009800000008,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_59",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.385009799999988,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 9.385009799999988,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_4",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0.9499999999999993,
+      "y": 5
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K4",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_54",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_54",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 2.1225910000000106,
+    "y": -13,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_54",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 2.1225910000000106,
+    "y": -13,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_54",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_55",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_55",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": -0.22259100000001197,
+    "y": -13,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_55",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": -0.22259100000001197,
+    "y": -13,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_55",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_60",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.04875720000002204,
+        "y": -13.726211400000011
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -13.519988799999965
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_61",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.04875720000002204,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -12.470003599999927
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_62",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.8012047999998906,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -12.273788599999989
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_63",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.8012047999998906,
+        "y": -13.726211400000011
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": -13.726211400000011
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_64",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.396760599999947,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 1.396760599999947,
+        "y": -13.726211400000011
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_12",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 16.825000000000045,
+    "y": -1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_13",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 23.174999999999955,
+    "y": 1.2700000000000955,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_56",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_57",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": 13.275095999999962,
+    "y": -1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_56",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 13.275095999999962,
+    "y": -1.2699999999999818,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_56",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_57",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_56",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 26.724904000000038,
+    "y": 1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_57",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 26.724904000000038,
+    "y": 1.2699999999999818,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_57",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_65",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 25.461000000000013,
+        "y": -0.4611370000000079
+      },
+      {
+        "x": 25.461000000000013,
+        "y": -2.9209999999999354
+      },
+      {
+        "x": 25.461000000000013,
+        "y": -2.9209999999999354
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_66",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 14.549998200000005,
+        "y": -2.950006799999869
+      },
+      {
+        "x": 25.461000000000013,
+        "y": -2.950006799999869
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_67",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.81701840000005,
+        "y": 1.0549889999999778
+      },
+      {
+        "x": 14.549972800000091,
+        "y": 1.0549889999999778
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_68",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 14.549972800000091,
+        "y": 1.0549889999999778
+      },
+      {
+        "x": 14.549972800000091,
+        "y": 0.4611370000000079
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_69",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 22.944114000000127,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 25.461000000000013,
+        "y": 2.9450030000000424
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_70",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 21.707006999999976,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 22.944114000000127,
+        "y": 2.9450030000000424
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_71",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 21.707006999999976,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 21.460311886129034,
+        "y": 2.9288336092640748
+      },
+      {
+        "x": 21.217837866175387,
+        "y": 2.8806021044970294
+      },
+      {
+        "x": 20.983733808737725,
+        "y": 2.801133754218995
+      },
+      {
+        "x": 20.762005367588813,
+        "y": 2.6917883071702136
+      },
+      {
+        "x": 20.55644644265726,
+        "y": 2.5544367262343712
+      },
+      {
+        "x": 20.370574264238485,
+        "y": 2.3914291751993915
+      },
+      {
+        "x": 20.20756921118118,
+        "y": 2.2055548061152876
+      },
+      {
+        "x": 20.07022039279377,
+        "y": 1.9999940353145576
+      },
+      {
+        "x": 19.96087792559524,
+        "y": 1.7782641246765252
+      },
+      {
+        "x": 19.881412721482775,
+        "y": 1.5441589992735771
+      },
+      {
+        "x": 19.833184475363396,
+        "y": 1.301684331151364
+      },
+      {
+        "x": 19.81701840000005,
+        "y": 1.0549889999999778
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_14",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 20.63499999999999,
+    "y": -3.6349987999999667,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_72",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 28.43500979999999,
+        "y": 4.165011000000032
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_73",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": -11.435008600000078
+      },
+      {
+        "x": 28.43500979999999,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_74",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 12.834990199999993,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_75",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 28.43500979999999,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 28.43500979999999,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_5",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 20,
+      "y": 5
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K5",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_58",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_58",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 21.17259100000001,
+    "y": -13,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_58",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 21.17259100000001,
+    "y": -13,
+    "pcb_component_id": "pcb_component_15",
+    "pcb_smtpad_id": "pcb_smtpad_58",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_59",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_59",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": 18.82740899999999,
+    "y": -13,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_59",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 18.82740899999999,
+    "y": -13,
+    "pcb_component_id": "pcb_component_15",
+    "pcb_smtpad_id": "pcb_smtpad_59",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_76",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.098757200000023,
+        "y": -13.726211400000011
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -13.519988799999965
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_77",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.098757200000023,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -12.470003599999927
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_78",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.85120479999989,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -12.273788599999989
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_79",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.85120479999989,
+        "y": -13.726211400000011
+      },
+      {
+        "x": 19.098757200000023,
+        "y": -13.726211400000011
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_80",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.446760599999948,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 20.446760599999948,
+        "y": -13.726211400000011
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_15",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 35.87500000000004,
+    "y": -1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_16",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 42.22499999999995,
+    "y": 1.2700000000000955,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_60",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_61",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": 32.32509599999996,
+    "y": -1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_60",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 32.32509599999996,
+    "y": -1.2699999999999818,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_60",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_60",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 45.774904000000035,
+    "y": 1.2699999999999818,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_61",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 45.774904000000035,
+    "y": 1.2699999999999818,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_81",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 44.51100000000001,
+        "y": -0.4611370000000079
+      },
+      {
+        "x": 44.51100000000001,
+        "y": -2.9209999999999354
+      },
+      {
+        "x": 44.51100000000001,
+        "y": -2.9209999999999354
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_82",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 33.5999982,
+        "y": -2.950006799999869
+      },
+      {
+        "x": 44.51100000000001,
+        "y": -2.950006799999869
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_83",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.86701840000005,
+        "y": 1.0549889999999778
+      },
+      {
+        "x": 33.59997280000009,
+        "y": 1.0549889999999778
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_84",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 33.59997280000009,
+        "y": 1.0549889999999778
+      },
+      {
+        "x": 33.59997280000009,
+        "y": 0.4611370000000079
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_85",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 41.994114000000124,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 44.51100000000001,
+        "y": 2.9450030000000424
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_86",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 40.75700699999997,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 41.994114000000124,
+        "y": 2.9450030000000424
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_87",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 40.75700699999997,
+        "y": 2.9450030000000424
+      },
+      {
+        "x": 40.51031188612903,
+        "y": 2.9288336092640748
+      },
+      {
+        "x": 40.267837866175384,
+        "y": 2.8806021044970294
+      },
+      {
+        "x": 40.03373380873772,
+        "y": 2.801133754218995
+      },
+      {
+        "x": 39.81200536758881,
+        "y": 2.6917883071702136
+      },
+      {
+        "x": 39.60644644265726,
+        "y": 2.5544367262343712
+      },
+      {
+        "x": 39.42057426423848,
+        "y": 2.3914291751993915
+      },
+      {
+        "x": 39.25756921118118,
+        "y": 2.2055548061152876
+      },
+      {
+        "x": 39.12022039279377,
+        "y": 1.9999940353145576
+      },
+      {
+        "x": 39.01087792559524,
+        "y": 1.7782641246765252
+      },
+      {
+        "x": 38.93141272148277,
+        "y": 1.5441589992735771
+      },
+      {
+        "x": 38.88318447536339,
+        "y": 1.301684331151364
+      },
+      {
+        "x": 38.86701840000005,
+        "y": 1.0549889999999778
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_17",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 39.68499999999999,
+    "y": -3.6349987999999667,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_88",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 47.485009799999986,
+        "y": 4.165011000000032
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_89",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": -11.435008600000078
+      },
+      {
+        "x": 47.485009799999986,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_90",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 31.88499019999999,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_91",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 47.485009799999986,
+        "y": 4.165011000000032
+      },
+      {
+        "x": 47.485009799999986,
+        "y": -11.435008600000078
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_6",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 39.05,
+      "y": 5
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K6",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_62",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 40.22259100000001,
+    "y": -13,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_62",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 40.22259100000001,
+    "y": -13,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_63",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": 37.877408999999986,
+    "y": -13,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_63",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 37.877408999999986,
+    "y": -13,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_92",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.14875720000002,
+        "y": -13.726211400000011
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -13.519988799999965
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_93",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.14875720000002,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -12.470003599999927
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_94",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.90120479999989,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -12.273788599999989
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_95",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.90120479999989,
+        "y": -13.726211400000011
+      },
+      {
+        "x": 38.14875720000002,
+        "y": -13.726211400000011
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_96",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.496760599999945,
+        "y": -12.273788599999989
+      },
+      {
+        "x": 39.496760599999945,
+        "y": -13.726211400000011
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_18",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": -2.2249999999999552,
+    "y": 17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_19",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 4.124999999999954,
+    "y": 20.320000000000096,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_65",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": -5.7749040000000385,
+    "y": 17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_64",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": -5.7749040000000385,
+    "y": 17.78000000000002,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_64",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 7.674904000000037,
+    "y": 20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_65",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 7.674904000000037,
+    "y": 20.319999999999983,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_97",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 6.411000000000012,
+        "y": 18.588862999999993
+      },
+      {
+        "x": 6.411000000000012,
+        "y": 16.129000000000065
+      },
+      {
+        "x": 6.411000000000012,
+        "y": 16.129000000000065
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_98",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": -4.500001799999996,
+        "y": 16.09999320000013
+      },
+      {
+        "x": 6.411000000000012,
+        "y": 16.09999320000013
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_99",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.7670184000000511,
+        "y": 20.10498899999998
+      },
+      {
+        "x": -4.500027199999909,
+        "y": 20.10498899999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_100",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": -4.500027199999909,
+        "y": 20.10498899999998
+      },
+      {
+        "x": -4.500027199999909,
+        "y": 19.51113700000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_101",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 3.894114000000126,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 6.411000000000012,
+        "y": 21.995003000000043
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_102",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 2.6570069999999752,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 3.894114000000126,
+        "y": 21.995003000000043
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_103",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 2.6570069999999752,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 2.4103118861290334,
+        "y": 21.978833609264075
+      },
+      {
+        "x": 2.167837866175386,
+        "y": 21.93060210449703
+      },
+      {
+        "x": 1.933733808737724,
+        "y": 21.851133754218996
+      },
+      {
+        "x": 1.7120053675888123,
+        "y": 21.741788307170214
+      },
+      {
+        "x": 1.5064464426572606,
+        "y": 21.604436726234372
+      },
+      {
+        "x": 1.3205742642384841,
+        "y": 21.441429175199392
+      },
+      {
+        "x": 1.1575692111811797,
+        "y": 21.25555480611529
+      },
+      {
+        "x": 1.020220392793771,
+        "y": 21.04999403531456
+      },
+      {
+        "x": 0.9108779255952406,
+        "y": 20.828264124676526
+      },
+      {
+        "x": 0.8314127214827742,
+        "y": 20.594158999273578
+      },
+      {
+        "x": 0.7831844753633952,
+        "y": 20.351684331151365
+      },
+      {
+        "x": 0.7670184000000511,
+        "y": 20.10498899999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_20",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 1.5849999999999902,
+    "y": 15.415001200000034,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_104",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 9.385009799999988,
+        "y": 23.215011000000032
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_105",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": 7.614991399999923
+      },
+      {
+        "x": 9.385009799999988,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_106",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.215009800000008,
+        "y": 23.215011000000032
+      },
+      {
+        "x": -6.215009800000008,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_107",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.385009799999988,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 9.385009799999988,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_7",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0.9499999999999993,
+      "y": 24.05
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K7",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "pcb_component_id": "pcb_component_21",
+    "pcb_port_id": "pcb_port_66",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 2.1225910000000106,
+    "y": 6.050000000000001,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_66",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 2.1225910000000106,
+    "y": 6.050000000000001,
+    "pcb_component_id": "pcb_component_21",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "pcb_component_id": "pcb_component_21",
+    "pcb_port_id": "pcb_port_67",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": -0.22259100000001197,
+    "y": 6.050000000000001,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_67",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": -0.22259100000001197,
+    "y": 6.050000000000001,
+    "pcb_component_id": "pcb_component_21",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_108",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.04875720000002204,
+        "y": 5.32378859999999
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": 5.530011200000036
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_109",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 0.04875720000002204,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": 6.5799964000000735
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_110",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.8012047999998906,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": 6.776211400000012
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_111",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.8012047999998906,
+        "y": 5.32378859999999
+      },
+      {
+        "x": 0.04875720000002204,
+        "y": 5.32378859999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_112",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 1.396760599999947,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 1.396760599999947,
+        "y": 5.32378859999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_21",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 16.825000000000045,
+    "y": 17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_22",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 23.174999999999955,
+    "y": 20.320000000000096,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "pcb_component_id": "pcb_component_22",
+    "pcb_port_id": "pcb_port_69",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": 13.275095999999962,
+    "y": 17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_68",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 13.275095999999962,
+    "y": 17.78000000000002,
+    "pcb_component_id": "pcb_component_22",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "pcb_component_id": "pcb_component_22",
+    "pcb_port_id": "pcb_port_68",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 26.724904000000038,
+    "y": 20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_69",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 26.724904000000038,
+    "y": 20.319999999999983,
+    "pcb_component_id": "pcb_component_22",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_113",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 25.461000000000013,
+        "y": 18.588862999999993
+      },
+      {
+        "x": 25.461000000000013,
+        "y": 16.129000000000065
+      },
+      {
+        "x": 25.461000000000013,
+        "y": 16.129000000000065
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_114",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 14.549998200000005,
+        "y": 16.09999320000013
+      },
+      {
+        "x": 25.461000000000013,
+        "y": 16.09999320000013
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_115",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.81701840000005,
+        "y": 20.10498899999998
+      },
+      {
+        "x": 14.549972800000091,
+        "y": 20.10498899999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_116",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 14.549972800000091,
+        "y": 20.10498899999998
+      },
+      {
+        "x": 14.549972800000091,
+        "y": 19.51113700000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_117",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 22.944114000000127,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 25.461000000000013,
+        "y": 21.995003000000043
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_118",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 21.707006999999976,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 22.944114000000127,
+        "y": 21.995003000000043
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_119",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 21.707006999999976,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 21.460311886129034,
+        "y": 21.978833609264075
+      },
+      {
+        "x": 21.217837866175387,
+        "y": 21.93060210449703
+      },
+      {
+        "x": 20.983733808737725,
+        "y": 21.851133754218996
+      },
+      {
+        "x": 20.762005367588813,
+        "y": 21.741788307170214
+      },
+      {
+        "x": 20.55644644265726,
+        "y": 21.604436726234372
+      },
+      {
+        "x": 20.370574264238485,
+        "y": 21.441429175199392
+      },
+      {
+        "x": 20.20756921118118,
+        "y": 21.25555480611529
+      },
+      {
+        "x": 20.07022039279377,
+        "y": 21.04999403531456
+      },
+      {
+        "x": 19.96087792559524,
+        "y": 20.828264124676526
+      },
+      {
+        "x": 19.881412721482775,
+        "y": 20.594158999273578
+      },
+      {
+        "x": 19.833184475363396,
+        "y": 20.351684331151365
+      },
+      {
+        "x": 19.81701840000005,
+        "y": 20.10498899999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_23",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 20.63499999999999,
+    "y": 15.415001200000034,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_120",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 28.43500979999999,
+        "y": 23.215011000000032
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_121",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": 7.614991399999923
+      },
+      {
+        "x": 28.43500979999999,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_122",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.834990199999993,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 12.834990199999993,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_123",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 28.43500979999999,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 28.43500979999999,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_8",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 20,
+      "y": 24.05
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K8",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "pcb_component_id": "pcb_component_24",
+    "pcb_port_id": "pcb_port_70",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 21.17259100000001,
+    "y": 6.050000000000001,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_70",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 21.17259100000001,
+    "y": 6.050000000000001,
+    "pcb_component_id": "pcb_component_24",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "pcb_component_id": "pcb_component_24",
+    "pcb_port_id": "pcb_port_71",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": 18.82740899999999,
+    "y": 6.050000000000001,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_71",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 18.82740899999999,
+    "y": 6.050000000000001,
+    "pcb_component_id": "pcb_component_24",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_124",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.098757200000023,
+        "y": 5.32378859999999
+      },
+      {
+        "x": 19.098757200000023,
+        "y": 5.530011200000036
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_125",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 19.098757200000023,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 19.098757200000023,
+        "y": 6.5799964000000735
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_126",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.85120479999989,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 19.098757200000023,
+        "y": 6.776211400000012
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_127",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.85120479999989,
+        "y": 5.32378859999999
+      },
+      {
+        "x": 19.098757200000023,
+        "y": 5.32378859999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_128",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 20.446760599999948,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 20.446760599999948,
+        "y": 5.32378859999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_24",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 35.87500000000004,
+    "y": 17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_25",
+    "hole_shape": "circle",
+    "hole_diameter": 2.9999939999999996,
+    "x": 42.22499999999995,
+    "y": 20.320000000000096,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_73",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["2"],
+    "x": 32.32509599999996,
+    "y": 17.78000000000002,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_72",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 32.32509599999996,
+    "y": 17.78000000000002,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "pcb_component_id": "pcb_component_25",
+    "pcb_port_id": "pcb_port_72",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.8999941999999996,
+    "height": 2.4999949999999997,
+    "port_hints": ["1"],
+    "x": 45.774904000000035,
+    "y": 20.319999999999983,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_73",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 2.0299959399999996,
+    "height": 1.7499964999999997,
+    "x": 45.774904000000035,
+    "y": 20.319999999999983,
+    "pcb_component_id": "pcb_component_25",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_129",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 44.51100000000001,
+        "y": 18.588862999999993
+      },
+      {
+        "x": 44.51100000000001,
+        "y": 16.129000000000065
+      },
+      {
+        "x": 44.51100000000001,
+        "y": 16.129000000000065
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_130",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 33.5999982,
+        "y": 16.09999320000013
+      },
+      {
+        "x": 44.51100000000001,
+        "y": 16.09999320000013
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_131",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.86701840000005,
+        "y": 20.10498899999998
+      },
+      {
+        "x": 33.59997280000009,
+        "y": 20.10498899999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_132",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 33.59997280000009,
+        "y": 20.10498899999998
+      },
+      {
+        "x": 33.59997280000009,
+        "y": 19.51113700000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_133",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 41.994114000000124,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 44.51100000000001,
+        "y": 21.995003000000043
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_134",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 40.75700699999997,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 41.994114000000124,
+        "y": 21.995003000000043
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_135",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 40.75700699999997,
+        "y": 21.995003000000043
+      },
+      {
+        "x": 40.51031188612903,
+        "y": 21.978833609264075
+      },
+      {
+        "x": 40.267837866175384,
+        "y": 21.93060210449703
+      },
+      {
+        "x": 40.03373380873772,
+        "y": 21.851133754218996
+      },
+      {
+        "x": 39.81200536758881,
+        "y": 21.741788307170214
+      },
+      {
+        "x": 39.60644644265726,
+        "y": 21.604436726234372
+      },
+      {
+        "x": 39.42057426423848,
+        "y": 21.441429175199392
+      },
+      {
+        "x": 39.25756921118118,
+        "y": 21.25555480611529
+      },
+      {
+        "x": 39.12022039279377,
+        "y": 21.04999403531456
+      },
+      {
+        "x": 39.01087792559524,
+        "y": 20.828264124676526
+      },
+      {
+        "x": 38.93141272148277,
+        "y": 20.594158999273578
+      },
+      {
+        "x": 38.88318447536339,
+        "y": 20.351684331151365
+      },
+      {
+        "x": 38.86701840000005,
+        "y": 20.10498899999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_26",
+    "hole_shape": "circle",
+    "hole_diameter": 4.1999916,
+    "x": 39.68499999999999,
+    "y": 15.415001200000034,
+    "subcircuit_id": "subcircuit_source_group_18"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_136",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 47.485009799999986,
+        "y": 23.215011000000032
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_137",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": 7.614991399999923
+      },
+      {
+        "x": 47.485009799999986,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_138",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 31.88499019999999,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 31.88499019999999,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_139",
+    "pcb_component_id": null,
+    "layer": "top",
+    "route": [
+      {
+        "x": 47.485009799999986,
+        "y": 23.215011000000032
+      },
+      {
+        "x": 47.485009799999986,
+        "y": 7.614991399999923
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_9",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 39.05,
+      "y": 24.05
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "K9",
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_74",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["1"],
+    "x": 40.22259100000001,
+    "y": 6.050000000000001,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_74",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 40.22259100000001,
+    "y": 6.050000000000001,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "pcb_component_id": "pcb_component_27",
+    "pcb_port_id": "pcb_port_75",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.9999979999999999,
+    "height": 0.7500112,
+    "port_hints": ["2"],
+    "x": 37.877408999999986,
+    "y": 6.050000000000001,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_75",
+    "layer": "bottom",
+    "shape": "rect",
+    "width": 0.6999985999999999,
+    "height": 0.52500784,
+    "x": 37.877408999999986,
+    "y": 6.050000000000001,
+    "pcb_component_id": "pcb_component_27",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_140",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.14875720000002,
+        "y": 5.32378859999999
+      },
+      {
+        "x": 38.14875720000002,
+        "y": 5.530011200000036
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_141",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 38.14875720000002,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 38.14875720000002,
+        "y": 6.5799964000000735
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_142",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.90120479999989,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 38.14875720000002,
+        "y": 6.776211400000012
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_143",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.90120479999989,
+        "y": 5.32378859999999
+      },
+      {
+        "x": 38.14875720000002,
+        "y": 5.32378859999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_144",
+    "pcb_component_id": null,
+    "layer": "bottom",
+    "route": [
+      {
+        "x": 39.496760599999945,
+        "y": 6.776211400000012
+      },
+      {
+        "x": 39.496760599999945,
+        "y": 5.32378859999999
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_0",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 24.13,
+    "source_port_id": "source_port_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_1",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 21.59,
+    "source_port_id": "source_port_1"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_2",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 19.049999999999997,
+    "source_port_id": "source_port_2"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_3",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 16.509999999999998,
+    "source_port_id": "source_port_3"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_4",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 13.969999999999999,
+    "source_port_id": "source_port_4"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_5",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 11.43,
+    "source_port_id": "source_port_5"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_6",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 8.889999999999999,
+    "source_port_id": "source_port_6"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_7",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 6.349999999999998,
+    "source_port_id": "source_port_7"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_8",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 3.8099999999999987,
+    "source_port_id": "source_port_8"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_9",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": 1.2699999999999996,
+    "source_port_id": "source_port_9"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_10",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -1.2699999999999996,
+    "source_port_id": "source_port_10"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_11",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -3.8100000000000023,
+    "source_port_id": "source_port_11"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_12",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -6.350000000000001,
+    "source_port_id": "source_port_12"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_13",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -8.890000000000004,
+    "source_port_id": "source_port_13"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_14",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -11.430000000000003,
+    "source_port_id": "source_port_14"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_15",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -13.970000000000002,
+    "source_port_id": "source_port_15"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_16",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -16.51,
+    "source_port_id": "source_port_16"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_17",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -19.05,
+    "source_port_id": "source_port_17"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_18",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -21.59,
+    "source_port_id": "source_port_18"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_19",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -39.39,
+    "y": -24.13,
+    "source_port_id": "source_port_19"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_20",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -24.13,
+    "source_port_id": "source_port_20"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_21",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -21.59,
+    "source_port_id": "source_port_21"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_22",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -19.049999999999997,
+    "source_port_id": "source_port_22"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_23",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -16.509999999999998,
+    "source_port_id": "source_port_23"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_24",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -13.969999999999999,
+    "source_port_id": "source_port_24"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_25",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -11.43,
+    "source_port_id": "source_port_25"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_26",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -8.889999999999999,
+    "source_port_id": "source_port_26"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_27",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -6.349999999999998,
+    "source_port_id": "source_port_27"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_28",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -3.8099999999999987,
+    "source_port_id": "source_port_28"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_29",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": -1.2699999999999996,
+    "source_port_id": "source_port_29"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_30",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 1.2699999999999996,
+    "source_port_id": "source_port_30"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_31",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 3.8100000000000023,
+    "source_port_id": "source_port_31"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_32",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 6.350000000000001,
+    "source_port_id": "source_port_32"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_33",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 8.890000000000004,
+    "source_port_id": "source_port_33"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_34",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 11.430000000000003,
+    "source_port_id": "source_port_34"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_35",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 13.970000000000002,
+    "source_port_id": "source_port_35"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_36",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 16.51,
+    "source_port_id": "source_port_36"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_37",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 19.05,
+    "source_port_id": "source_port_37"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_38",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 21.59,
+    "source_port_id": "source_port_38"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_39",
+    "pcb_component_id": "pcb_component_0",
+    "layers": ["top"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "x": -20.61,
+    "y": 24.13,
+    "source_port_id": "source_port_39"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_40",
+    "pcb_component_id": "pcb_component_1",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0",
+    "x": 7.674904000000037,
+    "y": -17.78000000000002,
+    "source_port_id": "source_port_40"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_41",
+    "pcb_component_id": "pcb_component_1",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_0",
+    "x": -5.7749040000000385,
+    "y": -20.319999999999983,
+    "source_port_id": "source_port_41"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_42",
+    "pcb_component_id": "pcb_component_3",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1",
+    "x": 2.1225910000000106,
+    "y": -32.05,
+    "source_port_id": "source_port_44"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_43",
+    "pcb_component_id": "pcb_component_3",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_1",
+    "x": -0.22259100000001197,
+    "y": -32.05,
+    "source_port_id": "source_port_45"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_44",
+    "pcb_component_id": "pcb_component_4",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2",
+    "x": 26.724904000000038,
+    "y": -17.78000000000002,
+    "source_port_id": "source_port_46"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_45",
+    "pcb_component_id": "pcb_component_4",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_2",
+    "x": 13.275095999999962,
+    "y": -20.319999999999983,
+    "source_port_id": "source_port_47"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_46",
+    "pcb_component_id": "pcb_component_6",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3",
+    "x": 21.17259100000001,
+    "y": -32.05,
+    "source_port_id": "source_port_50"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_47",
+    "pcb_component_id": "pcb_component_6",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_3",
+    "x": 18.82740899999999,
+    "y": -32.05,
+    "source_port_id": "source_port_51"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_48",
+    "pcb_component_id": "pcb_component_7",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4",
+    "x": 45.774904000000035,
+    "y": -17.78000000000002,
+    "source_port_id": "source_port_52"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_49",
+    "pcb_component_id": "pcb_component_7",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_4",
+    "x": 32.32509599999996,
+    "y": -20.319999999999983,
+    "source_port_id": "source_port_53"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_50",
+    "pcb_component_id": "pcb_component_9",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5",
+    "x": 40.22259100000001,
+    "y": -32.05,
+    "source_port_id": "source_port_56"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_51",
+    "pcb_component_id": "pcb_component_9",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_5",
+    "x": 37.877408999999986,
+    "y": -32.05,
+    "source_port_id": "source_port_57"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_52",
+    "pcb_component_id": "pcb_component_10",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6",
+    "x": 7.674904000000037,
+    "y": 1.2699999999999818,
+    "source_port_id": "source_port_58"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_53",
+    "pcb_component_id": "pcb_component_10",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_6",
+    "x": -5.7749040000000385,
+    "y": -1.2699999999999818,
+    "source_port_id": "source_port_59"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_54",
+    "pcb_component_id": "pcb_component_12",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7",
+    "x": 2.1225910000000106,
+    "y": -13,
+    "source_port_id": "source_port_62"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_55",
+    "pcb_component_id": "pcb_component_12",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_7",
+    "x": -0.22259100000001197,
+    "y": -13,
+    "source_port_id": "source_port_63"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_56",
+    "pcb_component_id": "pcb_component_13",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8",
+    "x": 26.724904000000038,
+    "y": 1.2699999999999818,
+    "source_port_id": "source_port_64"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_57",
+    "pcb_component_id": "pcb_component_13",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_8",
+    "x": 13.275095999999962,
+    "y": -1.2699999999999818,
+    "source_port_id": "source_port_65"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_58",
+    "pcb_component_id": "pcb_component_15",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9",
+    "x": 21.17259100000001,
+    "y": -13,
+    "source_port_id": "source_port_68"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_59",
+    "pcb_component_id": "pcb_component_15",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_9",
+    "x": 18.82740899999999,
+    "y": -13,
+    "source_port_id": "source_port_69"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_60",
+    "pcb_component_id": "pcb_component_16",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10",
+    "x": 45.774904000000035,
+    "y": 1.2699999999999818,
+    "source_port_id": "source_port_70"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_61",
+    "pcb_component_id": "pcb_component_16",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_10",
+    "x": 32.32509599999996,
+    "y": -1.2699999999999818,
+    "source_port_id": "source_port_71"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_62",
+    "pcb_component_id": "pcb_component_18",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11",
+    "x": 40.22259100000001,
+    "y": -13,
+    "source_port_id": "source_port_74"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_63",
+    "pcb_component_id": "pcb_component_18",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_11",
+    "x": 37.877408999999986,
+    "y": -13,
+    "source_port_id": "source_port_75"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_64",
+    "pcb_component_id": "pcb_component_19",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12",
+    "x": 7.674904000000037,
+    "y": 20.319999999999983,
+    "source_port_id": "source_port_76"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_65",
+    "pcb_component_id": "pcb_component_19",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_12",
+    "x": -5.7749040000000385,
+    "y": 17.78000000000002,
+    "source_port_id": "source_port_77"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_66",
+    "pcb_component_id": "pcb_component_21",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13",
+    "x": 2.1225910000000106,
+    "y": 6.050000000000001,
+    "source_port_id": "source_port_80"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_67",
+    "pcb_component_id": "pcb_component_21",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_13",
+    "x": -0.22259100000001197,
+    "y": 6.050000000000001,
+    "source_port_id": "source_port_81"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_68",
+    "pcb_component_id": "pcb_component_22",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14",
+    "x": 26.724904000000038,
+    "y": 20.319999999999983,
+    "source_port_id": "source_port_82"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_69",
+    "pcb_component_id": "pcb_component_22",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_14",
+    "x": 13.275095999999962,
+    "y": 17.78000000000002,
+    "source_port_id": "source_port_83"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_70",
+    "pcb_component_id": "pcb_component_24",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15",
+    "x": 21.17259100000001,
+    "y": 6.050000000000001,
+    "source_port_id": "source_port_86"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_71",
+    "pcb_component_id": "pcb_component_24",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_15",
+    "x": 18.82740899999999,
+    "y": 6.050000000000001,
+    "source_port_id": "source_port_87"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_72",
+    "pcb_component_id": "pcb_component_25",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16",
+    "x": 45.774904000000035,
+    "y": 20.319999999999983,
+    "source_port_id": "source_port_88"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_73",
+    "pcb_component_id": "pcb_component_25",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_16",
+    "x": 32.32509599999996,
+    "y": 17.78000000000002,
+    "source_port_id": "source_port_89"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_74",
+    "pcb_component_id": "pcb_component_27",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17",
+    "x": 40.22259100000001,
+    "y": 6.050000000000001,
+    "source_port_id": "source_port_92"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_75",
+    "pcb_component_id": "pcb_component_27",
+    "layers": ["bottom"],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "pcb_group_id": "pcb_group_17",
+    "x": 37.877408999999986,
+    "y": 6.050000000000001,
+    "source_port_id": "source_port_93"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_0",
+    "position": {
+      "x": -30,
+      "y": 0,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_0",
+    "source_component_id": "source_component_0",
+    "footprinter_string": "soic40_w22.58mm_p2.54mm_pl3.8_ph2.2"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_1",
+    "position": {
+      "x": 0.9499999999999988,
+      "y": -19.049999999999944,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_2",
+    "position": {
+      "x": 2.1649999999999903,
+      "y": -25.864998799999967,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_3",
+    "position": {
+      "x": 0.9499999999999993,
+      "y": -32.05,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_3",
+    "source_component_id": "source_component_3",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_4",
+    "position": {
+      "x": 20,
+      "y": -19.049999999999944,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_4",
+    "source_component_id": "source_component_4",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_5",
+    "position": {
+      "x": 21.21499999999999,
+      "y": -25.864998799999967,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_5",
+    "source_component_id": "source_component_5",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_6",
+    "position": {
+      "x": 20,
+      "y": -32.05,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_6",
+    "source_component_id": "source_component_6",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_7",
+    "position": {
+      "x": 39.05,
+      "y": -19.049999999999944,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_7",
+    "source_component_id": "source_component_7",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_8",
+    "position": {
+      "x": 40.264999999999986,
+      "y": -25.864998799999967,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_8",
+    "source_component_id": "source_component_8",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_9",
+    "position": {
+      "x": 39.05,
+      "y": -32.05,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_9",
+    "source_component_id": "source_component_9",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_10",
+    "position": {
+      "x": 0.9499999999999988,
+      "y": 5.684341886080802e-14,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_10",
+    "source_component_id": "source_component_10",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_11",
+    "position": {
+      "x": 2.1649999999999903,
+      "y": -6.814998799999967,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_11",
+    "source_component_id": "source_component_11",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_12",
+    "position": {
+      "x": 0.9499999999999993,
+      "y": -13,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_12",
+    "source_component_id": "source_component_12",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_13",
+    "position": {
+      "x": 20,
+      "y": 5.684341886080802e-14,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_13",
+    "source_component_id": "source_component_13",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_14",
+    "position": {
+      "x": 21.21499999999999,
+      "y": -6.814998799999967,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_14",
+    "source_component_id": "source_component_14",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_15",
+    "position": {
+      "x": 20,
+      "y": -13,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_15",
+    "source_component_id": "source_component_15",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_16",
+    "position": {
+      "x": 39.05,
+      "y": 5.684341886080802e-14,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_16",
+    "source_component_id": "source_component_16",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_17",
+    "position": {
+      "x": 40.264999999999986,
+      "y": -6.814998799999967,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_17",
+    "source_component_id": "source_component_17",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_18",
+    "position": {
+      "x": 39.05,
+      "y": -13,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_18",
+    "source_component_id": "source_component_18",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_19",
+    "position": {
+      "x": 0.9499999999999988,
+      "y": 19.050000000000058,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_19",
+    "source_component_id": "source_component_19",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_20",
+    "position": {
+      "x": 2.1649999999999903,
+      "y": 12.235001200000035,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_20",
+    "source_component_id": "source_component_20",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_21",
+    "position": {
+      "x": 0.9499999999999993,
+      "y": 6.050000000000001,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_21",
+    "source_component_id": "source_component_21",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_22",
+    "position": {
+      "x": 20,
+      "y": 19.050000000000058,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_22",
+    "source_component_id": "source_component_22",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_23",
+    "position": {
+      "x": 21.21499999999999,
+      "y": 12.235001200000035,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_23",
+    "source_component_id": "source_component_23",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_24",
+    "position": {
+      "x": 20,
+      "y": 6.050000000000001,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_24",
+    "source_component_id": "source_component_24",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_25",
+    "position": {
+      "x": 39.05,
+      "y": 19.050000000000058,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_25",
+    "source_component_id": "source_component_25",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_26",
+    "position": {
+      "x": 40.264999999999986,
+      "y": 12.235001200000035,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_26",
+    "source_component_id": "source_component_26",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_27",
+    "position": {
+      "x": 39.05,
+      "y": 6.050000000000001,
+      "z": -0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 180,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_27",
+    "source_component_id": "source_component_27",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=973acf8a660c48b1975f1ba1c890421a&pn=C57759&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_26_0",
+    "connection_name": "source_trace_26",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32.32509599999996,
+        "y": 17.78000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.623275050337117,
+        "y": 17.78000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.137650050337136,
+        "y": 18.265625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.078125,
+        "y": 18.265625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 30.078125,
+        "y": 18.265625,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 30.078125,
+        "y": 18.265625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.400831150032275,
+        "y": 12.588331150032273,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.988331150032275,
+        "y": 12.588331150032273,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.104010514479782,
+        "y": 12.588331150032273,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.11567936444751,
+        "y": 13.600000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.199999999999998,
+        "y": 13.600000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -9.199999999999998,
+        "y": 13.600000000000001,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.199999999999998,
+        "y": 13.600000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.42212249385504,
+        "y": 12.377877506144959,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.377877506144955,
+        "y": 12.377877506144959,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.4,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -26.4,
+        "y": 12.4,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.4,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.867200604399628,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.599999999999994,
+        "y": 11.667200604399632,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.599999999999994,
+        "y": 11.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -27.599999999999994,
+        "y": 11.6,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.599999999999994,
+        "y": 11.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.599999999999994,
+        "y": 9.627479697689092,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.41373984884454,
+        "y": 8.813739848844547,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -31.535965147835995,
+        "y": 8.813739848844547,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.78472529899145,
+        "y": 10.0625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.8125,
+        "y": 10.0625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -32.8125,
+        "y": 10.0625,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.8125,
+        "y": 10.0625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -38.2175,
+        "y": 10.0625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 8.889999999999999,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_26"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_25_0",
+    "connection_name": "source_trace_25",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 37.877408999999986,
+        "y": 6.050000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 37.877408999999986,
+        "y": 5.797551197291606,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 36.07292659187486,
+        "y": 3.9930687891664807,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 35.9375,
+        "y": 3.8125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 35.9375,
+        "y": 3.8125,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 35.9375,
+        "y": 3.8125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.798091371710868,
+        "y": 3.8125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.410591371710867,
+        "y": 9.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.4,
+        "y": 9.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 8.4,
+        "y": 9.200000000000001,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.4,
+        "y": 9.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.4,
+        "y": 6.096030742349015,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.03125,
+        "y": 4.727280742349015,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.03125,
+        "y": 4.59375,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 7.03125,
+        "y": 4.59375,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.03125,
+        "y": 4.59375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.2538627365379185,
+        "y": 4.59375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.460112736537919,
+        "y": 4.800000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.600000000000001,
+        "y": 4.800000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -5.600000000000001,
+        "y": 4.800000000000001,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.600000000000001,
+        "y": 4.800000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.600000000000001,
+        "y": 5.200000000000008,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.113884198696839,
+        "y": 6.713884198696846,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.111115801303152,
+        "y": 6.713884198696846,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.179314937610583,
+        "y": 3.645685062389415,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.224999999999998,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -13.224999999999998,
+        "y": 3.6,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.224999999999998,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.164423309910347,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.164423309910347,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.225,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -15.225,
+        "y": 3.6,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.225,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.568150908231814,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.800000000000004,
+        "y": -1.6318490917681914,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.800000000000004,
+        "y": -6.000000000000005,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -31.91574068888268,
+        "y": -9.11574068888268,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -32,
+        "y": -9.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -32,
+        "y": -9.200000000000001,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -32,
+        "y": -9.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.080000000000005,
+        "y": -9.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": -8.890000000000004,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_25"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_24_0",
+    "connection_name": "source_trace_24",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 40.22259100000001,
+        "y": 6.050000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.774904000000035,
+        "y": 11.602313000000027,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.774904000000035,
+        "y": 20.319999999999983,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_24"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_23_0",
+    "connection_name": "source_trace_23",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 13.275095999999962,
+        "y": 17.78000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.275095999999962,
+        "y": 16.07509599999996,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.20208507601842,
+        "y": 12.00208507601842,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.2,
+        "y": 11.999999999999998,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 9.2,
+        "y": 11.999999999999998,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.2,
+        "y": 11.999999999999998,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.2000000000000028,
+        "y": 11.999999999999998,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.180388885685904,
+        "y": 6.019611114314097,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.200000000000001,
+        "y": 6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -7.200000000000001,
+        "y": 6,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.200000000000001,
+        "y": 6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.400000000000002,
+        "y": 2.799999999999999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.400000000000002,
+        "y": -5.55528117289971,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.400000000000002,
+        "y": -5.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -10.400000000000002,
+        "y": -5.6,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.400000000000002,
+        "y": -5.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.400000000000002,
+        "y": -6.202772611644074,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.600000000000001,
+        "y": -7.002772611644074,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.600000000000001,
+        "y": -7.199999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -9.600000000000001,
+        "y": -7.199999999999999,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.600000000000001,
+        "y": -7.199999999999999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.600000000000001,
+        "y": -15.772876692504722,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.600000000000001,
+        "y": -15.772876692504722,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.600000000000001,
+        "y": -16.000000000000004,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -9.600000000000001,
+        "y": -16.000000000000004,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.600000000000001,
+        "y": -16.000000000000004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.189999999999998,
+        "y": -21.59,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.61,
+        "y": -21.59,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_23"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_22_0",
+    "connection_name": "source_trace_22",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 18.82740899999999,
+        "y": 6.050000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 18.82740899999999,
+        "y": 5.457331661892886,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.202267985678695,
+        "y": 3.8321906475715926,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.1875,
+        "y": 3.8125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 17.1875,
+        "y": 3.8125,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.1875,
+        "y": 3.8125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.099280570539682,
+        "y": 3.8125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.288219429460319,
+        "y": 9.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.4,
+        "y": 9.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.4,
+        "y": 9.200000000000001,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.4,
+        "y": 9.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.99590601177802,
+        "y": 9.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.09795300588901,
+        "y": 9.302046994110992,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.200000000000003,
+        "y": 9.2,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -9.200000000000003,
+        "y": 9.2,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.200000000000003,
+        "y": 9.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.200000000000003,
+        "y": 9.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.247356483898638,
+        "y": 10.247356483898635,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.400000000000004,
+        "y": 10.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -10.400000000000004,
+        "y": 10.4,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.400000000000004,
+        "y": 10.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.662309414335425,
+        "y": 2.137690585664579,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.103491433342256,
+        "y": 2.137690585664579,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.103491433342256,
+        "y": 1.8497101013616164,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.4,
+        "y": -3.446798465296126,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.4,
+        "y": -3.5999999999999996,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -32.4,
+        "y": -3.5999999999999996,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -32.4,
+        "y": -3.5999999999999996,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -37.690000000000005,
+        "y": -8.890000000000004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": -8.890000000000004,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_22"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_21_0",
+    "connection_name": "source_trace_21",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 21.17259100000001,
+        "y": 6.050000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.724904000000038,
+        "y": 11.602313000000027,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.724904000000038,
+        "y": 20.319999999999983,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_21"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_20_0",
+    "connection_name": "source_trace_20",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.7749040000000385,
+        "y": 17.78000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.7749040000000385,
+        "y": 14.225095999999963,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.737456953285632,
+        "y": 9.26254304671437,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.800000000000004,
+        "y": 9.199999999999998,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -10.800000000000004,
+        "y": 9.199999999999998,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.800000000000004,
+        "y": 9.199999999999998,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.800000000000004,
+        "y": -0.5504092370825968,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.049590762917408,
+        "y": -2.8000000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.200000000000001,
+        "y": -2.8000000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -13.200000000000001,
+        "y": -2.8000000000000003,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.200000000000001,
+        "y": -2.8000000000000003,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.200000000000001,
+        "y": -9.775191749774452,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.200000000000001,
+        "y": -11.775191749774452,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.200000000000001,
+        "y": -12.000000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -15.200000000000001,
+        "y": -12.000000000000002,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.200000000000001,
+        "y": -12.000000000000002,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.169999999999998,
+        "y": -13.969999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.61,
+        "y": -13.969999999999999,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_20"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_19_0",
+    "connection_name": "source_trace_19",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.22259100000001197,
+        "y": 6.050000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.278378233852271,
+        "y": 6.050000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.728378233852272,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.799999999999997,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -8.799999999999997,
+        "y": 3.6,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.799999999999997,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.476807719087375,
+        "y": 3.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.876807719087376,
+        "y": 4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.999999999999998,
+        "y": 4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -9.999999999999998,
+        "y": 4,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.999999999999998,
+        "y": 4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.40601214223173,
+        "y": -0.40601214223173265,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.87404856892693,
+        "y": -0.40601214223173304,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.586267938735347,
+        "y": -0.40601214223173304,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -31.990127898251806,
+        "y": -2.8098721017481942,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -32,
+        "y": -2.8000000000000003,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -32,
+        "y": -2.8000000000000003,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -32,
+        "y": -2.8000000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -38.09,
+        "y": -8.890000000000004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": -8.890000000000004,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_19"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_18_0",
+    "connection_name": "source_trace_18",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.1225910000000106,
+        "y": 6.050000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.674904000000037,
+        "y": 11.602313000000027,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.674904000000037,
+        "y": 20.319999999999983,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_18"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_17_0",
+    "connection_name": "source_trace_17",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32.32509599999996,
+        "y": -1.2699999999999818,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.782215450978683,
+        "y": -1.2699999999999818,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.526107725489332,
+        "y": -8.526107725489332,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.400000000000002,
+        "y": -8.400000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 21.400000000000002,
+        "y": -8.400000000000002,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.400000000000002,
+        "y": -8.400000000000002,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.055153922612458,
+        "y": -8.400000000000002,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.049123138089965,
+        "y": -6.393969215477509,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.593969215477509,
+        "y": -6.393969215477509,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.155812412565809,
+        "y": -7.955812412565809,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.92915268216919,
+        "y": -7.955812412565809,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.684965094734999,
+        "y": -5.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.825,
+        "y": -5.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -14.825,
+        "y": -5.200000000000001,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.825,
+        "y": -5.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.162069298548104,
+        "y": -5.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.067888597096207,
+        "y": -3.2941807014518973,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.21875,
+        "y": -3.21875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -24.21875,
+        "y": -3.21875,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.21875,
+        "y": -3.21875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -25.496860245196302,
+        "y": -3.21875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -25.6,
+        "y": -3.3218897548037005,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -25.6,
+        "y": -3.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -25.6,
+        "y": -3.2,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -25.6,
+        "y": -3.2,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.29453575480054,
+        "y": -3.2,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.89453575480054,
+        "y": -1.6000000000000003,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.000000000000004,
+        "y": -1.6000000000000003,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -28.000000000000004,
+        "y": -1.6000000000000003,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.000000000000004,
+        "y": -1.6000000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -38.49,
+        "y": 8.889999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 8.889999999999999,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_17"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_16_0",
+    "connection_name": "source_trace_16",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 37.877408999999986,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.508242717727914,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.141485435455827,
+        "y": -13.366757282272086,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.125,
+        "y": -13.375,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 28.125,
+        "y": -13.375,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.125,
+        "y": -13.375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.585536947510503,
+        "y": -13.375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.610536947510504,
+        "y": -8.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.400000000000002,
+        "y": -8.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.929320043658855,
+        "y": -4.8706799563411485,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.929320043658855,
+        "y": -3.90677390082947,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.40625,
+        "y": -3.429843944488325,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.40625,
+        "y": -3.21875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -16.40625,
+        "y": -3.21875,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.40625,
+        "y": -3.21875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -21.820116685503155,
+        "y": -3.21875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -22.88222505650947,
+        "y": -2.1566416289936865,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.046875,
+        "y": -2.046875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -23.046875,
+        "y": -2.046875,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.046875,
+        "y": -2.046875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -23.046875,
+        "y": 4.246875000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.26975457268686,
+        "y": 9.469754572686863,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.4,
+        "y": 9.600000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -28.4,
+        "y": 9.600000000000001,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.4,
+        "y": 9.600000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.99105711355547,
+        "y": 18.191057113555477,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -41.6974511514073,
+        "y": 18.191057113555477,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -41.796875,
+        "y": 18.265625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -41.796875,
+        "y": 18.265625,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -41.796875,
+        "y": 18.265625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -41.796875,
+        "y": 19.947056241856423,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -40.87729160303489,
+        "y": 20.866639638821532,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -40.113360361178465,
+        "y": 20.866639638821532,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 21.59,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_16"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_15_0",
+    "connection_name": "source_trace_15",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 40.22259100000001,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 40.22259100000001,
+        "y": -10.666402988647619,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 42.17350601135238,
+        "y": -8.715487977295247,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 42.1875,
+        "y": -8.6875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 42.1875,
+        "y": -8.6875,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 42.1875,
+        "y": -8.6875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.28623018887472,
+        "y": -8.6875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 46.82246037774944,
+        "y": -7.1512698111252835,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 46.875,
+        "y": -7.125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 46.875,
+        "y": -7.125,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 46.875,
+        "y": -7.125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 46.875,
+        "y": 0.1699040000000167,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.774904000000035,
+        "y": 1.2699999999999818,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_15"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_14_0",
+    "connection_name": "source_trace_14",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 13.275095999999962,
+        "y": -1.2699999999999818,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.091877615721073,
+        "y": -6.4532183842788715,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.091877615721073,
+        "y": -8.708122384278928,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.599999999999996,
+        "y": -9.200000000000005,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 7.599999999999996,
+        "y": -9.200000000000005,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.599999999999996,
+        "y": -9.200000000000005,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.7231613636372299,
+        "y": -9.200000000000005,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.29309407114744357,
+        "y": -8.769932707510218,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.533296738370719,
+        "y": -14.596323517028381,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.89632351702838,
+        "y": -14.596323517028381,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.89632351702838,
+        "y": -14.713828782551959,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.89256105587871,
+        "y": -20.710066321402287,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.730066321402287,
+        "y": -20.710066321402287,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.61,
+        "y": -21.59,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_14"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_13_0",
+    "connection_name": "source_trace_13",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 18.82740899999999,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.60508536593519,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.002542682967595,
+        "y": -12.397457317032405,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 12,
+        "y": -12.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 12,
+        "y": -12.4,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12,
+        "y": -12.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.2000000000000015,
+        "y": -12.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.4327390510283641,
+        "y": -9.632739051028363,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.40000000000000013,
+        "y": -9.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 0.40000000000000013,
+        "y": -9.6,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.40000000000000013,
+        "y": -9.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.40000000000000013,
+        "y": -8.928638108825357,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.4000000000000006,
+        "y": -8.128638108825356,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.4000000000000006,
+        "y": -8,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -0.4000000000000006,
+        "y": -8,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.4000000000000006,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.374346324617659,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.374346324617659,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.4000000000000004,
+        "y": -8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.4000000000000004,
+        "y": -8,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.4000000000000004,
+        "y": -8,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.4000000000000004,
+        "y": -5.695319548441814,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.5999999999999988,
+        "y": -4.495319548441816,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.5999999999999988,
+        "y": -4.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -3.5999999999999988,
+        "y": -4.4,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.5999999999999988,
+        "y": -4.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.300442978392534,
+        "y": 0.3004429783925344,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.300442978392534,
+        "y": 3.9004429783925305,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.300442978392534,
+        "y": 7.531521363785984,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.600000000000003,
+        "y": 10.831078385393454,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.073878441441376,
+        "y": 10.831078385393454,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.211550056047923,
+        "y": 13.96875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.40625,
+        "y": 13.96875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -16.40625,
+        "y": 13.96875,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.40625,
+        "y": 13.96875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.568100059578388,
+        "y": 13.96875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.59920234584621,
+        "y": 19.99985228626782,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.79999999999998,
+        "y": 20,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -34.79999999999998,
+        "y": 20,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.79999999999998,
+        "y": 20,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.389999999999986,
+        "y": 21.59,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 21.59,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_13"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_12_0",
+    "connection_name": "source_trace_12",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 21.17259100000001,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.17259100000001,
+        "y": -12.26809840337769,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.6,
+        "y": -9.8406894033777,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.6,
+        "y": -9.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 23.6,
+        "y": -9.6,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.6,
+        "y": -9.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.6,
+        "y": -5.451925408534908,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.5625,
+        "y": -2.4894254085349097,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.5625,
+        "y": -2.4375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 26.5625,
+        "y": -2.4375,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.5625,
+        "y": -2.4375,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.5625,
+        "y": 1.107595999999944,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.724904000000038,
+        "y": 1.2699999999999818,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_12"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_11_0",
+    "connection_name": "source_trace_11",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.7749040000000385,
+        "y": -1.2699999999999818,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.7749040000000385,
+        "y": -2.5749040000000356,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.851177201761558,
+        "y": -9.651177201761556,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13,
+        "y": -9.799999999999997,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -13,
+        "y": -9.799999999999997,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13,
+        "y": -9.799999999999997,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -17.17,
+        "y": -13.969999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.61,
+        "y": -13.969999999999999,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_11"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_10_0",
+    "connection_name": "source_trace_10",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.22259100000001197,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.5223774507177428,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.2,
+        "y": -7.322377450717743,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.2,
+        "y": -7.2,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -7.2,
+        "y": -7.2,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.2,
+        "y": -7.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.884172846622285,
+        "y": -3.515827153377715,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.4,
+        "y": -3.515827153377715,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.4,
+        "y": 2.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.018398408421678,
+        "y": 2.781601591578322,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14,
+        "y": 2.8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -14,
+        "y": 2.8,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14,
+        "y": 2.8,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14,
+        "y": 4.202863040324919,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.4,
+        "y": 4.6028630403249196,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.4,
+        "y": 4.8,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -14.4,
+        "y": 4.8,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.4,
+        "y": 4.8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.4,
+        "y": 8.375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.066211106522438,
+        "y": 9.041211106522438,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.225,
+        "y": 9.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -15.225,
+        "y": 9.2,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.225,
+        "y": 9.2,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.4713081799219,
+        "y": 9.2,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.6713081799219,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.12921104012599,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.12921104012599,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.19999999999999,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -29.19999999999999,
+        "y": 12.4,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.19999999999999,
+        "y": 12.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -38.389999999999986,
+        "y": 21.59,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 21.59,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_10"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_9_0",
+    "connection_name": "source_trace_9",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.1225910000000106,
+        "y": -13,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.72160741295088,
+        "y": -7.40098358704913,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.72160741295088,
+        "y": -1.9026539872601624,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.72160741295088,
+        "y": 1.2232965870491386,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.674904000000037,
+        "y": 1.2699999999999818,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_9"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_8_0",
+    "connection_name": "source_trace_8",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 32.32509599999996,
+        "y": -20.319999999999983,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 32.32509599999996,
+        "y": -21.274904000000046,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.407316939363255,
+        "y": -27.19268306063675,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.807316939363243,
+        "y": -27.19268306063675,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.500433931455202,
+        "y": -27.49956606854479,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.39999999999999,
+        "y": -27.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 24.39999999999999,
+        "y": -27.6,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 24.39999999999999,
+        "y": -27.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 17.29641548062391,
+        "y": -27.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.496415480623913,
+        "y": -28.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.4,
+        "y": -28.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 16.4,
+        "y": -28.4,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 16.4,
+        "y": -28.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.800000000000011,
+        "y": -28.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.478390628441527,
+        "y": -26.078390628441515,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.478390628441527,
+        "y": -25.27839062844152,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.649823183148314,
+        "y": -24.449823183148307,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.600000000000001,
+        "y": -24.399999999999995,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 9.600000000000001,
+        "y": -24.399999999999995,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.600000000000001,
+        "y": -24.399999999999995,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.851603715620918,
+        "y": -19.65160371562091,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.1984787156209122,
+        "y": -19.65160371562091,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.1984787156209122,
+        "y": -19.34129767710251,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.861568961481596,
+        "y": -19.004387922963193,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.78125,
+        "y": -18.84375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 0.78125,
+        "y": -18.84375,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.78125,
+        "y": -18.84375,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.7709707082104119,
+        "y": -18.84375,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.7504121246312406,
+        "y": -17.322367167158347,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.78125,
+        "y": -17.28125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -0.78125,
+        "y": -17.28125,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.78125,
+        "y": -17.28125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.862499999999999,
+        "y": -15.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.898977279210722,
+        "y": -15.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.000000000000004,
+        "y": -15.200000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -12.000000000000004,
+        "y": -15.200000000000001,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.000000000000004,
+        "y": -15.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -24.000000000000004,
+        "y": -15.200000000000001,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.89303598506797,
+        "y": -11.306964014932033,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.000000000000004,
+        "y": -11.2,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -28.000000000000004,
+        "y": -11.2,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.000000000000004,
+        "y": -11.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.000000000000004,
+        "y": -1.709962523565654,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -38.01905591862505,
+        "y": 8.309093395059392,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -38.80909339505939,
+        "y": 8.309093395059392,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 8.889999999999999,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_8"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_7_0",
+    "connection_name": "source_trace_7",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 37.877408999999986,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 34.34074962524899,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 32.89399925049798,
+        "y": -30.60324962524899,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 32.8125,
+        "y": -30.5625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 32.8125,
+        "y": -30.5625,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 32.8125,
+        "y": -30.5625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 28.131540223409658,
+        "y": -25.881540223409658,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.479960349198482,
+        "y": -25.881540223409658,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.71845977659035,
+        "y": -25.881540223409658,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.233939692580904,
+        "y": -26.366060307419104,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.20000000000001,
+        "y": -26.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 19.20000000000001,
+        "y": -26.4,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 19.20000000000001,
+        "y": -26.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.955343189169607,
+        "y": -26.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.677671594584808,
+        "y": -25.1223284054152,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.600000000000005,
+        "y": -25.200000000000003,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 11.600000000000005,
+        "y": -25.200000000000003,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.600000000000005,
+        "y": -25.200000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.250366598559037,
+        "y": -25.200000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.650366598559039,
+        "y": -24.8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.8,
+        "y": -24.8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -8.8,
+        "y": -24.8,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.8,
+        "y": -24.8,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.8,
+        "y": -27.019230769230766,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.8,
+        "y": -27.019230769230766,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.8,
+        "y": -27.200000000000003,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -8.8,
+        "y": -27.200000000000003,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.8,
+        "y": -27.200000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.916247492690346,
+        "y": -27.200000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.44649773260122,
+        "y": -20.66974976008913,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -30.45,
+        "y": -17.66624749269035,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -30.45,
+        "y": -6.539615213982576,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -30.45,
+        "y": -6.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -30.45,
+        "y": -6.4,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -30.45,
+        "y": -6.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -41.345797535747934,
+        "y": -6.4,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -46.858190142991724,
+        "y": -0.8876073927562089,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -46.875,
+        "y": -0.875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -46.875,
+        "y": -0.875,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -46.875,
+        "y": -0.875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -46.875,
+        "y": 17.426552223265897,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -40.36234379955873,
+        "y": 23.939208423707168,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.58079157629283,
+        "y": 23.939208423707168,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 24.13,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_7"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_6_0",
+    "connection_name": "source_trace_6",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 40.22259100000001,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 40.22259100000001,
+        "y": -29.49280733234856,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 42.09710166765144,
+        "y": -27.61829666469713,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 42.1875,
+        "y": -27.4375,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 42.1875,
+        "y": -27.4375,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 42.1875,
+        "y": -27.4375,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 42.1875,
+        "y": -24.34401512794338,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.3125,
+        "y": -21.21901512794338,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.3125,
+        "y": -21.1875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 45.3125,
+        "y": -21.1875,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.3125,
+        "y": -21.1875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.3125,
+        "y": -18.242404000000054,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 45.774904000000035,
+        "y": -17.78000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_6"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_5_0",
+    "connection_name": "source_trace_5",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 13.275095999999962,
+        "y": -20.319999999999983,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.96644569995849,
+        "y": -22.628650300041457,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.96644569995849,
+        "y": -25.366445699958494,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.200000000000005,
+        "y": -26.000000000000007,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 11.200000000000005,
+        "y": -26.000000000000007,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.200000000000005,
+        "y": -26.000000000000007,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.983760214254085,
+        "y": -26.216239785745927,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.183760214254074,
+        "y": -26.216239785745927,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.81,
+        "y": -21.59,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.61,
+        "y": -21.59,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_5"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_4_0",
+    "connection_name": "source_trace_4",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 18.82740899999999,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 15.574632858109059,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.111765716218123,
+        "y": -30.58713285810906,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.0625,
+        "y": -30.5625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 14.0625,
+        "y": -30.5625,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.0625,
+        "y": -30.5625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 14.0625,
+        "y": -18.9625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.254811489823332,
+        "y": -16.15481148982333,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.200000000000001,
+        "y": -16.1,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 11.200000000000001,
+        "y": -16.1,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.200000000000001,
+        "y": -16.1,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.200000000000001,
+        "y": -8.908714880127896,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.545642559936052,
+        "y": -7.254357440063947,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.600000000000001,
+        "y": -7.1999999999999975,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 9.600000000000001,
+        "y": -7.1999999999999975,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.600000000000001,
+        "y": -7.1999999999999975,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.8,
+        "y": -7.1999999999999975,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.272923272437038,
+        "y": -5.672923272437035,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.199999999999999,
+        "y": -5.599999999999996,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 7.199999999999999,
+        "y": -5.599999999999996,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.199999999999999,
+        "y": -5.599999999999996,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.199999999999999,
+        "y": -4.685545765169511,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.3894542348304886,
+        "y": -0.875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.52733413260911,
+        "y": -0.875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.7179514386963985,
+        "y": 1.3702855713055087,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.78125,
+        "y": 1.46875,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -0.78125,
+        "y": 1.46875,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.78125,
+        "y": 1.46875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.4687500000000018,
+        "y": 1.46875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.92068724023179,
+        "y": 5.920687240231788,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.92068724023179,
+        "y": 11.566991189118863,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.829961378691635,
+        "y": 14.476265327578707,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.091371417790748,
+        "y": 14.476265327578707,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.927606090212041,
+        "y": 16.3125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.0625,
+        "y": 16.3125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -14.0625,
+        "y": 16.3125,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.0625,
+        "y": 16.3125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -26.23575126720594,
+        "y": 16.3125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -31.92325126720594,
+        "y": 22,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -32,
+        "y": 22,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -32,
+        "y": 22,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -32,
+        "y": 22,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -34.129999999999995,
+        "y": 24.13,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 24.13,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_4"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_3_0",
+    "connection_name": "source_trace_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 21.17259100000001,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 21.905344618836775,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.258878475347085,
+        "y": -30.696466143489687,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.4375,
+        "y": -30.5625,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 23.4375,
+        "y": -30.5625,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.4375,
+        "y": -30.5625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 23.4375,
+        "y": -29.362500000000008,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.384157153572684,
+        "y": -26.415842846427324,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.400000000000002,
+        "y": -26.400000000000006,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 26.400000000000002,
+        "y": -26.400000000000006,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.400000000000002,
+        "y": -26.400000000000006,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.400000000000002,
+        "y": -18.104904000000055,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 26.724904000000038,
+        "y": -17.78000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_3"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_2_0",
+    "connection_name": "source_trace_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.7749040000000385,
+        "y": -20.319999999999983,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.276193194453704,
+        "y": -20.319999999999983,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.314943194453686,
+        "y": -17.28125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.40625,
+        "y": -17.28125,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -16.40625,
+        "y": -17.28125,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.40625,
+        "y": -17.28125,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -19.7175,
+        "y": -13.969999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.61,
+        "y": -13.969999999999999,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_1_0",
+    "connection_name": "source_trace_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.22259100000001197,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.22259100000001197,
+        "y": -29.21662440340717,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.8,
+        "y": -28.63921540340718,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.8,
+        "y": -28.6,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -0.8,
+        "y": -28.6,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.8,
+        "y": -28.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.57618375917081,
+        "y": -28.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.759349049408243,
+        "y": -20.41683470976257,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.726040764008562,
+        "y": -20.226040764008562,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -28.726040764008562,
+        "y": -20.226040764008562,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.726040764008562,
+        "y": -20.226040764008562,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.726040764008562,
+        "y": -20.226040764008562,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.668242868886132,
+        "y": -19.168242868886132,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.523959235991434,
+        "y": -19.023959235991434,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -27.523959235991434,
+        "y": -19.023959235991434,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.523959235991434,
+        "y": -19.023959235991434,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -27.523959235991434,
+        "y": 7.82879195573542,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -29.200000000000003,
+        "y": 9.50483271974399,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.508739300601555,
+        "y": 10.196093419142437,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.508739300601555,
+        "y": 14.55102406635475,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -28.508739300601555,
+        "y": 16.091765985574803,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -36.21015660165911,
+        "y": 23.793183286632356,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.05318328663236,
+        "y": 23.793183286632356,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -39.39,
+        "y": 24.13,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_0_0",
+    "connection_name": "source_trace_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.1225910000000106,
+        "y": -32.05,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.674904000000037,
+        "y": -26.49768699999997,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.674904000000037,
+        "y": -17.78000000000002,
+        "width": 0.15,
+        "layer": "bottom"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_18",
+    "source_trace_id": "source_trace_0"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_0",
+    "pcb_trace_id": "source_trace_26_0",
+    "x": 30.078125,
+    "y": 18.265625,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_1",
+    "pcb_trace_id": "source_trace_26_0",
+    "x": -9.199999999999998,
+    "y": 13.600000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_2",
+    "pcb_trace_id": "source_trace_26_0",
+    "x": -26.4,
+    "y": 12.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_3",
+    "pcb_trace_id": "source_trace_26_0",
+    "x": -27.599999999999994,
+    "y": 11.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_4",
+    "pcb_trace_id": "source_trace_26_0",
+    "x": -32.8125,
+    "y": 10.0625,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_5",
+    "pcb_trace_id": "source_trace_25_0",
+    "x": 35.9375,
+    "y": 3.8125,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_6",
+    "pcb_trace_id": "source_trace_25_0",
+    "x": 8.4,
+    "y": 9.200000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_7",
+    "pcb_trace_id": "source_trace_25_0",
+    "x": 7.03125,
+    "y": 4.59375,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_8",
+    "pcb_trace_id": "source_trace_25_0",
+    "x": -5.600000000000001,
+    "y": 4.800000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_9",
+    "pcb_trace_id": "source_trace_25_0",
+    "x": -13.224999999999998,
+    "y": 3.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_10",
+    "pcb_trace_id": "source_trace_25_0",
+    "x": -15.225,
+    "y": 3.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_11",
+    "pcb_trace_id": "source_trace_25_0",
+    "x": -32,
+    "y": -9.200000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_12",
+    "pcb_trace_id": "source_trace_23_0",
+    "x": 9.2,
+    "y": 11.999999999999998,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_13",
+    "pcb_trace_id": "source_trace_23_0",
+    "x": -7.200000000000001,
+    "y": 6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_14",
+    "pcb_trace_id": "source_trace_23_0",
+    "x": -10.400000000000002,
+    "y": -5.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_15",
+    "pcb_trace_id": "source_trace_23_0",
+    "x": -9.600000000000001,
+    "y": -7.199999999999999,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_16",
+    "pcb_trace_id": "source_trace_23_0",
+    "x": -9.600000000000001,
+    "y": -16.000000000000004,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_17",
+    "pcb_trace_id": "source_trace_22_0",
+    "x": 17.1875,
+    "y": 3.8125,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_18",
+    "pcb_trace_id": "source_trace_22_0",
+    "x": -2.4,
+    "y": 9.200000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_19",
+    "pcb_trace_id": "source_trace_22_0",
+    "x": -9.200000000000003,
+    "y": 9.2,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_20",
+    "pcb_trace_id": "source_trace_22_0",
+    "x": -10.400000000000004,
+    "y": 10.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_21",
+    "pcb_trace_id": "source_trace_22_0",
+    "x": -32.4,
+    "y": -3.5999999999999996,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_22",
+    "pcb_trace_id": "source_trace_20_0",
+    "x": -10.800000000000004,
+    "y": 9.199999999999998,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_23",
+    "pcb_trace_id": "source_trace_20_0",
+    "x": -13.200000000000001,
+    "y": -2.8000000000000003,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_24",
+    "pcb_trace_id": "source_trace_20_0",
+    "x": -15.200000000000001,
+    "y": -12.000000000000002,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_25",
+    "pcb_trace_id": "source_trace_19_0",
+    "x": -8.799999999999997,
+    "y": 3.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_26",
+    "pcb_trace_id": "source_trace_19_0",
+    "x": -9.999999999999998,
+    "y": 4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_27",
+    "pcb_trace_id": "source_trace_19_0",
+    "x": -32,
+    "y": -2.8000000000000003,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_28",
+    "pcb_trace_id": "source_trace_17_0",
+    "x": 21.400000000000002,
+    "y": -8.400000000000002,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_29",
+    "pcb_trace_id": "source_trace_17_0",
+    "x": -14.825,
+    "y": -5.200000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_30",
+    "pcb_trace_id": "source_trace_17_0",
+    "x": -24.21875,
+    "y": -3.21875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_31",
+    "pcb_trace_id": "source_trace_17_0",
+    "x": -25.6,
+    "y": -3.2,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_32",
+    "pcb_trace_id": "source_trace_17_0",
+    "x": -28.000000000000004,
+    "y": -1.6000000000000003,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_33",
+    "pcb_trace_id": "source_trace_16_0",
+    "x": 28.125,
+    "y": -13.375,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_34",
+    "pcb_trace_id": "source_trace_16_0",
+    "x": -16.40625,
+    "y": -3.21875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_35",
+    "pcb_trace_id": "source_trace_16_0",
+    "x": -23.046875,
+    "y": -2.046875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_36",
+    "pcb_trace_id": "source_trace_16_0",
+    "x": -28.4,
+    "y": 9.600000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_37",
+    "pcb_trace_id": "source_trace_16_0",
+    "x": -41.796875,
+    "y": 18.265625,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_38",
+    "pcb_trace_id": "source_trace_15_0",
+    "x": 42.1875,
+    "y": -8.6875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_39",
+    "pcb_trace_id": "source_trace_15_0",
+    "x": 46.875,
+    "y": -7.125,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_40",
+    "pcb_trace_id": "source_trace_14_0",
+    "x": 7.599999999999996,
+    "y": -9.200000000000005,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_41",
+    "pcb_trace_id": "source_trace_13_0",
+    "x": 12,
+    "y": -12.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_42",
+    "pcb_trace_id": "source_trace_13_0",
+    "x": 0.40000000000000013,
+    "y": -9.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_43",
+    "pcb_trace_id": "source_trace_13_0",
+    "x": -0.4000000000000006,
+    "y": -8,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_44",
+    "pcb_trace_id": "source_trace_13_0",
+    "x": -2.4000000000000004,
+    "y": -8,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_45",
+    "pcb_trace_id": "source_trace_13_0",
+    "x": -3.5999999999999988,
+    "y": -4.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_46",
+    "pcb_trace_id": "source_trace_13_0",
+    "x": -16.40625,
+    "y": 13.96875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_47",
+    "pcb_trace_id": "source_trace_13_0",
+    "x": -34.79999999999998,
+    "y": 20,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_48",
+    "pcb_trace_id": "source_trace_12_0",
+    "x": 23.6,
+    "y": -9.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_49",
+    "pcb_trace_id": "source_trace_12_0",
+    "x": 26.5625,
+    "y": -2.4375,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_50",
+    "pcb_trace_id": "source_trace_11_0",
+    "x": -13,
+    "y": -9.799999999999997,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_51",
+    "pcb_trace_id": "source_trace_10_0",
+    "x": -7.2,
+    "y": -7.2,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_52",
+    "pcb_trace_id": "source_trace_10_0",
+    "x": -14,
+    "y": 2.8,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_53",
+    "pcb_trace_id": "source_trace_10_0",
+    "x": -14.4,
+    "y": 4.8,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_54",
+    "pcb_trace_id": "source_trace_10_0",
+    "x": -15.225,
+    "y": 9.2,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_55",
+    "pcb_trace_id": "source_trace_10_0",
+    "x": -29.19999999999999,
+    "y": 12.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_56",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": 24.39999999999999,
+    "y": -27.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_57",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": 16.4,
+    "y": -28.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_58",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": 9.600000000000001,
+    "y": -24.399999999999995,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_59",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": 0.78125,
+    "y": -18.84375,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_60",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": -0.78125,
+    "y": -17.28125,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_61",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": -12.000000000000004,
+    "y": -15.200000000000001,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_62",
+    "pcb_trace_id": "source_trace_8_0",
+    "x": -28.000000000000004,
+    "y": -11.2,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_63",
+    "pcb_trace_id": "source_trace_7_0",
+    "x": 32.8125,
+    "y": -30.5625,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_64",
+    "pcb_trace_id": "source_trace_7_0",
+    "x": 19.20000000000001,
+    "y": -26.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_65",
+    "pcb_trace_id": "source_trace_7_0",
+    "x": 11.600000000000005,
+    "y": -25.200000000000003,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_66",
+    "pcb_trace_id": "source_trace_7_0",
+    "x": -8.8,
+    "y": -24.8,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_67",
+    "pcb_trace_id": "source_trace_7_0",
+    "x": -8.8,
+    "y": -27.200000000000003,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_68",
+    "pcb_trace_id": "source_trace_7_0",
+    "x": -30.45,
+    "y": -6.4,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_69",
+    "pcb_trace_id": "source_trace_7_0",
+    "x": -46.875,
+    "y": -0.875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_70",
+    "pcb_trace_id": "source_trace_6_0",
+    "x": 42.1875,
+    "y": -27.4375,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_71",
+    "pcb_trace_id": "source_trace_6_0",
+    "x": 45.3125,
+    "y": -21.1875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_72",
+    "pcb_trace_id": "source_trace_5_0",
+    "x": 11.200000000000005,
+    "y": -26.000000000000007,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_73",
+    "pcb_trace_id": "source_trace_4_0",
+    "x": 14.0625,
+    "y": -30.5625,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_74",
+    "pcb_trace_id": "source_trace_4_0",
+    "x": 11.200000000000001,
+    "y": -16.1,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_75",
+    "pcb_trace_id": "source_trace_4_0",
+    "x": 9.600000000000001,
+    "y": -7.1999999999999975,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_76",
+    "pcb_trace_id": "source_trace_4_0",
+    "x": 7.199999999999999,
+    "y": -5.599999999999996,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_77",
+    "pcb_trace_id": "source_trace_4_0",
+    "x": -0.78125,
+    "y": 1.46875,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_78",
+    "pcb_trace_id": "source_trace_4_0",
+    "x": -14.0625,
+    "y": 16.3125,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_79",
+    "pcb_trace_id": "source_trace_4_0",
+    "x": -32,
+    "y": 22,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_80",
+    "pcb_trace_id": "source_trace_3_0",
+    "x": 23.4375,
+    "y": -30.5625,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_81",
+    "pcb_trace_id": "source_trace_3_0",
+    "x": 26.400000000000002,
+    "y": -26.400000000000006,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_82",
+    "pcb_trace_id": "source_trace_2_0",
+    "x": -16.40625,
+    "y": -17.28125,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_83",
+    "pcb_trace_id": "source_trace_1_0",
+    "x": -0.8,
+    "y": -28.6,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_84",
+    "pcb_trace_id": "source_trace_1_0",
+    "x": -28.726040764008562,
+    "y": -20.226040764008562,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["top", "bottom"],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_85",
+    "pcb_trace_id": "source_trace_1_0",
+    "x": -27.523959235991434,
+    "y": -19.023959235991434,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": ["bottom", "top"],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  }
+]


### PR DESCRIPTION
/fixes #274

The problem was that one hole was cut at a time, now they are combined and cut all at once.

There is still a little lag when adding updating the view, but that's not a problem with the holes it was already the case when adding the copper of the traces and the vias and my update didn't make it worse.

I'll create a separate issue for it.
the issue happens when adding traces to the board, making them into a texture should fix things
