### PR TITLE
Respect cad component z offsets for faux boards

### DIFF
--- a/src/utils/preprocess-circuit-json.ts
+++ b/src/utils/preprocess-circuit-json.ts
@@ -33,12 +33,13 @@ export function addFauxBoardIfNeeded(
     if (element.type === "cad_component") {
       const cadComponent = element as CadComponent
       if (cadComponent.position) {
+        const positionZOffset = cadComponent.position.z ?? 0
         // Set z position to componentZ, preserving x and y
         return {
           ...cadComponent,
           position: {
             ...cadComponent.position,
-            z: componentZ,
+            z: positionZOffset + componentZ,
           },
         }
       }

--- a/tests/preprocess-circuit-json.test.ts
+++ b/tests/preprocess-circuit-json.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import type { CadComponent } from "circuit-json"
+import { addFauxBoardIfNeeded } from "../src/utils/preprocess-circuit-json"
+
+const createCadComponent = (z: number): CadComponent => ({
+  type: "cad_component",
+  cad_component_id: "cad-1",
+  pcb_component_id: "pcb-1",
+  source_component_id: "source-1",
+  position: { x: 0, y: 0, z },
+})
+
+test("adds faux board and defaults cad component z to half board thickness", () => {
+  const result = addFauxBoardIfNeeded([createCadComponent(0)])
+
+  const updatedComponent = result.find(
+    (element) => element.type === "cad_component",
+  ) as CadComponent
+
+  expect(updatedComponent.position?.z).toBeCloseTo(0.8)
+  expect(
+    result.some(
+      (element) =>
+        element.type === "pcb_board" && element.pcb_board_id === "faux-board",
+    ),
+  ).toBeTrue()
+})
+
+test("respects existing cad component z offsets when adding faux board", () => {
+  const result = addFauxBoardIfNeeded([createCadComponent(1)])
+
+  const updatedComponent = result.find(
+    (element) => element.type === "cad_component",
+  ) as CadComponent
+
+  expect(updatedComponent.position?.z).toBeCloseTo(1.8)
+})


### PR DESCRIPTION
## Summary
- keep cad component vertical offsets when generating faux boards
- document faux board default z handling with new tests

## Testing
- bun test tests/preprocess-circuit-json.test.ts
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f580e449c832eba66f6db7fb8342e)