### PR TITLE
feat: Add B-rep shape support for copper pours

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -39,6 +39,7 @@ import {
 import type { Vec2 } from "@jscad/modeling/src/maths/types"
 import { createSilkscreenTextGeoms } from "./geoms/create-geoms-for-silkscreen-text"
 import { createSilkscreenPathGeom } from "./geoms/create-geoms-for-silkscreen-path"
+import { createGeom2FromBRep } from "./geoms/brep-converter"
 import type { GeomContext } from "./GeomContext"
 
 type BuilderState =
@@ -341,6 +342,14 @@ export class BoardGeomBuilder {
       }
 
       pourGeom = translate([pour.center.x, pour.center.y, zPos], baseGeom)
+    } else if (pour.shape === "brep") {
+      // @ts-ignore
+      const brepShape = pour.brep_shape
+      if (brepShape) {
+        const pourGeom2 = createGeom2FromBRep(brepShape)
+        pourGeom = extrudeLinear({ height: M }, pourGeom2)
+        pourGeom = translate([0, 0, zPos], pourGeom)
+      }
     } else if (pour.shape === "polygon") {
       let pointsVec2: Vec2[] = pour.points.map((p) => [p.x, p.y])
       if (pointsVec2.length < 3) {

--- a/src/geoms/brep-converter.ts
+++ b/src/geoms/brep-converter.ts
@@ -1,0 +1,121 @@
+import { polygon } from "@jscad/modeling/src/primitives"
+import { subtract } from "@jscad/modeling/src/operations/booleans"
+import type { Vec2 } from "@jscad/modeling/src/maths/types"
+
+type PointWithBulge = { x: number; y: number; bulge?: number }
+type Ring = { vertices: PointWithBulge[] }
+
+// Convert a single arc segment (defined by two points and a bulge factor) to a series of points.
+function segmentToPoints(
+  p1: Vec2,
+  p2: Vec2,
+  bulge: number,
+  arcSegments: number,
+): Vec2[] {
+  if (!bulge || Math.abs(bulge) < 1e-9) {
+    return [] // Straight line segment, no intermediate points
+  }
+
+  const theta = 4 * Math.atan(bulge)
+  const dx = p2[0] - p1[0]
+  const dy = p2[1] - p1[1]
+  const dist = Math.sqrt(dx * dx + dy * dy)
+
+  if (dist < 1e-9) return []
+
+  const radius = Math.abs(dist / (2 * Math.sin(theta / 2)))
+
+  const m = Math.sqrt(Math.max(0, radius * radius - (dist / 2) * (dist / 2)))
+
+  const midPoint: Vec2 = [(p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2]
+  const ux = dx / dist
+  const uy = dy / dist
+  const nx = -uy
+  const ny = ux
+
+  const centerX = midPoint[0] + nx * m * Math.sign(bulge)
+  const centerY = midPoint[1] + ny * m * Math.sign(bulge)
+
+  const startAngle = Math.atan2(p1[1] - centerY, p1[0] - centerX)
+
+  const points: Vec2[] = []
+  // Increase segments for larger arcs
+  const numSteps = Math.max(
+    2,
+    Math.ceil(((arcSegments * Math.abs(theta)) / (Math.PI * 2)) * 4),
+  )
+  const angleStep = theta / numSteps
+
+  for (let i = 1; i < numSteps; i++) {
+    const angle = startAngle + angleStep * i
+    points.push([
+      centerX + radius * Math.cos(angle),
+      centerY + radius * Math.sin(angle),
+    ])
+  }
+  return points
+}
+
+// Convert a ring of vertices (with bulges) to a flat array of Vec2 points.
+function ringToPoints(ring: Ring, arcSegments: number): Vec2[] {
+  const allPoints: Vec2[] = []
+  const vertices = ring.vertices
+
+  for (let i = 0; i < vertices.length; i++) {
+    const p1 = vertices[i]!
+    const p2 = vertices[(i + 1) % vertices.length]!
+    allPoints.push([p1.x, p1.y])
+    if (p1.bulge) {
+      const arcPoints = segmentToPoints(
+        [p1.x, p1.y],
+        [p2.x, p2.y],
+        p1.bulge,
+        arcSegments,
+      )
+      allPoints.push(...arcPoints)
+    }
+  }
+  return allPoints
+}
+
+// Check if a polygon is wound clockwise
+function arePointsClockwise(points: Vec2[]): boolean {
+  let area = 0
+  for (let i = 0; i < points.length; i++) {
+    const j = (i + 1) % points.length
+    area += points[i]![0] * points[j]![1]
+    area -= points[j]![0] * points[i]![1]
+  }
+  return area / 2 <= 0
+}
+
+export function createGeom2FromBRep(
+  brep: {
+    outer_ring: Ring
+    inner_rings: Ring[]
+  },
+  arcSegments = 16,
+): any /*Geom2*/ {
+  let outerPoints = ringToPoints(brep.outer_ring, arcSegments)
+  if (arePointsClockwise(outerPoints)) {
+    outerPoints.reverse() // Ensure it's CCW for JSCAD
+  }
+  const outerGeom = polygon({ points: outerPoints })
+
+  if (!brep.inner_rings || brep.inner_rings.length === 0) {
+    return outerGeom
+  }
+
+  const innerGeoms = brep.inner_rings.map((ring) => {
+    let innerPoints = ringToPoints(ring, arcSegments)
+    // For holes with subtract, they also need to be solid polygons (CCW)
+    if (arePointsClockwise(innerPoints)) {
+      innerPoints.reverse()
+    }
+    return polygon({ points: innerPoints })
+  })
+
+  if (innerGeoms.length === 0) return outerGeom
+
+  return subtract(outerGeom, innerGeoms)
+}

--- a/src/utils/manifold/process-copper-pours.ts
+++ b/src/utils/manifold/process-copper-pours.ts
@@ -6,6 +6,7 @@ import {
   colors as defaultColors,
   DEFAULT_SMT_PAD_THICKNESS,
   MANIFOLD_Z_OFFSET,
+  SMOOTH_CIRCLE_SEGMENTS,
 } from "../../geoms/constants"
 
 const COPPER_COLOR = new THREE.Color(...defaultColors.copper)
@@ -21,6 +22,80 @@ const arePointsClockwise = (points: Array<[number, number]>): boolean => {
   }
   const signedArea = area / 2
   return signedArea <= 0
+}
+
+type PointWithBulge = { x: number; y: number; bulge?: number }
+type Ring = { vertices: PointWithBulge[] }
+
+function segmentToPoints(
+  p1: [number, number],
+  p2: [number, number],
+  bulge: number,
+  arcSegments: number,
+): [number, number][] {
+  if (!bulge || Math.abs(bulge) < 1e-9) {
+    return [] // Straight line segment, no intermediate points
+  }
+
+  const theta = 4 * Math.atan(bulge)
+  const dx = p2[0] - p1[0]
+  const dy = p2[1] - p1[1]
+  const dist = Math.sqrt(dx * dx + dy * dy)
+
+  if (dist < 1e-9) return []
+
+  const radius = Math.abs(dist / (2 * Math.sin(theta / 2)))
+
+  const m = Math.sqrt(Math.max(0, radius * radius - (dist / 2) * (dist / 2)))
+
+  const midPoint: [number, number] = [(p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2]
+  const ux = dx / dist
+  const uy = dy / dist
+  const nx = -uy
+  const ny = ux
+
+  const centerX = midPoint[0] + nx * m * Math.sign(bulge)
+  const centerY = midPoint[1] + ny * m * Math.sign(bulge)
+
+  const startAngle = Math.atan2(p1[1] - centerY, p1[0] - centerX)
+
+  const points: [number, number][] = []
+  // Increase segments for larger arcs
+  const numSteps = Math.max(
+    2,
+    Math.ceil(((arcSegments * Math.abs(theta)) / (Math.PI * 2)) * 4),
+  )
+  const angleStep = theta / numSteps
+
+  for (let i = 1; i < numSteps; i++) {
+    const angle = startAngle + angleStep * i
+    points.push([
+      centerX + radius * Math.cos(angle),
+      centerY + radius * Math.sin(angle),
+    ])
+  }
+  return points
+}
+
+function ringToPoints(ring: Ring, arcSegments: number): [number, number][] {
+  const allPoints: [number, number][] = []
+  const vertices = ring.vertices
+
+  for (let i = 0; i < vertices.length; i++) {
+    const p1 = vertices[i]!
+    const p2 = vertices[(i + 1) % vertices.length]!
+    allPoints.push([p1.x, p1.y])
+    if (p1.bulge) {
+      const arcPoints = segmentToPoints(
+        [p1.x, p1.y],
+        [p2.x, p2.y],
+        p1.bulge,
+        arcSegments,
+      )
+      allPoints.push(...arcPoints)
+    }
+  }
+  return allPoints
 }
 
 export interface ProcessCopperPoursResult {
@@ -72,6 +147,42 @@ export function processCopperPoursForManifold(
         pointsVec2 = pointsVec2.reverse()
       }
       const crossSection = CrossSection.ofPolygons([pointsVec2])
+      manifoldInstancesForCleanup.push(crossSection)
+      pourOp = Manifold.extrude(
+        crossSection,
+        pourThickness,
+        0, // nDivisions
+        0, // twistDegrees
+        [1, 1], // scaleTop
+        true, // center extrusion
+      ).translate([0, 0, zPos])
+      manifoldInstancesForCleanup.push(pourOp)
+    } else if (pour.shape === "brep") {
+      const brepShape = (pour as any).brep_shape
+      if (!brepShape || !brepShape.outer_ring) continue
+
+      let outerRingPoints = ringToPoints(
+        brepShape.outer_ring,
+        SMOOTH_CIRCLE_SEGMENTS,
+      )
+      if (arePointsClockwise(outerRingPoints)) {
+        outerRingPoints = outerRingPoints.reverse() // Manifold wants CCW for solid
+      }
+
+      const polygons = [outerRingPoints]
+
+      if (brepShape.inner_rings) {
+        const innerRingsPoints = brepShape.inner_rings.map((ring) => {
+          let points = ringToPoints(ring, SMOOTH_CIRCLE_SEGMENTS)
+          if (!arePointsClockwise(points)) {
+            points = points.reverse() // Manifold wants CW for holes
+          }
+          return points
+        })
+        polygons.push(...innerRingsPoints)
+      }
+
+      const crossSection = CrossSection.ofPolygons(polygons)
       manifoldInstancesForCleanup.push(crossSection)
       pourOp = Manifold.extrude(
         crossSection,

--- a/stories/CopperPour.stories.tsx
+++ b/stories/CopperPour.stories.tsx
@@ -1,5 +1,5 @@
 import { CadViewer } from "src/CadViewer"
-import type { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, PcbCopperPour } from "circuit-json"
 
 // Test a mix of rect and polygon pours on both layers
 const soup: AnyCircuitElement[] = [
@@ -7,52 +7,147 @@ const soup: AnyCircuitElement[] = [
     type: "pcb_board",
     pcb_board_id: "board1",
     center: { x: 0, y: 0 },
-    width: 50,
-    height: 50,
+    width: 200,
+    height: 100,
     material: "fr4",
     num_layers: 2,
     thickness: 1.6,
   },
+  // pour_brep_1: square with rounded-square hole
   {
     type: "pcb_copper_pour",
-    shape: "rect",
-    pcb_copper_pour_id: "pour1",
+    pcb_copper_pour_id: "pour_brep_1",
     layer: "top",
-    center: { x: -12, y: 12 },
-    width: 10,
-    height: 10,
-  } as any,
+    shape: "brep",
+    source_net_id: "net1",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          { x: -30, y: 30 },
+          { x: -50, y: 30 },
+          { x: -50, y: 10 },
+          { x: -30, y: 10 },
+        ],
+      },
+      inner_rings: [
+        {
+          vertices: [
+            { x: -35, y: 25, bulge: 0.5 },
+            { x: -45, y: 25 },
+            { x: -45, y: 15 },
+            { x: -35, y: 15 },
+          ],
+        },
+      ],
+    },
+  } as PcbCopperPour,
+  // pour_brep_2: Bulgy outer ring, two holes
   {
     type: "pcb_copper_pour",
-    shape: "rect",
-    pcb_copper_pour_id: "pour2",
+    pcb_copper_pour_id: "pour_brep_2",
     layer: "top",
-    center: { x: 12, y: 12 },
-    width: 10,
-    height: 5,
-    rotation: 45,
-  } as any,
+    shape: "brep",
+    source_net_id: "net2",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          { x: 10, y: 30, bulge: -0.5 },
+          { x: -10, y: 30 },
+          { x: -10, y: 10, bulge: 0.5 },
+          { x: 10, y: 10 },
+        ],
+      },
+      inner_rings: [
+        {
+          // square hole
+          vertices: [
+            { x: -5, y: 25 },
+            { x: -8, y: 25 },
+            { x: -8, y: 22 },
+            { x: -5, y: 22 },
+          ],
+        },
+        {
+          // triangular hole
+          vertices: [
+            { x: 5, y: 25 },
+            { x: 8, y: 22 },
+            { x: 5, y: 22 },
+          ],
+        },
+      ],
+    },
+  } as PcbCopperPour,
+  // pour_brep_3: Circular pour with square hole
   {
     type: "pcb_copper_pour",
-    pcb_copper_pour_id: "pour3",
-    shape: "polygon",
+    pcb_copper_pour_id: "pour_brep_3",
+    layer: "top",
+    shape: "brep",
+    source_net_id: "net3",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          { x: 30, y: 20, bulge: 1 },
+          { x: 50, y: 20, bulge: 1 },
+        ],
+      },
+      inner_rings: [
+        {
+          vertices: [
+            { x: 38, y: 22 },
+            { x: 42, y: 22 },
+            { x: 42, y: 18 },
+            { x: 38, y: 18 },
+          ],
+        },
+      ],
+    },
+  } as PcbCopperPour,
+  // pour_brep_4: bottom layer pour
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "pour_brep_4",
     layer: "bottom",
+    shape: "brep",
+    source_net_id: "net4",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          { x: -30, y: -10 },
+          { x: -50, y: -10 },
+          { x: -50, y: -30 },
+          { x: -30, y: -30, bulge: 0.5 },
+        ],
+      },
+    },
+  } as PcbCopperPour,
+  // pour_rect_1: A rect pour with rotation
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "pour_rect_1",
+    layer: "top",
+    shape: "rect",
+    source_net_id: "net5",
+    center: { x: 0, y: -20 },
+    width: 20,
+    height: 10,
+    rotation: 15,
+  } as PcbCopperPour,
+  // pour_polygon_1: A polygon pour (triangle)
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "pour_polygon_1",
+    layer: "top",
+    shape: "polygon",
+    source_net_id: "net6",
     points: [
-      { x: -2, y: -9 },
-      { x: 2, y: -9 },
-      { x: 2, y: -13 },
-      { x: 6, y: -13 },
-      { x: 6, y: -17 },
-      { x: 2, y: -17 },
-      { x: 2, y: -21 },
-      { x: -2, y: -21 },
-      { x: -6, y: -17 },
-      { x: -6, y: -13 },
-      { x: -2, y: -13 },
+      { x: 30, y: -10 },
+      { x: 50, y: -30 },
+      { x: 30, y: -30 },
     ],
-  } as any,
+  } as PcbCopperPour,
 ]
-
 export const Default = () => <CadViewer circuitJson={soup} />
 
 export default {


### PR DESCRIPTION
Implements support for brep (Boundary Representation) shapes for copper pours, as defined in the latest circuit JSON specification. This allows for the rendering of complex copper pour shapes with curved segments (arcs) defined by a bulge factor.                                

 • src/BoardGeomBuilder.ts and the new src/geoms/brep-converter.ts handle B-rep processing for the JSCAD engine.                             
 • src/utils/manifold/process-copper-pours.ts is updated to handle B-rep shapes for the Manifold engine.                                     
 • Both implementations include logic to convert segments with a bulge factor into the corresponding arcs.
 
<img width="1482" height="716" alt="image" src="https://github.com/user-attachments/assets/5751bc89-2d7c-4220-8716-baa33ebb11f1" />
