### PR TITLE
feat: Add support for covered_with_solder_mask on copper pours

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "bun-match-svg": "^0.0.9",
     "bun-types": "1.2.1",
-    "circuit-json": "0.0.279",
+    "circuit-json": "0.0.300",
     "circuit-to-svg": "^0.0.179",
     "debug": "^4.4.0",
     "jscad-electronics": "^0.0.48",

--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -441,7 +441,12 @@ export class BoardGeomBuilder {
       if (this.boardClipGeom) {
         pourGeom = intersect(this.boardClipGeom, pourGeom)
       }
-      const coloredPourGeom = colorize(colors.copper, pourGeom)
+      const covered = (pour as any).covered_with_solder_mask !== false
+      const pourMaterialColor = covered
+        ? (tracesMaterialColors[this.board.material] ??
+          colors.fr4GreenSolderWithMask)
+        : colors.copper
+      const coloredPourGeom = colorize(pourMaterialColor, pourGeom)
       this.copperPourGeoms.push(coloredPourGeom)
     }
   }

--- a/src/hooks/useManifoldBoardBuilder.ts
+++ b/src/hooks/useManifoldBoardBuilder.ts
@@ -318,6 +318,7 @@ export const useManifoldBoardBuilder = (
         circuitJson,
         currentPcbThickness,
         manifoldInstancesForCleanup.current,
+        boardData.material,
         holeUnion,
         boardClipVolume,
       )

--- a/src/utils/manifold/process-copper-pours.ts
+++ b/src/utils/manifold/process-copper-pours.ts
@@ -1,5 +1,5 @@
 import type { ManifoldToplevel, CrossSection } from "manifold-3d/manifold.d.ts"
-import type { AnyCircuitElement, PcbCopperPour } from "circuit-json"
+import type { AnyCircuitElement, PcbBoard, PcbCopperPour } from "circuit-json"
 import * as THREE from "three"
 import { manifoldMeshToThreeGeometry } from "../manifold-mesh-to-three-geometry"
 import {
@@ -7,9 +7,8 @@ import {
   DEFAULT_SMT_PAD_THICKNESS,
   MANIFOLD_Z_OFFSET,
   SMOOTH_CIRCLE_SEGMENTS,
+  tracesMaterialColors,
 } from "../../geoms/constants"
-
-const COPPER_COLOR = new THREE.Color(...defaultColors.copper)
 
 const arePointsClockwise = (points: Array<[number, number]>): boolean => {
   let area = 0
@@ -112,6 +111,7 @@ export function processCopperPoursForManifold(
   circuitJson: AnyCircuitElement[],
   pcbThickness: number,
   manifoldInstancesForCleanup: any[],
+  boardMaterial: PcbBoard["material"],
   holeUnion?: any,
   boardClipVolume?: any,
 ): ProcessCopperPoursResult {
@@ -207,11 +207,17 @@ export function processCopperPoursForManifold(
         manifoldInstancesForCleanup.push(clipped)
         pourOp = clipped
       }
+      const covered = (pour as any).covered_with_solder_mask !== false
+      const pourColorArr = covered
+        ? (tracesMaterialColors[boardMaterial] ??
+          defaultColors.fr4GreenSolderWithMask)
+        : defaultColors.copper
+      const pourColor = new THREE.Color(...pourColorArr)
       const threeGeom = manifoldMeshToThreeGeometry(pourOp.getMesh())
       copperPourGeoms.push({
         key: `coppour-${pour.pcb_copper_pour_id}`,
         geometry: threeGeom,
-        color: COPPER_COLOR,
+        color: pourColor,
       })
     }
   }

--- a/stories/CopperPour.stories.tsx
+++ b/stories/CopperPour.stories.tsx
@@ -147,6 +147,28 @@ const soup: AnyCircuitElement[] = [
       { x: 30, y: -30 },
     ],
   } as PcbCopperPour,
+  // pour_rect_2: A rect pour without solder mask
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "pour_rect_2",
+    layer: "top",
+    shape: "rect",
+    source_net_id: "net7",
+    center: { x: 70, y: 0 },
+    width: 20,
+    height: 10,
+    covered_with_solder_mask: false,
+  } as PcbCopperPour,
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "pour_full_bottom",
+    layer: "bottom",
+    shape: "rect",
+    source_net_id: "gnd",
+    center: { x: 0, y: 0 },
+    width: 198,
+    height: 98,
+  } as PcbCopperPour,
 ]
 export const Default = () => <CadViewer circuitJson={soup} />
 


### PR DESCRIPTION
This pull request introduces support for the covered_with_solder_mask property on               
pcb_copper_pour elements.                                                                       

 • Copper pours are now rendered with the solder mask color by default, consistent with traces. 
 • If covered_with_solder_mask is set to false, the pour is rendered with a bare copper color.  
 • This functionality is implemented for both the jscad and manifold rendering paths.           
 • A story has been added to CopperPour.stories.tsx to demonstrate a pour without a solder mask.
 • The circuit-json dependency has been updated to include the new property type.

<img width="968" height="503" alt="Screenshot 2025-11-02 at 7 04 47 AM" src="https://github.com/user-attachments/assets/d7196a07-72ac-43af-b6ad-ee5df59041b5" />
