### PR TITLE
Fix context menu boundary detection and improve styling (#535)

### DIFF
--- a/src/components/AppearanceMenu.tsx
+++ b/src/components/AppearanceMenu.tsx
@@ -50,36 +50,37 @@ export const AppearanceMenu = () => {
         const PADDING = 20
 
         let style: React.CSSProperties = {
-          position: 'absolute',
+          position: "absolute",
           minWidth: 200,
-          background: '#2c313a',
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          background: "#2c313a",
+          border: "1px solid rgba(255, 255, 255, 0.1)",
           borderRadius: 8,
-          boxShadow: '0 10px 40px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.2)',
+          boxShadow:
+            "0 10px 40px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.2)",
           zIndex: 1001,
-          padding: '4px 0',
+          padding: "4px 0",
         }
 
         // Determine horizontal placement
         const spaceOnRight = viewportWidth - triggerRect.right
         const spaceOnLeft = triggerRect.left
         const submenuWidthWithSpacing = submenuRect.width + Math.abs(SPACING)
-        
+
         if (spaceOnRight >= submenuWidthWithSpacing + PADDING) {
           // Enough space on right - position to the right
-          style.left = '100%'
+          style.left = "100%"
           style.marginLeft = SPACING
         } else if (spaceOnLeft >= submenuWidthWithSpacing + PADDING) {
           // Not enough space on right, but enough on left - position to the left
-          style.right = '100%'
+          style.right = "100%"
           style.marginRight = SPACING
         } else {
           // Not enough space on either side - choose side with more space
           if (spaceOnRight > spaceOnLeft) {
-            style.left = '100%'
+            style.left = "100%"
             style.marginLeft = SPACING
           } else {
-            style.right = '100%'
+            style.right = "100%"
             style.marginRight = SPACING
           }
         }
@@ -87,7 +88,7 @@ export const AppearanceMenu = () => {
         // Vertical placement - check if submenu fits below
         const spaceBelow = viewportHeight - triggerRect.top - PADDING
         const spaceAbove = triggerRect.bottom - PADDING
-        
+
         if (submenuRect.height <= spaceBelow) {
           // Fits below - align with Appearance item
           style.top = 0
@@ -100,12 +101,12 @@ export const AppearanceMenu = () => {
             // More space below - align to top and let it extend
             style.top = 0
             style.maxHeight = spaceBelow - PADDING
-            style.overflowY = 'auto'
+            style.overflowY = "auto"
           } else {
             // More space above - align to bottom
             style.bottom = 0
             style.maxHeight = spaceAbove - PADDING
-            style.overflowY = 'auto'
+            style.overflowY = "auto"
           }
         }
 
@@ -141,7 +142,11 @@ export const AppearanceMenu = () => {
           <span style={checkmarkStyle}></span>
           Appearance
         </div>
-        <span style={{ fontSize: 16, opacity: 0.7, transform: "translateY(1px)" }}>›</span>
+        <span
+          style={{ fontSize: 16, opacity: 0.7, transform: "translateY(1px)" }}
+        >
+          ›
+        </span>
 
         {showSubmenu && (
           <div

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -53,43 +53,49 @@ export const useContextMenu = ({ containerRef }: ContextMenuProps) => {
       // Initial position at click
       const initialX = eventX
       const initialY = eventY
-      
+
       setMenuPos({ x: initialX, y: initialY })
       setMenuVisible(true)
-      
+
       // Adjust position after render using actual menu dimensions
       setTimeout(() => {
         if (!menuRef.current) return
-        
+
         const menuRect = menuRef.current.getBoundingClientRect()
         const viewportWidth = window.innerWidth
         const viewportHeight = window.innerHeight
-        
+
         let adjustedX = initialX
         let adjustedY = initialY
-        
+
         // Adjust horizontal position
         if (initialX + menuRect.width > viewportWidth - VIEWPORT_PADDING) {
-          adjustedX = Math.max(VIEWPORT_PADDING, viewportWidth - menuRect.width - VIEWPORT_PADDING)
+          adjustedX = Math.max(
+            VIEWPORT_PADDING,
+            viewportWidth - menuRect.width - VIEWPORT_PADDING,
+          )
         }
         if (adjustedX < VIEWPORT_PADDING) {
           adjustedX = VIEWPORT_PADDING
         }
-        
+
         // Adjust vertical position
         if (initialY + menuRect.height > viewportHeight - VIEWPORT_PADDING) {
-          adjustedY = Math.max(VIEWPORT_PADDING, viewportHeight - menuRect.height - VIEWPORT_PADDING)
+          adjustedY = Math.max(
+            VIEWPORT_PADDING,
+            viewportHeight - menuRect.height - VIEWPORT_PADDING,
+          )
         }
         if (adjustedY < VIEWPORT_PADDING) {
           adjustedY = VIEWPORT_PADDING
         }
-        
+
         // Only update if position changed
         if (adjustedX !== initialX || adjustedY !== initialY) {
           setMenuPos({ x: adjustedX, y: adjustedY })
         }
       }, 0)
-      
+
       // Reset after menu is shown or if swipe check passed but didn't swipe
       interactionOriginPosRef.current = null
     },
@@ -187,13 +193,13 @@ export const useContextMenu = ({ containerRef }: ContextMenuProps) => {
     if (!menuVisible) return
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key === "Escape") {
         setMenuVisible(false)
       }
     }
 
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
+    document.addEventListener("keydown", handleEscape)
+    return () => document.removeEventListener("keydown", handleEscape)
   }, [menuVisible])
 
   // Close on scroll
@@ -204,8 +210,8 @@ export const useContextMenu = ({ containerRef }: ContextMenuProps) => {
       setMenuVisible(false)
     }
 
-    window.addEventListener('scroll', handleScroll, true)
-    return () => window.removeEventListener('scroll', handleScroll, true)
+    window.addEventListener("scroll", handleScroll, true)
+    return () => window.removeEventListener("scroll", handleScroll, true)
   }, [menuVisible])
 
   const contextMenuEventHandlers = {


### PR DESCRIPTION
Fixes #535 

## Changes
-  Prevents context menu from going off-screen on any edge
-  Smart submenu positioning (auto-flips left/right based on space)
-  Modern styling with better shadows and spacing
-  Keyboard support (Escape to close)
-  Improved visual consistency

## Testing

https://github.com/user-attachments/assets/91672b0f-b14b-4232-a720-f6d8b9d93a6f


Tested scenarios:
- Right-click near all viewport edges
- Submenu positioning with various space constraints
- Keyboard interactions
- Click-outside behavior

/claim #535 