### PR TITLE
Fixed the hover tooltip offset

### DIFF
--- a/src/react-three/Html.tsx
+++ b/src/react-three/Html.tsx
@@ -34,12 +34,16 @@ export const Html: React.FC<HtmlProps> = ({ children, position, style }) => {
     const vector = new THREE.Vector3(...position)
     vector.project(camera)
 
-    const x = Math.round(((vector.x + 1) * renderer!.domElement.width) / 2)
-    const y = Math.round(((-vector.y + 1) * renderer!.domElement.height) / 2)
+    // Get canvas position and size
+    const rect = renderer.domElement.getBoundingClientRect()
+    // NDC [-1,1] to pixel coordinates within canvas
+    const x = Math.round(((vector.x + 1) / 2) * rect.width)
+    const y = Math.round(((-vector.y + 1) / 2) * rect.height)
 
+    // Position relative to the page, then offset by canvas position
     el.current.style.position = "absolute"
-    el.current.style.left = `${x}px`
-    el.current.style.top = `${y}px`
+    el.current.style.left = `${rect.left + x}px`
+    el.current.style.top = `${rect.top + y}px`
     el.current.style.pointerEvents = "none"
 
     if (style) {


### PR DESCRIPTION
/closes #433 
/claim #433

The tooltip’s DOM position was calculated incorrectly, leading to the offset. I updated the projection logic in `Html.tsx` to use the canvas’s bounding rectangle, ensuring the tooltip appears exactly where the 3D point projects onto the screen.


https://github.com/user-attachments/assets/98c83c4c-2237-4d75-b9d2-fa7e32bc5154

