### PR TITLE
Correct board positioning for outlines

### DIFF
--- a/src/utils/manifold/create-manifold-board.ts
+++ b/src/utils/manifold/create-manifold-board.ts
@@ -44,6 +44,7 @@ export function createManifoldBoard(
       undefined, // scaleTop
       true, // center (for Z-axis)
     )
+    manifoldInstancesForCleanup.push(boardOp)
   } else {
     if (boardData.outline && boardData.outline.length > 0) {
       // Has outline but < 3 points
@@ -56,11 +57,10 @@ export function createManifoldBoard(
       [boardData.width, boardData.height, pcbThickness],
       true, // center (for all axes)
     )
+    manifoldInstancesForCleanup.push(boardOp)
+    boardOp = boardOp.translate([boardData.center.x, boardData.center.y, 0])
+    manifoldInstancesForCleanup.push(boardOp) // Also track the translated op
   }
-
-  manifoldInstancesForCleanup.push(boardOp)
-  boardOp = boardOp.translate([boardData.center.x, boardData.center.y, 0])
-  manifoldInstancesForCleanup.push(boardOp) // Also track the translated op
 
   return boardOp
 }


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/e0fdd1b8-4188-496c-bd96-ba65a9db79ba)
after:
![image](https://github.com/user-attachments/assets/5eb46043-4984-4eba-b25a-ef7412918cd2)

