### PR TITLE
Fix: alignment of elements in the context menu

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -213,7 +213,6 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
             <DropdownMenu.Item
               style={{
                 ...itemStyles,
-                ...itemPaddingStyles,
                 backgroundColor:
                   hoveredItem === "autorotate" ? "#404040" : "transparent",
               }}
@@ -238,7 +237,6 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
             <DropdownMenu.Item
               style={{
                 ...itemStyles,
-                ...itemPaddingStyles,
                 backgroundColor:
                   hoveredItem === "cameratype" ? "#404040" : "transparent",
               }}


### PR DESCRIPTION
**Before**
<img width="356" height="411" alt="image" src="https://github.com/user-attachments/assets/a074bbb5-8eb8-4ebb-bf66-a524eb41b551" />


**After**
<img width="374" height="383" alt="image" src="https://github.com/user-attachments/assets/c0be3366-9ad4-4909-8897-8ffc51b256a1" />
