### PR TITLE
fix: Manifold module to prevent loading state on subsequent renders

### DIFF
--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -19,7 +19,6 @@ declare global {
     ManifoldModule: any
     MANIFOLD?: any
     MANIFOLD_MODULE?: any
-    _CACHED_MANIFOLD_MODULE?: any
   }
 }
 
@@ -69,16 +68,18 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
     return circuitJsonProp ?? childrenCircuitJson
   }, [circuitJsonProp, childrenCircuitJson])
 
-  const [manifoldJSModule, setManifoldJSModule] = useState<any | null>(
-    window._CACHED_MANIFOLD_MODULE || null
-  )
+  const [manifoldJSModule, setManifoldJSModule] = useState<any | null>(null)
   const [manifoldLoadingError, setManifoldLoadingError] = useState<
     string | null
   >(null)
 
   useEffect(() => {
-    if (window._CACHED_MANIFOLD_MODULE) {
-      setManifoldJSModule(window._CACHED_MANIFOLD_MODULE)
+    if (
+      window.ManifoldModule &&
+      typeof window.ManifoldModule === "object" &&
+      window.ManifoldModule.setup
+    ) {
+      setManifoldJSModule(window.ManifoldModule)
       return
     }
 
@@ -86,7 +87,7 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
       try {
         const loadedModule: ManifoldToplevel = await ManifoldModule()
         loadedModule.setup()
-        window._CACHED_MANIFOLD_MODULE = loadedModule
+        window.ManifoldModule = loadedModule
         setManifoldJSModule(loadedModule)
       } catch (error) {
         console.error("Failed to initialize Manifold:", error)


### PR DESCRIPTION
## PR description

- Added global cache `window._CACHED_MANIFOLD_MODULE` to store initialized Manifold module 
- Initialize component state with cached module if available 
- Early return in useEffect when cached module exists 
- Store module in cache after successful initialization

## Video Demo 

https://github.com/user-attachments/assets/33bde091-3906-4a46-baa0-bbbac4f1cafc

fixes https://github.com/tscircuit/tscircuit.com/issues/1695
/claim https://github.com/tscircuit/tscircuit.com/issues/1695