### PR TITLE
fix: handle undefined hole offsets to prevent board render crash

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -439,8 +439,8 @@ export class BoardGeomBuilder {
       if (ph.shape === "circular_hole_with_rect_pad") {
         cyGeom = cylinder({
           center: [
-            ph.x + ph.hole_offset_x || 0,
-            ph.y + ph.hole_offset_y || 0,
+            ph.x + (ph.hole_offset_x || 0),
+            ph.y + (ph.hole_offset_y || 0),
             0,
           ],
           radius: ph.hole_diameter / 2 + M, // Add margin for subtraction

--- a/stories/PlatedHoleOffset.stories.tsx
+++ b/stories/PlatedHoleOffset.stories.tsx
@@ -11,6 +11,8 @@ export const PlatedHoleOffset = () => {
           rectPadHeight={4}
           holeOffsetX={1}
           holeOffsetY={-0.5}
+          pcbX={-5}
+          pcbY={-5}
         />
         <platedhole
           shape="pill_hole_with_rect_pad"
@@ -20,7 +22,6 @@ export const PlatedHoleOffset = () => {
           holeHeight={3}
           rectPadWidth={4}
           rectPadHeight={5}
-          holeOffsetX={-0.75}
           holeOffsetY={0.5}
           pcbX={5.5}
           pcbY={4.5}


### PR DESCRIPTION
Fixes a bug where hole_offset_x or hole_offset_y being undefined caused the board rendering to fail for plated holes.
Defaults offsets to 0 when not provided to ensure stable geometry generation for circular and pill-shaped plated holes.