### PR TITLE
feat: add support for oval-shaped plated holes

### DIFF
--- a/stories/assets/pill_plated_holes.json
+++ b/stories/assets/pill_plated_holes.json
@@ -21,6 +21,21 @@
   },
   {
     "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_2",
+    "pcb_component_id": "pcb_component_1",
+    "x": 0,
+    "y": 2,
+    "port_hints": ["2"],
+    "shape": "oval",
+    "ccw_rotation": 0,
+    "hole_width": 3.2,
+    "hole_height": 1.2,
+    "outer_width": 4.8,
+    "outer_height": 2.4,
+    "layers": ["top", "bottom"]
+  },
+  {
+    "type": "pcb_plated_hole",
     "shape": "pill",
     "layers": ["top", "bottom"],
     "hole_width": 2.0,


### PR DESCRIPTION
## Description
This PR adds support for oval-shaped plated holes in the 3D viewer, implemented in both JSCAD and Manifold engines.

<img width="444" height="271" alt="Screenshot 2025-11-23 at 3 10 30 PM" src="https://github.com/user-attachments/assets/b0e877a6-96a8-408b-83d8-5e7faee08d11" />
<img width="333" height="253" alt="Screenshot 2025-11-23 at 3 10 50 PM" src="https://github.com/user-attachments/assets/6e09c709-4989-4c1e-a82d-235374f06c44" />
