### PR TITLE
Adjust FR4 material to physical board properties

### DIFF
--- a/src/geoms/constants.ts
+++ b/src/geoms/constants.ts
@@ -5,20 +5,57 @@ export const M = 0.01
 
 export const colors = {
   copper: [0.9, 0.6, 0.2],
-  fr4Green: [0x05 / 255, 0xa3 / 255, 0x2e / 255],
+  fr4Green: [0.04, 0.16, 0.08],
   fr4GreenSolderWithMask: [0x00 / 255, 0x98 / 255, 0x13 / 255],
   fr1Copper: [0.8, 0.4, 0.2],
   fr1CopperSolderWithMask: [0.9, 0.6, 0.2],
 } satisfies Record<string, RGB>
+
+export interface BoardMaterialPhysicalProperties {
+  baseColor: RGB
+  alpha: number
+  metalness: number
+  specularIntensity: number
+  roughness: number
+  ior: number
+  sheen: number
+  clearcoat: number
+}
 
 // Constants for Manifold processing
 export const MANIFOLD_Z_OFFSET = 0.001 // Small offset to prevent Z-fighting
 export const SMOOTH_CIRCLE_SEGMENTS = 32 // Number of segments for smooth circles
 export const DEFAULT_SMT_PAD_THICKNESS = 0.035 // Typical 1oz copper thickness in mm
 export const TRACE_TEXTURE_RESOLUTION = 50 // pixels per mm for trace texture
+export const boardMaterialPhysicalProperties: Record<
+  PcbBoard["material"],
+  BoardMaterialPhysicalProperties
+> = {
+  fr1: {
+    baseColor: colors.fr1Copper,
+    alpha: 1,
+    metalness: 0.2,
+    specularIntensity: 0.3,
+    roughness: 0.6,
+    ior: 1.5,
+    sheen: 0,
+    clearcoat: 0,
+  },
+  fr4: {
+    baseColor: colors.fr4Green,
+    alpha: 1,
+    metalness: 0,
+    specularIntensity: 0.2,
+    roughness: 0.8,
+    ior: 1.45,
+    sheen: 0,
+    clearcoat: 0,
+  },
+}
+
 export const boardMaterialColors: Record<PcbBoard["material"], RGB> = {
-  fr1: colors.fr1Copper,
-  fr4: colors.fr4Green,
+  fr1: boardMaterialPhysicalProperties.fr1.baseColor,
+  fr4: boardMaterialPhysicalProperties.fr4.baseColor,
 }
 
 export const tracesMaterialColors: Record<PcbBoard["material"], RGB> = {

--- a/src/hooks/useManifoldBoardBuilder.ts
+++ b/src/hooks/useManifoldBoardBuilder.ts
@@ -13,8 +13,10 @@ import type {
 } from "circuit-json"
 import { su } from "@tscircuit/circuit-json-util"
 import * as THREE from "three"
+import type { BoardMaterialPhysicalProperties } from "../geoms/constants"
 import {
   boardMaterialColors,
+  boardMaterialPhysicalProperties,
   colors as defaultColors,
   tracesMaterialColors,
   MANIFOLD_Z_OFFSET,
@@ -35,7 +37,11 @@ import { processCopperPoursForManifold } from "../utils/manifold/process-copper-
 import { processCutoutsForManifold } from "../utils/manifold/process-cutouts"
 
 export interface ManifoldGeoms {
-  board?: { geometry: THREE.BufferGeometry; color: THREE.Color }
+  board?: {
+    geometry: THREE.BufferGeometry
+    color: THREE.Color
+    materialProps: BoardMaterialPhysicalProperties
+  }
   platedHoles?: Array<{
     key: string
     geometry: THREE.BufferGeometry
@@ -207,8 +213,13 @@ export const useManifoldBoardBuilder = (
       if (boardManifold) {
         const boardThreeMesh = boardManifold.getMesh()
         const finalBoardGeom = manifoldMeshToThreeGeometry(boardThreeMesh)
+        const materialKey = (boardData.material ??
+          "fr4") as PcbBoard["material"]
+        const materialProps =
+          boardMaterialPhysicalProperties[materialKey] ??
+          boardMaterialPhysicalProperties.fr4
         const matColorArray =
-          boardMaterialColors[boardData.material] ?? defaultColors.fr4Green
+          boardMaterialColors[materialKey] ?? materialProps.baseColor
         currentGeoms.board = {
           geometry: finalBoardGeom,
           color: new THREE.Color(
@@ -216,6 +227,7 @@ export const useManifoldBoardBuilder = (
             matColorArray[1],
             matColorArray[2],
           ),
+          materialProps,
         }
       }
 

--- a/src/utils/manifold/create-three-geometry-meshes.ts
+++ b/src/utils/manifold/create-three-geometry-meshes.ts
@@ -8,12 +8,21 @@ export function createGeometryMeshes(
   if (!geoms) return meshes
 
   if (geoms.board && geoms.board.geometry) {
+    const { materialProps } = geoms.board
     const mesh = new THREE.Mesh(
       geoms.board.geometry,
-      new THREE.MeshStandardMaterial({
+      new THREE.MeshPhysicalMaterial({
         color: geoms.board.color,
         side: THREE.DoubleSide,
         flatShading: true,
+        metalness: materialProps?.metalness ?? 0,
+        roughness: materialProps?.roughness ?? 1,
+        ior: materialProps?.ior ?? 1.5,
+        sheen: materialProps?.sheen ?? 0,
+        clearcoat: materialProps?.clearcoat ?? 0,
+        specularIntensity: materialProps?.specularIntensity ?? 1,
+        opacity: materialProps?.alpha ?? 1,
+        transparent: (materialProps?.alpha ?? 1) < 1,
       }),
     )
     mesh.name = "board-geom"


### PR DESCRIPTION
## Summary
- add explicit board material property mappings including updated FR4 base color
- propagate material properties through the manifold board builder to the mesh creation
- render the board with a MeshPhysicalMaterial configured from the FR4 properties

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68df3daa3c98832e8b2d2d3e5f6cb81f