### PR TITLE
Show error tooltip on hover

### DIFF
--- a/src/three-components/Error3d.tsx
+++ b/src/three-components/Error3d.tsx
@@ -1,10 +1,32 @@
-import { Text } from "@react-three/drei"
+import { Html, Text } from "@react-three/drei"
 import type { CadComponent } from "circuit-json"
+import { useState, useCallback } from "react"
+import ContainerWithTooltip from "src/ContainerWithTooltip"
 
 export const Error3d = ({
   error,
   cad_component,
 }: { error: any; cad_component?: CadComponent }) => {
+  const [isHovered, setIsHovered] = useState(false)
+  const [hoverPosition, setHoverPosition] = useState<
+    [number, number, number] | null
+  >(null)
+
+  const handleHover = useCallback((e: any) => {
+    if (e?.mousePosition) {
+      setIsHovered(true)
+      setHoverPosition(e.mousePosition)
+    } else {
+      setIsHovered(false)
+      setHoverPosition(null)
+    }
+  }, [])
+
+  const handleUnhover = useCallback(() => {
+    setIsHovered(false)
+    setHoverPosition(null)
+  }, [])
+
   let position = [0, 0, 0]
   if (cad_component?.position) {
     position = [
@@ -15,37 +37,66 @@ export const Error3d = ({
     // make sure the position doesn't have any NaN values
     position = position.map((p) => (Number.isNaN(p) ? 0 : p))
   }
+
   return (
-    <group
-      // @ts-expect-error
-      position={position}
-    >
-      <mesh
-        renderOrder={-99999}
-        rotation={[Math.PI / 4, Math.PI / 4, 0]}
-        ref={(mesh) => {
-          if (mesh) {
-            mesh.renderOrder = 999999
-          }
-        }}
+    <>
+      <ContainerWithTooltip
+        isHovered={isHovered}
+        onHover={handleHover}
+        onUnhover={handleUnhover}
+        position={position as any}
       >
-        <boxGeometry args={[0.5, 0.5, 0.5]} />
-        <meshStandardMaterial
-          depthTest={false}
-          transparent
-          color="red"
-          opacity={0.5}
-        />
-      </mesh>
-      <Text
-        scale={[0.1, 0.1, 0.1]}
-        color="red" // default
-        anchorX="center" // default
-        anchorY="middle" // default
-        depthOffset={-99999}
-      >
-        {error.toString().slice(0, 50)}...
-      </Text>
-    </group>
+        <group
+          // @ts-expect-error
+          position={position}
+        >
+          <mesh
+            renderOrder={-99999}
+            rotation={[Math.PI / 4, Math.PI / 4, 0]}
+            ref={(mesh) => {
+              if (mesh) {
+                mesh.renderOrder = 999999
+              }
+            }}
+          >
+            <boxGeometry args={[0.5, 0.5, 0.5]} />
+            <meshStandardMaterial
+              depthTest={false}
+              transparent
+              color="red"
+              opacity={0.5}
+            />
+          </mesh>
+          <Text
+            scale={[0.1, 0.1, 0.1]}
+            color="red"
+            anchorX="center"
+            anchorY="middle"
+            depthOffset={-99999}
+          >
+            {error.toString().slice(0, 50)}...
+          </Text>
+        </group>
+      </ContainerWithTooltip>
+      {isHovered && hoverPosition ? (
+        <Html
+          position={hoverPosition}
+          style={{
+            fontFamily: "sans-serif",
+            transform: "translate3d(50%, 50%, 0)",
+            backgroundColor: "white",
+            padding: "5px",
+            borderRadius: "3px",
+            pointerEvents: "none",
+            userSelect: "none",
+            WebkitUserSelect: "none",
+            MozUserSelect: "none",
+            msUserSelect: "none",
+          }}
+        >
+          {error.toString()}
+        </Html>
+      ) : null}
+    </>
   ) as any
 }


### PR DESCRIPTION
## Summary
- make error cube show hover tooltip similar to component name overlay

## Testing
- `bun test`
- `bun run format:check` *(fails: file size limit in keyboard-default60.json)*

------
https://chatgpt.com/codex/tasks/task_b_68516182287c8327b345baaf95e34331