### PR TITLE
feat: support kicad footprinter urls

### DIFF
--- a/src/AnyCadComponent.tsx
+++ b/src/AnyCadComponent.tsx
@@ -9,6 +9,7 @@ import { GltfModel } from "./three-components/GltfModel"
 import { JscadModel } from "./three-components/JscadModel"
 import { FootprinterModel } from "./three-components/FootprinterModel"
 import { tuple } from "./utils/tuple"
+import { getModelUrl } from "./utils/get-model-url"
 import { Html } from "./react-three/Html"
 
 export const AnyCadComponent = ({
@@ -46,10 +47,7 @@ export const AnyCadComponent = ({
     })?.name
   }, [circuitJson, cad_component.source_component_id])
 
-  const url =
-    cad_component.model_obj_url ??
-    cad_component.model_wrl_url ??
-    cad_component.model_stl_url
+  const url = getModelUrl(cad_component)
   const gltfUrl = cad_component.model_gltf_url
   const rotationOffset = cad_component.rotation
     ? tuple(

--- a/src/utils/get-model-url.ts
+++ b/src/utils/get-model-url.ts
@@ -1,0 +1,20 @@
+export function getModelUrl(component: {
+  model_obj_url?: string
+  model_wrl_url?: string
+  model_stl_url?: string
+  footprinter_string?: string
+}): string | undefined {
+  return (
+    component.model_obj_url ??
+    component.model_wrl_url ??
+    component.model_stl_url ??
+    getKicadUrl(component.footprinter_string)
+  )
+}
+
+function getKicadUrl(footprinter?: string): string | undefined {
+  if (!footprinter) return undefined
+  if (!footprinter.startsWith("kicad:")) return undefined
+  const path = footprinter.replace(/^kicad:/, "").replace(/:/g, "/")
+  return `https://kicad-mod-cache.tscircuit.com/${path}.wrl`
+}

--- a/src/utils/render-component.tsx
+++ b/src/utils/render-component.tsx
@@ -8,17 +8,14 @@ import { executeJscadOperations } from "jscad-planner"
 import * as THREE from "three"
 import { load3DModel } from "./load-model"
 import type { CadComponent } from "circuit-json"
+import { getModelUrl } from "./get-model-url"
 
 export async function renderComponent(
   component: CadComponent,
   scene: THREE.Scene,
 ) {
-  // Handle STL/OBJ models first
-  const url =
-    component.model_obj_url ??
-    component.model_wrl_url ??
-    component.model_stl_url ??
-    component.model_gltf_url
+  // Handle STL/OBJ/WRL/GLTF models first
+  const url = getModelUrl(component) ?? component.model_gltf_url
   if (url) {
     const model = await load3DModel(url)
     if (model) {


### PR DESCRIPTION
## Summary
- prefer explicit model URLs over footprinter strings
- load KiCad `.wrl` models when footprinter string begins with `kicad:`
- remove redundant getModelUrl test file

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/convert-3d-view-to-svg-top-view.test.ts tests/convert-3d-view-to-svg-with-multiple-elements.test.ts`
- `bun test tests/remove-existing-canvases.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bfbaa4e150832e8f944f342f9aaae7