### PR TITLE
feat: add touch support for item hover in AppearanceMenu and ContextMenu

### DIFF
--- a/src/components/AppearanceMenu.tsx
+++ b/src/components/AppearanceMenu.tsx
@@ -79,6 +79,8 @@ export const AppearanceMenu = () => {
           }}
           onMouseEnter={() => setHoveredItem("appearance")}
           onMouseLeave={() => setHoveredItem(null)}
+          onTouchStart={() => setHoveredItem("appearance")}
+          onTouchEnd={() => setHoveredItem(null)}
         >
           <span style={{ flex: 1, display: "flex", alignItems: "center" }}>
             Appearance
@@ -114,6 +116,8 @@ export const AppearanceMenu = () => {
               }}
               onMouseEnter={() => setHoveredItem("boardBody")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("boardBody")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={iconContainerStyles}>
                 {visibility.boardBody && <CheckIcon />}
@@ -136,6 +140,8 @@ export const AppearanceMenu = () => {
               }}
               onMouseEnter={() => setHoveredItem("topCopper")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("topCopper")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={iconContainerStyles}>
                 {visibility.topCopper && <CheckIcon />}
@@ -158,6 +164,8 @@ export const AppearanceMenu = () => {
               }}
               onMouseEnter={() => setHoveredItem("bottomCopper")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("bottomCopper")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={iconContainerStyles}>
                 {visibility.bottomCopper && <CheckIcon />}
@@ -180,6 +188,8 @@ export const AppearanceMenu = () => {
               }}
               onMouseEnter={() => setHoveredItem("topSilkscreen")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("topSilkscreen")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={iconContainerStyles}>
                 {visibility.topSilkscreen && <CheckIcon />}
@@ -204,6 +214,8 @@ export const AppearanceMenu = () => {
               }}
               onMouseEnter={() => setHoveredItem("bottomSilkscreen")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("bottomSilkscreen")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={iconContainerStyles}>
                 {visibility.bottomSilkscreen && <CheckIcon />}
@@ -226,6 +238,8 @@ export const AppearanceMenu = () => {
               }}
               onMouseEnter={() => setHoveredItem("smtModels")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("smtModels")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={iconContainerStyles}>
                 {visibility.smtModels && <CheckIcon />}

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -147,6 +147,8 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
                 }}
                 onMouseEnter={() => setHoveredItem("camera")}
                 onMouseLeave={() => setHoveredItem(null)}
+                onTouchStart={() => setHoveredItem("camera")}
+                onTouchEnd={() => setHoveredItem(null)}
               >
                 <span
                   style={{ flex: 1, display: "flex", alignItems: "center" }}
@@ -189,6 +191,8 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
                       }}
                       onMouseEnter={() => setHoveredItem(option)}
                       onMouseLeave={() => setHoveredItem(null)}
+                      onTouchStart={() => setHoveredItem(option)}
+                      onTouchEnd={() => setHoveredItem(null)}
                     >
                       <span style={iconContainerStyles}>
                         {cameraPreset === option && <DotIcon />}
@@ -217,6 +221,8 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
               }}
               onMouseEnter={() => setHoveredItem("autorotate")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("autorotate")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={iconContainerStyles}>
                 {autoRotate && <CheckIcon />}
@@ -242,6 +248,8 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
               onSelect={onDownloadGltf}
               onMouseEnter={() => setHoveredItem("download")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("download")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={{ display: "flex", alignItems: "center" }}>
                 Download GLTF
@@ -265,6 +273,8 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
               }}
               onMouseEnter={() => setHoveredItem("engine")}
               onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("engine")}
+              onTouchEnd={() => setHoveredItem(null)}
             >
               <span style={{ flex: 1, display: "flex", alignItems: "center" }}>
                 Switch to {engine === "jscad" ? "Manifold" : "JSCAD"} Engine


### PR DESCRIPTION
This pull request improves the usability of both the `AppearanceMenu` and `ContextMenu` components by adding touch event handlers to menu items. This ensures that hover effects and item highlighting work correctly on touch devices, enhancing the user experience for mobile and tablet users.

**Touch support enhancements:**

* Added `onTouchStart` and `onTouchEnd` handlers to all interactive items in `AppearanceMenu`, allowing hover-like feedback when users interact via touch. [[1]](diffhunk://#diff-2c9f9bd1aa17fc40426e1d9d1609fd25345396c4de2441346dc1e179a1cccca6R82-R83) [[2]](diffhunk://#diff-2c9f9bd1aa17fc40426e1d9d1609fd25345396c4de2441346dc1e179a1cccca6R119-R120) [[3]](diffhunk://#diff-2c9f9bd1aa17fc40426e1d9d1609fd25345396c4de2441346dc1e179a1cccca6R143-R144) [[4]](diffhunk://#diff-2c9f9bd1aa17fc40426e1d9d1609fd25345396c4de2441346dc1e179a1cccca6R167-R168) [[5]](diffhunk://#diff-2c9f9bd1aa17fc40426e1d9d1609fd25345396c4de2441346dc1e179a1cccca6R191-R192) [[6]](diffhunk://#diff-2c9f9bd1aa17fc40426e1d9d1609fd25345396c4de2441346dc1e179a1cccca6R217-R218) [[7]](diffhunk://#diff-2c9f9bd1aa17fc40426e1d9d1609fd25345396c4de2441346dc1e179a1cccca6R241-R242)
* Added `onTouchStart` and `onTouchEnd` handlers to all interactive items in `ContextMenu`, including camera options, autorotate, download, and engine switch, for consistent touch interaction feedback. [[1]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR150-R151) [[2]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR194-R195) [[3]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR224-R225) [[4]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR251-R252) [[5]](diffhunk://#diff-0ca2cd2abd2988842053d6f6a78df9f366e0fa38e6011ea58bbfe024d4505abeR276-R277)