### PR TITLE
Fix board offset with outline in jscad viewer

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -146,7 +146,6 @@ export class BoardGeomBuilder {
     if (this.board.outline && this.board.outline.length > 0) {
       this.boardGeom = createBoardGeomWithOutline(
         {
-          center: this.board.center,
           outline: this.board.outline!,
         },
         this.ctx.pcbThickness,

--- a/src/geoms/create-board-with-outline.ts
+++ b/src/geoms/create-board-with-outline.ts
@@ -17,10 +17,10 @@ export const arePointsClockwise = (points: Vec2[]): boolean => {
 }
 
 export const createBoardGeomWithOutline = (
-  board: { center: { x: number; y: number }; outline: Point[] },
+  board: { center?: { x: number; y: number }; outline: Point[] },
   depth = 1.2,
 ): Geom3 => {
-  const { center, outline } = board
+  const { outline } = board
   let outlineVec2: Vec2[] = outline.map((point) => [point.x, point.y])
 
   if (arePointsClockwise(outlineVec2)) {
@@ -31,7 +31,7 @@ export const createBoardGeomWithOutline = (
 
   let boardGeom: Geom3 = extrudeLinear({ height: depth }, shape)
 
-  boardGeom = translate([center.x, center.y, -depth / 2], boardGeom)
+  boardGeom = translate([0, 0, -depth / 2], boardGeom)
 
   return boardGeom
 }

--- a/src/soup-to-3d/index.ts
+++ b/src/soup-to-3d/index.ts
@@ -29,7 +29,6 @@ export const createSimplifiedBoardGeom = (
   if (board.outline && board.outline.length > 0) {
     boardGeom = createBoardGeomWithOutline(
       {
-        center: board.center,
         outline: board.outline!,
       },
       pcbThickness,


### PR DESCRIPTION
## Summary
- keep board outlines anchored at their provided coordinates
- adjust board creation helpers to no longer translate by `center`

## Testing
- `bun run test:node-bundle` *(fails: Cannot find module '/workspace/3d-viewer/dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684b489e14988332b6cbd89be152a3bc