### PR TITLE
fix duplicate canvas creation

### DIFF
--- a/src/react-three/Canvas.tsx
+++ b/src/react-three/Canvas.tsx
@@ -10,6 +10,7 @@ import React, {
 import * as THREE from "three"
 import { ThreeContext, ThreeContextState } from "./ThreeContext"
 import { HoverProvider } from "./HoverContext"
+import { removeExistingCanvases } from "./remove-existing-canvases"
 
 interface CanvasProps {
   children: React.ReactNode
@@ -54,6 +55,8 @@ export const Canvas = forwardRef<THREE.Object3D, CanvasProps>(
 
     useEffect(() => {
       if (!mountRef.current) return
+
+      removeExistingCanvases(mountRef.current)
 
       const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
       renderer.setSize(

--- a/src/react-three/remove-existing-canvases.ts
+++ b/src/react-three/remove-existing-canvases.ts
@@ -1,0 +1,5 @@
+export function removeExistingCanvases(container: HTMLElement) {
+  container
+    .querySelectorAll("canvas")
+    .forEach((existingCanvas) => existingCanvas.remove())
+}

--- a/tests/remove-existing-canvases.test.ts
+++ b/tests/remove-existing-canvases.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test"
+import { JSDOM } from "jsdom"
+import { removeExistingCanvases } from "../src/react-three/remove-existing-canvases"
+
+test("removeExistingCanvases removes all canvases", () => {
+  const dom = new JSDOM()
+  const container = dom.window.document.createElement("div")
+  for (let i = 0; i < 3; i++) {
+    container.appendChild(dom.window.document.createElement("canvas"))
+  }
+  removeExistingCanvases(container as unknown as HTMLElement)
+  expect(container.querySelectorAll("canvas")).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary
- ensure existing canvases are removed before creating WebGL renderer
- add helper for removing canvases and unit test

## Testing
- `bun test tests/remove-existing-canvases.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b33a0c1e6c832ebc3f7f12214eb40a