### PR TITLE
Made a couple stories run async so that traces are rendered

### DIFF
--- a/stories/BottomTraceThroughVias.stories.tsx
+++ b/stories/BottomTraceThroughVias.stories.tsx
@@ -49,11 +49,11 @@ export const BottomTraceThroughVias = () => {
   const [circuitJson, setCircuitJson] = useState<any>(null)
 
   useEffect(() => {
-    const fetchCircuit = async () => {
+    const renderCircuit = async () => {
       const json = await createCircuit()
       setCircuitJson(json)
     }
-    fetchCircuit()
+    renderCircuit()
   }, [])
 
   if (!circuitJson) {

--- a/stories/BottomTraceThroughVias.stories.tsx
+++ b/stories/BottomTraceThroughVias.stories.tsx
@@ -1,11 +1,12 @@
+import React, { useState, useEffect } from "react"
 import { CadViewer } from "src/CadViewer"
 import { Circuit } from "@tscircuit/core"
 
-const createCircuit = () => {
+const createCircuit = async () => {
   const circuit = new Circuit()
 
   circuit.add(
-    <board width="20mm" height="20mm">
+    <board width="25mm" height="25mm">
       <resistor
         name="R1"
         footprint="0805"
@@ -34,16 +35,31 @@ const createCircuit = () => {
         pcbX={0}
         pcbY={10}
       />
-      <trace from={".R1 > .right"} to={".R2 > .left"} />
-      <trace from={".R4 > .right"} to={".R3 > .left"} />
+      <trace from={".R1 > .pin1"} to={".R2 > .pin2"} />
+      <trace from={".R4 > .pin1"} to={".R3 > .pin2"} />
     </board>,
   )
+
+  await circuit.renderUntilSettled()
 
   return circuit.getCircuitJson()
 }
 
 export const BottomTraceThroughVias = () => {
-  const circuitJson = createCircuit()
+  const [circuitJson, setCircuitJson] = useState<any>(null)
+
+  useEffect(() => {
+    const fetchCircuit = async () => {
+      const json = await createCircuit()
+      setCircuitJson(json)
+    }
+    fetchCircuit()
+  }, [])
+
+  if (!circuitJson) {
+    return <div>Loading...</div>
+  }
+
   return <CadViewer circuitJson={circuitJson as any} />
 }
 

--- a/stories/SilkscreenText/SilkscreenTextOnTraces.stories.tsx
+++ b/stories/SilkscreenText/SilkscreenTextOnTraces.stories.tsx
@@ -1,11 +1,12 @@
+import React, { useState, useEffect } from "react"
 import { CadViewer } from "src/CadViewer"
 import { Circuit, SilkscreenText } from "@tscircuit/core"
 
-const createCircuit = () => {
+const createCircuit = async () => {
   const circuit = new Circuit()
 
   circuit.add(
-    <board width="20mm" height="20mm">
+    <board width="25mm" height="25mm">
       <resistor
         name="R1"
         footprint="0805"
@@ -37,16 +38,35 @@ const createCircuit = () => {
       <trace from={".R1 > .right"} to={".R2 > .left"} />
       <trace from={".R4 > .right"} to={".R3 > .left"} />
       <footprint>
-        <silkscreentext text="Tscircuit" pcbX={0} pcbY={1.6} />
+        <silkscreentext
+          text="Tscircuit build electronics with React"
+          pcbX={0}
+          pcbY={1.6}
+        />
       </footprint>
     </board>,
   )
+
+  await circuit.renderUntilSettled()
 
   return circuit.getCircuitJson()
 }
 
 export const SilkscreenTextOnTraces = () => {
-  const circuitJson = createCircuit()
+  const [circuitJson, setCircuitJson] = useState<any>(null)
+
+  useEffect(() => {
+    const fetchCircuit = async () => {
+      const json = await createCircuit()
+      setCircuitJson(json)
+    }
+    fetchCircuit()
+  }, [])
+
+  if (!circuitJson) {
+    return <div>Loading...</div>
+  }
+
   return <CadViewer circuitJson={circuitJson as any} />
 }
 

--- a/stories/SilkscreenText/SilkscreenTextOnTraces.stories.tsx
+++ b/stories/SilkscreenText/SilkscreenTextOnTraces.stories.tsx
@@ -56,11 +56,11 @@ export const SilkscreenTextOnTraces = () => {
   const [circuitJson, setCircuitJson] = useState<any>(null)
 
   useEffect(() => {
-    const fetchCircuit = async () => {
+    const renderCircuit = async () => {
       const json = await createCircuit()
       setCircuitJson(json)
     }
-    fetchCircuit()
+    renderCircuit()
   }, [])
 
   if (!circuitJson) {


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/bbec64d1-512f-47c1-9872-d7b148014337)
after:
![image](https://github.com/user-attachments/assets/1452e3d4-8c16-4dc8-8e03-a8efae580fcf)
