### PR TITLE
Handle redundant Manifold delete errors

### DIFF
--- a/src/hooks/useManifoldBoardBuilder.ts
+++ b/src/hooks/useManifoldBoardBuilder.ts
@@ -127,8 +127,22 @@ export const useManifoldBoardBuilder = (
     const Manifold = manifoldJSModule.Manifold
     const CrossSection = manifoldJSModule.CrossSection
 
+    const safeDelete = (inst: any) => {
+      if (!inst || typeof inst.delete !== "function") return
+      try {
+        inst.delete()
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          !error.message?.includes("Manifold instance already deleted")
+        ) {
+          console.warn("Failed to delete Manifold instance", error)
+        }
+      }
+    }
+
     // Cleanup previous Manifold objects
-    manifoldInstancesForCleanup.current.forEach((inst) => inst.delete())
+    manifoldInstancesForCleanup.current.forEach(safeDelete)
     manifoldInstancesForCleanup.current = []
 
     let boardManifold: any = null
@@ -377,7 +391,7 @@ export const useManifoldBoardBuilder = (
 
     return () => {
       // Cleanup all Manifold instances created during this effect
-      manifoldInstancesForCleanup.current.forEach((inst) => inst.delete())
+      manifoldInstancesForCleanup.current.forEach(safeDelete)
       manifoldInstancesForCleanup.current = []
       // boardManifold is part of manifoldInstancesForCleanup if it was assigned
     }


### PR DESCRIPTION
## Summary
- guard Manifold instance cleanup with a safe delete helper
- ignore redundant "already deleted" errors while logging unexpected failures

## Testing
- bunx --bun tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_69081d205d78832ea202c3e6b367d71c