### PR TITLE
feat: add release-tracker integration to 3d-viewer

### DIFF
--- a/.github/workflows/on-merge-inform-release-tracker.yml
+++ b/.github/workflows/on-merge-inform-release-tracker.yml
@@ -1,0 +1,24 @@
+name: Release Tracker - Feature Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  track-feature-merge:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send feature merge event
+        continue-on-error: true
+        run: |
+          FEATURE_NAME=$(echo "${{ github.event.pull_request.user.login }}: ${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}" | jq -R .)
+          curl -X POST https://release-tracker.tscircuit.com/release_events/create \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"event\": {
+                \"event_type\": \"feature_merged\",
+                \"repo\": \"tscircuit/3d-viewer\",
+                \"feature_name\": $FEATURE_NAME
+              }
+            }"

--- a/.github/workflows/pver-release.yml
+++ b/.github/workflows/pver-release.yml
@@ -37,3 +37,19 @@ jobs:
             -H "Content-Type: application/json" \
             "https://api.github.com/repos/tscircuit/${{ env.UPSTREAM_REPO }}/actions/workflows/update-package.yml/dispatches" \
             -d "{\"ref\":\"main\",\"inputs\":{\"package_names\":\"${{ env.PACKAGE_NAMES }}\"}}"
+      - name: Notify release-tracker of version update
+        # Continue-on-error just in case the tracker is down
+        continue-on-error: true
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_JSON=$(cat package.json)
+          curl -X POST https://release-tracker.tscircuit.com/release_events/create \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"event\": {
+                \"event_type\": \"versions_updated\",
+                \"repo\": \"tscircuit/3d-viewer\",
+                \"version\": \"$VERSION\",
+                \"package_json\": $PACKAGE_JSON
+              }
+            }"


### PR DESCRIPTION
Integrate release-tracker into 3d-viewer workflows

- Add `on-merge-inform-release-tracker.yml` to send feature_merged events when PRs are merged
- Update `pver-release.yml` to notify release-tracker of version updates with package.json data
- Enables tracking of features as they flow through the tscircuit release pipeline