### PR TITLE
chop off elements outside board outline

### DIFF
--- a/src/geoms/create-board-with-outline.ts
+++ b/src/geoms/create-board-with-outline.ts
@@ -4,6 +4,7 @@ import type { Geom2, Geom3 } from "@jscad/modeling/src/geometries/types"
 import type { Vec2 } from "@jscad/modeling/src/maths/types"
 import type { Point } from "circuit-json"
 import { translate } from "@jscad/modeling/src/operations/transforms"
+import { expand } from "@jscad/modeling/src/operations/expansions"
 
 export const arePointsClockwise = (points: Vec2[]): boolean => {
   let area = 0
@@ -16,10 +17,16 @@ export const arePointsClockwise = (points: Vec2[]): boolean => {
   return signedArea <= 0
 }
 
+type CreateBoardGeomWithOutlineOptions = {
+  xyOutset?: number
+}
+
 export const createBoardGeomWithOutline = (
   board: { center?: { x: number; y: number }; outline: Point[] },
   depth = 1.2,
+  options: CreateBoardGeomWithOutlineOptions = {},
 ): Geom3 => {
+  const { xyOutset = 0 } = options
   const { outline } = board
   let outlineVec2: Vec2[] = outline.map((point) => [point.x, point.y])
 
@@ -27,7 +34,11 @@ export const createBoardGeomWithOutline = (
     outlineVec2 = outlineVec2.reverse()
   }
 
-  const shape: Geom2 = polygon({ points: outlineVec2 })
+  let shape: Geom2 = polygon({ points: outlineVec2 })
+
+  if (xyOutset !== 0) {
+    shape = expand({ delta: xyOutset, corners: "edge" }, shape)
+  }
 
   let boardGeom: Geom3 = extrudeLinear({ height: depth }, shape)
 

--- a/src/geoms/plated-hole.ts
+++ b/src/geoms/plated-hole.ts
@@ -6,7 +6,11 @@ import {
   roundedRectangle,
 } from "@jscad/modeling/src/primitives"
 import { colorize } from "@jscad/modeling/src/colors"
-import { subtract, union } from "@jscad/modeling/src/operations/booleans"
+import {
+  intersect,
+  subtract,
+  union,
+} from "@jscad/modeling/src/operations/booleans"
 import { M, colors } from "./constants"
 import type { GeomContext } from "../GeomContext"
 import { extrudeLinear } from "@jscad/modeling/src/operations/extrusions"
@@ -18,6 +22,9 @@ import {
 
 const platedHoleLipHeight = 0.05
 const RECT_PAD_SEGMENTS = 64
+
+const maybeClip = (geom: Geom3, clipGeom?: Geom3 | null) =>
+  clipGeom ? intersect(clipGeom, geom) : geom
 
 const createRectPadGeom = ({
   width,
@@ -48,88 +55,86 @@ const createRectPadGeom = ({
   return translate([center[0], center[1], offsetZ], extruded)
 }
 
+type PlatedHoleOptions = {
+  clipGeom?: Geom3 | null
+}
+
 export const platedHole = (
   plated_hole: PCBPlatedHole,
   ctx: GeomContext,
+  options: PlatedHoleOptions = {},
 ): Geom3 => {
+  const { clipGeom } = options
   if (!(plated_hole as PCBPlatedHole).shape) plated_hole.shape = "circle"
+  const throughDrillHeight = ctx.pcbThickness + 2 * platedHoleLipHeight + 4 * M
   if (plated_hole.shape === "circle") {
-    return colorize(
-      colors.copper,
-      subtract(
-        union(
-          cylinder({
-            center: [plated_hole.x, plated_hole.y, 0],
-            radius: plated_hole.hole_diameter / 2,
-            height: ctx.pcbThickness,
-          }),
-          cylinder({
-            center: [
-              plated_hole.x,
-              plated_hole.y,
-              ctx.pcbThickness / 2 + platedHoleLipHeight / 2 + M,
-            ],
-            radius: plated_hole.outer_diameter / 2,
-            height: platedHoleLipHeight,
-          }),
-          cylinder({
-            center: [
-              plated_hole.x,
-              plated_hole.y,
-              -ctx.pcbThickness / 2 - platedHoleLipHeight / 2 - M,
-            ],
-            radius: plated_hole.outer_diameter / 2,
-            height: platedHoleLipHeight,
-          }),
-        ),
-        cylinder({
-          center: [plated_hole.x, plated_hole.y, 0],
-          radius: plated_hole.hole_diameter / 2 - M,
-          height: 1.5,
-        }),
-      ),
-    )
+    const outerDiameter =
+      plated_hole.outer_diameter ?? Math.max(plated_hole.hole_diameter, 0)
+    const copperHeight = ctx.pcbThickness + 2 * (platedHoleLipHeight + M)
+    const copperBody = cylinder({
+      center: [plated_hole.x, plated_hole.y, 0],
+      radius: outerDiameter / 2,
+      height: copperHeight,
+    })
+
+    const copperSolid = maybeClip(copperBody, clipGeom)
+
+    const drill = cylinder({
+      center: [plated_hole.x, plated_hole.y, 0],
+      radius: Math.max(plated_hole.hole_diameter / 2, 0.01),
+      height: throughDrillHeight,
+    })
+
+    return colorize(colors.copper, subtract(copperSolid, drill))
   }
   if (plated_hole.shape === "circular_hole_with_rect_pad") {
     const padWidth = plated_hole.rect_pad_width || plated_hole.hole_diameter
     const padHeight = plated_hole.rect_pad_height || plated_hole.hole_diameter
     const rectBorderRadius = extractRectBorderRadius(plated_hole)
 
-    return colorize(
-      colors.copper,
-      subtract(
-        union(
-          // Top rectangular pad
-          createRectPadGeom({
-            width: padWidth,
-            height: padHeight,
-            thickness: platedHoleLipHeight,
-            center: [plated_hole.x, plated_hole.y, 1.2 / 2],
-            borderRadius: rectBorderRadius,
-          }),
-          // Bottom rectangular pad
-          createRectPadGeom({
-            width: padWidth,
-            height: padHeight,
-            thickness: platedHoleLipHeight,
-            center: [plated_hole.x, plated_hole.y, -1.2 / 2],
-            borderRadius: rectBorderRadius,
-          }),
-          // Plated barrel around hole
-          cylinder({
-            center: [plated_hole.x, plated_hole.y, 0],
-            radius: plated_hole.hole_diameter / 2,
-            height: 1.2,
-          }),
-        ),
-        // Subtract actual hole through
+    const copperSolid = maybeClip(
+      union(
+        // Top rectangular pad
+        createRectPadGeom({
+          width: padWidth,
+          height: padHeight,
+          thickness: platedHoleLipHeight,
+          center: [
+            plated_hole.x,
+            plated_hole.y,
+            ctx.pcbThickness / 2 + platedHoleLipHeight / 2 + M,
+          ],
+          borderRadius: rectBorderRadius,
+        }),
+        // Bottom rectangular pad
+        createRectPadGeom({
+          width: padWidth,
+          height: padHeight,
+          thickness: platedHoleLipHeight,
+          center: [
+            plated_hole.x,
+            plated_hole.y,
+            -ctx.pcbThickness / 2 - platedHoleLipHeight / 2 - M,
+          ],
+          borderRadius: rectBorderRadius,
+        }),
+        // Plated barrel around hole
         cylinder({
           center: [plated_hole.x, plated_hole.y, 0],
-          radius: Math.max(plated_hole.hole_diameter / 2 - M, 0.01),
-          height: 1.5,
+          radius: plated_hole.hole_diameter / 2,
+          height: ctx.pcbThickness,
         }),
       ),
+      clipGeom,
     )
+
+    const drill = cylinder({
+      center: [plated_hole.x, plated_hole.y, 0],
+      radius: Math.max(plated_hole.hole_diameter / 2 - M, 0.01),
+      height: throughDrillHeight,
+    })
+
+    return colorize(colors.copper, subtract(copperSolid, drill))
   }
 
   if (plated_hole.shape === "pill") {
@@ -152,105 +157,82 @@ export const platedHole = (
     const outerRadius = outerPillHeight / 2
     const rectLength = Math.abs(holeWidth - holeHeight)
     const outerRectLength = Math.abs(outerPillWidth - outerPillHeight)
+    const copperHeight = ctx.pcbThickness + 2 * (platedHoleLipHeight + M)
 
-    const mainRectBarrel = cuboid({
-      center: [plated_hole.x, plated_hole.y, 0],
-      size: shouldRotate
-        ? [holeHeight, rectLength, ctx.pcbThickness]
-        : [rectLength, holeHeight, ctx.pcbThickness],
-    })
-    const leftCapBarrel = cylinder({
-      center: shouldRotate
-        ? [plated_hole.x, plated_hole.y - rectLength / 2, 0]
-        : [plated_hole.x - rectLength / 2, plated_hole.y, 0],
-      radius: holeRadius,
-      height: ctx.pcbThickness,
-    })
-    const rightCapBarrel = cylinder({
-      center: shouldRotate
-        ? [plated_hole.x, plated_hole.y + rectLength / 2, 0]
-        : [plated_hole.x + rectLength / 2, plated_hole.y, 0],
-      radius: holeRadius,
-      height: ctx.pcbThickness,
-    })
-    const barrelUnion = union(mainRectBarrel, leftCapBarrel, rightCapBarrel)
+    const createPillSection = (
+      width: number,
+      height: number,
+      thickness: number,
+    ) => {
+      const radius = height / 2
+      const length = Math.abs(width - height)
 
-    const topLipZ = ctx.pcbThickness / 2 + platedHoleLipHeight / 2 + M
-    const topLipRect = cuboid({
-      center: [plated_hole.x, plated_hole.y, topLipZ],
-      size: shouldRotate
-        ? [outerPillHeight, outerRectLength, platedHoleLipHeight]
-        : [outerRectLength, outerPillHeight, platedHoleLipHeight],
-    })
-    const topLipLeftCap = cylinder({
-      center: shouldRotate
-        ? [plated_hole.x, plated_hole.y - outerRectLength / 2, topLipZ]
-        : [plated_hole.x - outerRectLength / 2, plated_hole.y, topLipZ],
-      radius: outerRadius,
-      height: platedHoleLipHeight,
-    })
-    const topLipRightCap = cylinder({
-      center: shouldRotate
-        ? [plated_hole.x, plated_hole.y + outerRectLength / 2, topLipZ]
-        : [plated_hole.x + outerRectLength / 2, plated_hole.y, topLipZ],
-      radius: outerRadius,
-      height: platedHoleLipHeight,
-    })
-    const topLipUnion = union(topLipRect, topLipLeftCap, topLipRightCap)
+      if (length <= 1e-6) {
+        return cylinder({
+          center: [plated_hole.x, plated_hole.y, 0],
+          radius,
+          height: thickness,
+        })
+      }
 
-    const bottomLipZ = -ctx.pcbThickness / 2 - platedHoleLipHeight / 2 - M
-    const bottomLipRect = cuboid({
-      center: [plated_hole.x, plated_hole.y, bottomLipZ],
-      size: shouldRotate
-        ? [outerPillHeight, outerRectLength, platedHoleLipHeight]
-        : [outerRectLength, outerPillHeight, platedHoleLipHeight],
-    })
-    const bottomLipLeftCap = cylinder({
-      center: shouldRotate
-        ? [plated_hole.x, plated_hole.y - outerRectLength / 2, bottomLipZ]
-        : [plated_hole.x - outerRectLength / 2, plated_hole.y, bottomLipZ],
-      radius: outerRadius,
-      height: platedHoleLipHeight,
-    })
-    const bottomLipRightCap = cylinder({
-      center: shouldRotate
-        ? [plated_hole.x, plated_hole.y + outerRectLength / 2, bottomLipZ]
-        : [plated_hole.x + outerRectLength / 2, plated_hole.y, bottomLipZ],
-      radius: outerRadius,
-      height: platedHoleLipHeight,
-    })
-    const bottomLipUnion = union(
-      bottomLipRect,
-      bottomLipLeftCap,
-      bottomLipRightCap,
+      const rect = cuboid({
+        center: [plated_hole.x, plated_hole.y, 0],
+        size: shouldRotate
+          ? [height, length, thickness]
+          : [length, height, thickness],
+      })
+
+      const leftCap = cylinder({
+        center: shouldRotate
+          ? [plated_hole.x, plated_hole.y - length / 2, 0]
+          : [plated_hole.x - length / 2, plated_hole.y, 0],
+        radius,
+        height: thickness,
+      })
+
+      const rightCap = cylinder({
+        center: shouldRotate
+          ? [plated_hole.x, plated_hole.y + length / 2, 0]
+          : [plated_hole.x + length / 2, plated_hole.y, 0],
+        radius,
+        height: thickness,
+      })
+
+      return union(rect, leftCap, rightCap)
+    }
+
+    const outerBarrel = createPillSection(
+      outerPillWidth,
+      outerPillHeight,
+      copperHeight,
     )
 
     const drillRect = cuboid({
       center: [plated_hole.x, plated_hole.y, 0],
       size: shouldRotate
-        ? [holeHeight - 2 * M, rectLength, ctx.pcbThickness + 2 * M]
-        : [rectLength, holeHeight - 2 * M, ctx.pcbThickness + 2 * M],
+        ? [holeHeight - 2 * M, rectLength, throughDrillHeight]
+        : [rectLength, holeHeight - 2 * M, throughDrillHeight],
     })
     const drillLeftCap = cylinder({
       center: shouldRotate
         ? [plated_hole.x, plated_hole.y - rectLength / 2, 0]
         : [plated_hole.x - rectLength / 2, plated_hole.y, 0],
       radius: holeRadius - M,
-      height: ctx.pcbThickness + 2 * M,
+      height: throughDrillHeight,
     })
     const drillRightCap = cylinder({
       center: shouldRotate
         ? [plated_hole.x, plated_hole.y + rectLength / 2, 0]
         : [plated_hole.x + rectLength / 2, plated_hole.y, 0],
       radius: holeRadius - M,
-      height: ctx.pcbThickness + 2 * M,
+      height: throughDrillHeight,
     })
     const drillUnion = union(drillRect, drillLeftCap, drillRightCap)
 
-    return colorize(
-      colors.copper,
-      subtract(union(barrelUnion, topLipUnion, bottomLipUnion), drillUnion),
-    )
+    const copperSolid = maybeClip(outerBarrel, clipGeom)
+    const drill = drillUnion
+
+    return colorize(colors.copper, subtract(copperSolid, drill))
     // biome-ignore lint/style/noUselessElse: <explanation>
   }
   if (plated_hole.shape === "pill_hole_with_rect_pad") {
@@ -271,8 +253,8 @@ export const platedHole = (
     const mainRect = cuboid({
       center: [plated_hole.x, plated_hole.y, 0],
       size: shouldRotate
-        ? [holeHeight, rectLength, 1.2]
-        : [rectLength, holeHeight, 1.2],
+        ? [holeHeight, rectLength, ctx.pcbThickness]
+        : [rectLength, holeHeight, ctx.pcbThickness],
     })
 
     const leftCap = cylinder({
@@ -280,7 +262,7 @@ export const platedHole = (
         ? [plated_hole.x, plated_hole.y - rectLength / 2, 0]
         : [plated_hole.x - rectLength / 2, plated_hole.y, 0],
       radius: holeRadius,
-      height: 1.2,
+      height: ctx.pcbThickness,
     })
 
     const rightCap = cylinder({
@@ -288,14 +270,18 @@ export const platedHole = (
         ? [plated_hole.x, plated_hole.y + rectLength / 2, 0]
         : [plated_hole.x + rectLength / 2, plated_hole.y, 0],
       radius: holeRadius,
-      height: 1.2,
+      height: ctx.pcbThickness,
     })
 
     const topPad = createRectPadGeom({
       width: padWidth,
       height: padHeight,
       thickness: platedHoleLipHeight,
-      center: [plated_hole.x, plated_hole.y, 1.2 / 2],
+      center: [
+        plated_hole.x,
+        plated_hole.y,
+        ctx.pcbThickness / 2 + platedHoleLipHeight / 2 + M,
+      ],
       borderRadius: rectBorderRadius,
     })
 
@@ -303,7 +289,11 @@ export const platedHole = (
       width: padWidth,
       height: padHeight,
       thickness: platedHoleLipHeight,
-      center: [plated_hole.x, plated_hole.y, -1.2 / 2],
+      center: [
+        plated_hole.x,
+        plated_hole.y,
+        -ctx.pcbThickness / 2 - platedHoleLipHeight / 2 - M,
+      ],
       borderRadius: rectBorderRadius,
     })
 
@@ -311,29 +301,32 @@ export const platedHole = (
       cuboid({
         center: [plated_hole.x, plated_hole.y, 0],
         size: shouldRotate
-          ? [holeHeight - platedHoleLipHeight, rectLength, 1.5]
-          : [rectLength, holeHeight - platedHoleLipHeight, 1.5],
+          ? [holeHeight - platedHoleLipHeight, rectLength, throughDrillHeight]
+          : [rectLength, holeHeight - platedHoleLipHeight, throughDrillHeight],
       }),
       cylinder({
         center: shouldRotate
           ? [plated_hole.x, plated_hole.y - rectLength / 2, 0]
           : [plated_hole.x - rectLength / 2, plated_hole.y, 0],
         radius: holeRadius - platedHoleLipHeight,
-        height: 1.5,
+        height: throughDrillHeight,
       }),
       cylinder({
         center: shouldRotate
           ? [plated_hole.x, plated_hole.y + rectLength / 2, 0]
           : [plated_hole.x + rectLength / 2, plated_hole.y, 0],
         radius: holeRadius - platedHoleLipHeight,
-        height: 1.5,
+        height: throughDrillHeight,
       }),
     )
 
-    return colorize(
-      colors.copper,
-      subtract(union(mainRect, leftCap, rightCap, topPad, bottomPad), holeCut),
+    const copperSolid = maybeClip(
+      union(mainRect, leftCap, rightCap, topPad, bottomPad),
+      clipGeom,
     )
+    const drill = holeCut
+
+    return colorize(colors.copper, subtract(copperSolid, drill))
   } else {
     throw new Error(`Unsupported plated hole shape: ${plated_hole.shape}`)
   }

--- a/src/utils/manifold/create-manifold-board.ts
+++ b/src/utils/manifold/create-manifold-board.ts
@@ -1,4 +1,7 @@
-import type { ManifoldToplevel } from "manifold-3d/manifold.d.ts"
+import type {
+  ManifoldToplevel,
+  CrossSection as ManifoldCrossSection,
+} from "manifold-3d/manifold.d.ts"
 import type { PcbBoard } from "circuit-json"
 
 const arePointsClockwise = (points: Array<[number, number]>): boolean => {
@@ -14,14 +17,20 @@ const arePointsClockwise = (points: Array<[number, number]>): boolean => {
   return signedArea <= 0
 }
 
+export interface CreateManifoldBoardResult {
+  boardOp: any
+  outlineCrossSection: ManifoldCrossSection | null
+}
+
 export function createManifoldBoard(
   Manifold: ManifoldToplevel["Manifold"],
   CrossSection: ManifoldToplevel["CrossSection"],
   boardData: PcbBoard,
   pcbThickness: number,
   manifoldInstancesForCleanup: any[],
-): any {
+): CreateManifoldBoardResult {
   let boardOp: any
+  let outlineCrossSection: ManifoldCrossSection | null = null
 
   if (boardData.outline && boardData.outline.length >= 3) {
     let outlineVec2: Array<[number, number]> = boardData.outline.map((p) => [
@@ -35,6 +44,7 @@ export function createManifoldBoard(
 
     const crossSection = CrossSection.ofPolygons([outlineVec2])
     manifoldInstancesForCleanup.push(crossSection)
+    outlineCrossSection = crossSection
 
     boardOp = Manifold.extrude(
       crossSection,
@@ -62,5 +72,5 @@ export function createManifoldBoard(
     manifoldInstancesForCleanup.push(boardOp) // Also track the translated op
   }
 
-  return boardOp
+  return { boardOp, outlineCrossSection }
 }

--- a/src/utils/manifold/process-copper-pours.ts
+++ b/src/utils/manifold/process-copper-pours.ts
@@ -113,6 +113,7 @@ export function processCopperPoursForManifold(
   pcbThickness: number,
   manifoldInstancesForCleanup: any[],
   holeUnion?: any,
+  boardClipVolume?: any,
 ): ProcessCopperPoursResult {
   const copperPourGeoms: ProcessCopperPoursResult["copperPourGeoms"] = []
   const copperPours = circuitJson.filter(
@@ -200,6 +201,11 @@ export function processCopperPoursForManifold(
         const withHoles = pourOp.subtract(holeUnion)
         manifoldInstancesForCleanup.push(withHoles)
         pourOp = withHoles
+      }
+      if (boardClipVolume) {
+        const clipped = Manifold.intersection([pourOp, boardClipVolume])
+        manifoldInstancesForCleanup.push(clipped)
+        pourOp = clipped
       }
       const threeGeom = manifoldMeshToThreeGeometry(pourOp.getMesh())
       copperPourGeoms.push({

--- a/src/utils/manifold/process-plated-holes.ts
+++ b/src/utils/manifold/process-plated-holes.ts
@@ -31,6 +31,7 @@ export function processPlatedHolesForManifold(
   circuitJson: AnyCircuitElement[],
   pcbThickness: number,
   manifoldInstancesForCleanup: any[],
+  boardClipVolume?: any,
 ): ProcessPlatedHolesResult {
   const platedHoleBoardDrills: any[] = []
   const pcbPlatedHoles = su(circuitJson).pcb_plated_hole.list()
@@ -89,9 +90,16 @@ export function processPlatedHolesForManifold(
       manifoldInstancesForCleanup.push(finalPlatedPartOp)
       const translatedPlatedPart = finalPlatedPartOp.translate([ph.x, ph.y, 0])
       manifoldInstancesForCleanup.push(translatedPlatedPart)
-      const threeGeom = manifoldMeshToThreeGeometry(
-        translatedPlatedPart.getMesh(),
-      )
+      let finalCopperOp: any = translatedPlatedPart
+      if (boardClipVolume) {
+        const clipped = Manifold.intersection([
+          translatedPlatedPart,
+          boardClipVolume,
+        ])
+        manifoldInstancesForCleanup.push(clipped)
+        finalCopperOp = clipped
+      }
+      const threeGeom = manifoldMeshToThreeGeometry(finalCopperOp.getMesh())
       platedHoleCopperGeoms.push({
         key: `ph-${ph.pcb_plated_hole_id || index}`,
         geometry: threeGeom,
@@ -239,9 +247,17 @@ export function processPlatedHolesForManifold(
       const translatedPlatedPart = finalPlatedPartOp.translate([ph.x, ph.y, 0])
       manifoldInstancesForCleanup.push(translatedPlatedPart)
 
-      const threeGeom = manifoldMeshToThreeGeometry(
-        translatedPlatedPart.getMesh(),
-      )
+      let finalCopperOp: any = translatedPlatedPart
+      if (boardClipVolume) {
+        const clipped = Manifold.intersection([
+          translatedPlatedPart,
+          boardClipVolume,
+        ])
+        manifoldInstancesForCleanup.push(clipped)
+        finalCopperOp = clipped
+      }
+
+      const threeGeom = manifoldMeshToThreeGeometry(finalCopperOp.getMesh())
       platedHoleCopperGeoms.push({
         key: `ph-${ph.pcb_plated_hole_id || index}`,
         geometry: threeGeom,
@@ -326,7 +342,17 @@ export function processPlatedHolesForManifold(
       const translatedCopper = copperUnion.translate([ph.x, ph.y, 0])
       manifoldInstancesForCleanup.push(translatedCopper)
 
-      const threeGeom = manifoldMeshToThreeGeometry(translatedCopper.getMesh())
+      let finalCopperOp: any = translatedCopper
+      if (boardClipVolume) {
+        const clipped = Manifold.intersection([
+          translatedCopper,
+          boardClipVolume,
+        ])
+        manifoldInstancesForCleanup.push(clipped)
+        finalCopperOp = clipped
+      }
+
+      const threeGeom = manifoldMeshToThreeGeometry(finalCopperOp.getMesh())
       platedHoleCopperGeoms.push({
         key: `ph-${ph.pcb_plated_hole_id || index}`,
         geometry: threeGeom,

--- a/src/utils/manifold/process-smt-pads.ts
+++ b/src/utils/manifold/process-smt-pads.ts
@@ -26,6 +26,7 @@ export function processSmtPadsForManifold(
   pcbThickness: number,
   manifoldInstancesForCleanup: any[],
   holeUnion?: any,
+  boardClipVolume?: any,
 ): ProcessSmtPadsResult {
   const smtPadGeoms: Array<{
     key: string
@@ -56,6 +57,11 @@ export function processSmtPadsForManifold(
       if (holeUnion) {
         finalPadOp = translatedPad.subtract(holeUnion)
         manifoldInstancesForCleanup.push(finalPadOp)
+      }
+      if (boardClipVolume) {
+        const clipped = Manifold.intersection([finalPadOp, boardClipVolume])
+        manifoldInstancesForCleanup.push(clipped)
+        finalPadOp = clipped
       }
       const threeGeom = manifoldMeshToThreeGeometry(finalPadOp.getMesh())
       smtPadGeoms.push({

--- a/src/utils/manifold/process-vias.ts
+++ b/src/utils/manifold/process-vias.ts
@@ -27,6 +27,7 @@ export function processViasForManifold(
   circuitJson: AnyCircuitElement[],
   pcbThickness: number,
   manifoldInstancesForCleanup: any[],
+  boardClipVolume?: any,
 ): ProcessViasResult {
   const viaBoardDrills: any[] = []
   const pcbVias = su(circuitJson).pcb_via.list() as PcbVia[]
@@ -68,9 +69,16 @@ export function processViasForManifold(
         segments: SMOOTH_CIRCLE_SEGMENTS,
       })
       manifoldInstancesForCleanup.push(translatedViaCopper)
-      const threeGeom = manifoldMeshToThreeGeometry(
-        translatedViaCopper.getMesh(),
-      )
+      let finalCopperOp: any = translatedViaCopper
+      if (boardClipVolume) {
+        const clipped = Manifold.intersection([
+          translatedViaCopper,
+          boardClipVolume,
+        ])
+        manifoldInstancesForCleanup.push(clipped)
+        finalCopperOp = clipped
+      }
+      const threeGeom = manifoldMeshToThreeGeometry(finalCopperOp.getMesh())
       viaCopperGeoms.push({
         key: `via-${via.pcb_via_id || index}`,
         geometry: threeGeom,

--- a/stories/Bugs/PlatedHoleEdge.stories.tsx
+++ b/stories/Bugs/PlatedHoleEdge.stories.tsx
@@ -1,0 +1,40 @@
+import { CadViewer } from "src/CadViewer"
+
+export const boardWithEdgePlatedHole = () => (
+  <CadViewer>
+    <board width="20mm" height="20mm">
+      <platedhole
+        shape="circle"
+        pcbX={10}
+        pcbY={0}
+        holeDiameter={2}
+        outerDiameter={5}
+      />
+      <platedhole
+        shape="circle"
+        pcbX={-10}
+        pcbY={0}
+        holeDiameter={1}
+        outerDiameter={3}
+      />
+      <platedhole
+        shape="circle"
+        pcbX={0}
+        pcbY={10}
+        holeDiameter={2}
+        outerDiameter={3}
+      />
+      <platedhole
+        shape="circle"
+        pcbX={0}
+        pcbY={-10}
+        holeDiameter={2}
+        outerDiameter={3}
+      />
+    </board>
+  </CadViewer>
+)
+boardWithEdgePlatedHole.storyName = "Board with Edge Plated Hole"
+export default {
+  title: "Bugs/Plated Hole Edge Cutout",
+}


### PR DESCRIPTION
Added boardClipGeom / boardClipVolume to define a slightly expanded clipping region around the board.

Applied clipping to pads, traces, copper pours, vias, and plated holes.

Updated createBoardGeomWithOutline to support xyOutset for small outward expansion.

Refactored plated-hole.ts with a maybeClip helper and more consistent through-hole generation.

Extended manifold processing functions to use the new clip volume.

Added PlatedHoleEdge story to test cases where holes sit right at the edge.


/claim #512