### PR TITLE
Check for existing Manifold globals before script injection

### DIFF
--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -17,6 +17,8 @@ import { createTextureMeshes } from "./utils/manifold/create-three-texture-meshe
 declare global {
   interface Window {
     ManifoldModule: any
+    MANIFOLD?: any
+    MANIFOLD_MODULE?: any
   }
 }
 
@@ -85,14 +87,20 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
       }
     }
 
-    if (window.ManifoldModule) {
+    const existingManifold =
+      window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE
+    if (existingManifold) {
+      window.ManifoldModule = existingManifold
       initManifold(window.ManifoldModule)
       return
     }
 
     const eventName = "manifoldLoaded"
     const handleLoad = () => {
-      if (window.ManifoldModule) {
+      const loadedManifold =
+        window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE
+      if (loadedManifold) {
+        window.ManifoldModule = loadedManifold
         initManifold(window.ManifoldModule)
       } else {
         const errText = "ManifoldModule not found on window after script load."


### PR DESCRIPTION
## Summary
- Avoid injecting Manifold script if `window.ManifoldModule`, `window.MANIFOLD`, or `window.MANIFOLD_MODULE` already exists
- Use existing globals during load and declare optional typings for them

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68b46dd74950832ea479dccc0b5f75c0