### PR TITLE
Fix: Boards are loaded from the default wrong angle

### DIFF
--- a/src/CadViewerContainer.tsx
+++ b/src/CadViewerContainer.tsx
@@ -46,7 +46,7 @@ export const CadViewerContainer = forwardRef<
   (
     {
       children,
-      initialCameraPosition = [5, 5, 5],
+      initialCameraPosition = [5, -5, 5],
       autoRotateDisabled,
       clickToInteractEnabled = false,
       boardDimensions,

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -58,24 +58,24 @@ export const CadViewerJscad = forwardRef<
     const boardGeom = useBoardGeomBuilder(internalCircuitJson)
 
     const initialCameraPosition = useMemo(() => {
-      if (!internalCircuitJson) return [5, 5, 5] as const
+      if (!internalCircuitJson) return [5, -5, 5] as const
       try {
         const board = su(internalCircuitJson as any).pcb_board.list()[0]
-        if (!board) return [5, 5, 5] as const
+        if (!board) return [5, -5, 5] as const
         const { width, height } = board
 
         if (!width && !height) {
-          return [5, 5, 5] as const
+          return [5, -5, 5] as const
         }
 
         const minCameraDistance = 5
         const adjustedBoardWidth = Math.max(width, minCameraDistance)
         const adjustedBoardHeight = Math.max(height, minCameraDistance)
         const largestDim = Math.max(adjustedBoardWidth, adjustedBoardHeight)
-        return [largestDim / 2, largestDim / 2, largestDim] as const
+        return [largestDim / 2, -largestDim / 2, largestDim] as const
       } catch (e) {
         console.error(e)
-        return [5, 5, 5] as const
+        return [5, -5, 5] as const
       }
     }, [internalCircuitJson])
 

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -255,12 +255,12 @@ try {
   }, [boardData])
 
   const initialCameraPosition = useMemo(() => {
-    if (!boardData) return [5, 5, 5] as const
+    if (!boardData) return [5, -5, 5] as const
     const { width = 0, height = 0 } = boardData
     const safeWidth = Math.max(width, 1)
     const safeHeight = Math.max(height, 1)
     const largestDim = Math.max(safeWidth, safeHeight, 5)
-    return [largestDim * 0.75, largestDim * 0.75, largestDim * 0.75] as const
+    return [largestDim * 0.75, -largestDim * 0.75, largestDim * 0.75] as const
   }, [boardData])
 
   if (manifoldLoadingError) {

--- a/src/hooks/useCameraController.ts
+++ b/src/hooks/useCameraController.ts
@@ -224,7 +224,7 @@ export const useCameraController = ({
   const controlsRef = useRef<ThreeOrbitControls | null>(null)
 
   const baseDistance = useMemo(() => {
-    const [x, y, z] = initialCameraPosition ?? [5, 5, 5]
+    const [x, y, z] = initialCameraPosition ?? [5, -5, 5]
     const distance = Math.hypot(
       x - defaultTarget.x,
       y - defaultTarget.y,


### PR DESCRIPTION
Before:
<img width="1062" height="553" alt="image" src="https://github.com/user-attachments/assets/c3f40458-b439-4af0-86a7-58537b52ae60" />


After: 
<img width="1122" height="537" alt="image" src="https://github.com/user-attachments/assets/ea4584ea-8089-4adb-8e25-0ddea2598710" />
