### PR TITLE
feat: center orbit controls on board bounds by default

### DIFF
--- a/src/CadViewerContainer.tsx
+++ b/src/CadViewerContainer.tsx
@@ -32,6 +32,7 @@ interface Props {
   initialCameraPosition?: readonly [number, number, number] | undefined
   clickToInteractEnabled?: boolean
   boardDimensions?: { width?: number; height?: number }
+  boardCenter?: { x: number; y: number }
   onUserInteraction?: () => void
 }
 
@@ -46,6 +47,7 @@ export const CadViewerContainer = forwardRef<
       autoRotateDisabled,
       clickToInteractEnabled = false,
       boardDimensions,
+      boardCenter,
       onUserInteraction,
     },
     ref,
@@ -62,6 +64,11 @@ export const CadViewerContainer = forwardRef<
       const desired = largest * 1.5
       return desired > 10 ? desired : 10
     }, [boardDimensions])
+
+    const orbitTarget = useMemo(() => {
+      if (!boardCenter) return undefined
+      return [boardCenter.x, boardCenter.y, 0] as [number, number, number]
+    }, [boardCenter])
 
     return (
       <div style={{ position: "relative", width: "100%", height: "100%" }}>
@@ -100,6 +107,7 @@ export const CadViewerContainer = forwardRef<
               zoomSpeed={0.5}
               enableDamping={true}
               dampingFactor={0.1}
+              target={orbitTarget}
             />
           )}
           <Lights />

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -87,6 +87,18 @@ export const CadViewerJscad = forwardRef<
       }
     }, [internalCircuitJson])
 
+    const boardCenter = useMemo(() => {
+      if (!internalCircuitJson) return undefined
+      try {
+        const board = su(internalCircuitJson as any).pcb_board.list()[0]
+        if (!board || !board.center) return undefined
+        return { x: board.center.x, y: board.center.y }
+      } catch (e) {
+        console.error(e)
+        return undefined
+      }
+    }, [internalCircuitJson])
+
     // Use the state `boardGeom` which starts simplified and gets updated
     const { stls: boardStls, loading } = useStlsFromGeom(boardGeom)
 
@@ -99,6 +111,7 @@ export const CadViewerJscad = forwardRef<
         initialCameraPosition={initialCameraPosition}
         clickToInteractEnabled={clickToInteractEnabled}
         boardDimensions={boardDimensions}
+        boardCenter={boardCenter}
         onUserInteraction={onUserInteraction}
       >
         {boardStls.map(({ stlData, color }, index) => (

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -166,6 +166,13 @@ try {
     return { width, height }
   }, [boardData])
 
+  const boardCenter = useMemo(() => {
+    if (!boardData) return undefined
+    const { center } = boardData
+    if (!center) return undefined
+    return { x: center.x, y: center.y }
+  }, [boardData])
+
   const initialCameraPosition = useMemo(() => {
     if (!boardData) return [5, 5, 5] as const
     const { width = 0, height = 0 } = boardData
@@ -216,6 +223,7 @@ try {
       autoRotateDisabled={autoRotateDisabled}
       clickToInteractEnabled={clickToInteractEnabled}
       boardDimensions={boardDimensions}
+      boardCenter={boardCenter}
       onUserInteraction={onUserInteraction}
     >
       <BoardMeshes

--- a/src/react-three/OrbitControls.tsx
+++ b/src/react-three/OrbitControls.tsx
@@ -11,6 +11,7 @@ interface OrbitControlsProps {
   zoomSpeed?: number
   enableDamping?: boolean
   dampingFactor?: number
+  target?: [number, number, number]
 }
 
 export const OrbitControls: React.FC<OrbitControlsProps> = ({
@@ -22,6 +23,7 @@ export const OrbitControls: React.FC<OrbitControlsProps> = ({
   zoomSpeed,
   enableDamping,
   dampingFactor,
+  target,
 }) => {
   const { camera, renderer } = useThree()
 
@@ -40,6 +42,10 @@ export const OrbitControls: React.FC<OrbitControlsProps> = ({
     if (zoomSpeed !== undefined) controls.zoomSpeed = zoomSpeed
     if (enableDamping !== undefined) controls.enableDamping = enableDamping
     if (dampingFactor !== undefined) controls.dampingFactor = dampingFactor
+    if (target) {
+      controls.target.set(target[0], target[1], target[2])
+      controls.update()
+    }
   }, [
     controls,
     autoRotate,
@@ -49,6 +55,7 @@ export const OrbitControls: React.FC<OrbitControlsProps> = ({
     zoomSpeed,
     enableDamping,
     dampingFactor,
+    target,
   ])
 
   useEffect(() => {

--- a/stories/BoardOutline.stories.tsx
+++ b/stories/BoardOutline.stories.tsx
@@ -69,6 +69,23 @@ export const StarBoardOutline = () => {
   return <CadViewer circuitJson={circuitJson as any} />
 }
 
+const createOffCenterBoardCircuit = () => {
+  return [
+    {
+      type: "pcb_board",
+      width: 20,
+      height: 20,
+      center: { x: 10, y: 10 },
+      thickness: 1.6,
+    },
+  ]
+}
+
+export const OffCenterBoardOrbitTest = () => {
+  const circuitJson = createOffCenterBoardCircuit()
+  return <CadViewer circuitJson={circuitJson as any} />
+}
+
 export default {
   title: "BoardOutline",
   component: AtariBoardOutline,


### PR DESCRIPTION
Add support for a custom orbit target based on the board center from circuit JSON.
Orbit controls now center on the actual board center instead of the origin (0,0,0).

/claim #479
/fixes #479