### PR TITLE
Disable automatic zoom on camera position change

### DIFF
--- a/src/contexts/CameraControllerContext.tsx
+++ b/src/contexts/CameraControllerContext.tsx
@@ -126,8 +126,16 @@ export const CameraControllerProvider: React.FC<
         defaultTarget.y,
         defaultTarget.z,
       ] as const
-      const distance = baseDistance
-      const heightOffset = distance * 0.3
+      
+      let distance = baseDistance
+      if (mainCameraRef.current && controlsRef.current) {
+        const currentTarget = controlsRef.current.target
+        distance = Math.hypot(
+          mainCameraRef.current.position.x - currentTarget.x,
+          mainCameraRef.current.position.y - currentTarget.y,
+          mainCameraRef.current.position.z - currentTarget.z,
+        )
+      }
 
       switch (preset) {
         case "Top Center Angled": {
@@ -207,7 +215,7 @@ export const CameraControllerProvider: React.FC<
           return null
       }
     },
-    [baseDistance, defaultTarget],
+    [baseDistance, defaultTarget, mainCameraRef, controlsRef],
   )
 
   const handleControlsChange = useCallback(


### PR DESCRIPTION
Preserve current camera zoom level when selecting preset camera positions to prevent unwanted automatic zooming.

---
<a href="https://cursor.com/background-agent?bcId=bc-49fc9ea7-aca5-4377-bf6f-a48b7bfe9010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49fc9ea7-aca5-4377-bf6f-a48b7bfe9010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

