### PR TITLE
feat: add pcb_copper_text support with knockout and proper mirroring

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -7,11 +7,6 @@ import type {
   PcbSmtPad,
   PcbTrace,
   PcbVia,
-  PcbSilkscreenText,
-  PcbSilkscreenPath,
-  PcbSilkscreenLine,
-  PcbSilkscreenRect,
-  PcbSilkscreenCircle,
   PcbCutout,
   PcbCopperPour,
   PcbPanel,
@@ -46,11 +41,7 @@ import {
   arePointsClockwise,
 } from "./geoms/create-board-with-outline"
 import type { Vec2 } from "@jscad/modeling/src/maths/types"
-import { createSilkscreenTextGeoms } from "./geoms/create-geoms-for-silkscreen-text"
-import { createSilkscreenPathGeom } from "./geoms/create-geoms-for-silkscreen-path"
-import { createSilkscreenLineGeom } from "./geoms/create-geoms-for-silkscreen-line"
-import { createSilkscreenRectGeom } from "./geoms/create-geoms-for-silkscreen-rect"
-import { createSilkscreenCircleGeom } from "./geoms/create-geoms-for-silkscreen-circle"
+
 import { createGeom2FromBRep } from "./geoms/brep-converter"
 import type { GeomContext } from "./GeomContext"
 import {
@@ -92,11 +83,6 @@ type BuilderState =
   | "processing_pads"
   | "processing_traces"
   | "processing_vias"
-  | "processing_silkscreen_text"
-  | "processing_silkscreen_lines"
-  | "processing_silkscreen_circles"
-  | "processing_silkscreen_rects"
-  | "processing_silkscreen_paths"
   | "processing_cutouts"
   | "processing_copper_pours"
   | "finalizing"
@@ -113,11 +99,6 @@ const buildStateOrder: BuilderState[] = [
 
   "processing_traces",
   "processing_vias",
-  "processing_silkscreen_text",
-  "processing_silkscreen_lines",
-  "processing_silkscreen_circles",
-  "processing_silkscreen_rects",
-  "processing_silkscreen_paths",
   "finalizing",
   "done",
 ]
@@ -130,11 +111,6 @@ export class BoardGeomBuilder {
   private pads: PcbSmtPad[]
   private traces: PcbTrace[]
   private pcb_vias: PcbVia[]
-  private silkscreenTexts: PcbSilkscreenText[]
-  private silkscreenPaths: PcbSilkscreenPath[]
-  private silkscreenLines: PcbSilkscreenLine[]
-  private silkscreenCircles: PcbSilkscreenCircle[]
-  private silkscreenRects: PcbSilkscreenRect[]
   private pcb_cutouts: PcbCutout[]
   private pcb_copper_pours: PcbCopperPour[]
 
@@ -143,11 +119,6 @@ export class BoardGeomBuilder {
   private padGeoms: Geom3[] = []
   private traceGeoms: Geom3[] = []
   private viaGeoms: Geom3[] = [] // Combined with platedHoleGeoms
-  private silkscreenTextGeoms: Geom3[] = []
-  private silkscreenPathGeoms: Geom3[] = []
-  private silkscreenLineGeoms: Geom3[] = []
-  private silkscreenCircleGeoms: Geom3[] = []
-  private silkscreenRectGeoms: Geom3[] = []
   private copperPourGeoms: Geom3[] = []
   private boardClipGeom: Geom3 | null = null
 
@@ -219,11 +190,6 @@ export class BoardGeomBuilder {
     this.pads = su(circuitJson).pcb_smtpad.list()
     this.traces = su(circuitJson).pcb_trace.list()
     this.pcb_vias = su(circuitJson).pcb_via.list()
-    this.silkscreenTexts = su(circuitJson).pcb_silkscreen_text.list()
-    this.silkscreenPaths = su(circuitJson).pcb_silkscreen_path.list()
-    this.silkscreenLines = su(circuitJson).pcb_silkscreen_line.list()
-    this.silkscreenCircles = su(circuitJson).pcb_silkscreen_circle.list()
-    this.silkscreenRects = su(circuitJson).pcb_silkscreen_rect.list()
     this.pcb_cutouts = su(circuitJson).pcb_cutout.list()
     this.pcb_copper_pours = circuitJson.filter(
       (e) => e.type === "pcb_copper_pour",
@@ -325,53 +291,6 @@ export class BoardGeomBuilder {
         case "processing_vias":
           if (this.currentIndex < this.pcb_vias.length) {
             this.processVia(this.pcb_vias[this.currentIndex]!)
-            this.currentIndex++
-          } else {
-            this.goToNextState()
-          }
-          break
-
-        case "processing_silkscreen_text":
-          if (this.currentIndex < this.silkscreenTexts.length) {
-            this.processSilkscreenText(this.silkscreenTexts[this.currentIndex]!)
-            this.currentIndex++
-          } else {
-            this.goToNextState()
-          }
-          break
-
-        case "processing_silkscreen_lines":
-          if (this.currentIndex < this.silkscreenLines.length) {
-            this.processSilkscreenLine(this.silkscreenLines[this.currentIndex]!)
-            this.currentIndex++
-          } else {
-            this.goToNextState()
-          }
-          break
-
-        case "processing_silkscreen_circles":
-          if (this.currentIndex < this.silkscreenCircles.length) {
-            this.processSilkscreenCircle(
-              this.silkscreenCircles[this.currentIndex]!,
-            )
-            this.currentIndex++
-          } else {
-            this.goToNextState()
-          }
-          break
-
-        case "processing_silkscreen_rects":
-          if (this.currentIndex < this.silkscreenRects.length) {
-            this.processSilkscreenRect(this.silkscreenRects[this.currentIndex]!)
-            this.currentIndex++
-          } else {
-            this.goToNextState()
-          }
-          break
-
-        case "processing_silkscreen_paths":
-          if (this.currentIndex < this.silkscreenPaths.length) {
-            this.processSilkscreenPath(this.silkscreenPaths[this.currentIndex]!)
             this.currentIndex++
           } else {
             this.goToNextState()
@@ -1027,70 +946,6 @@ export class BoardGeomBuilder {
     }
   }
 
-  private processSilkscreenText(st: PcbSilkscreenText) {
-    const { textOutlines, xOffset, yOffset } = createSilkscreenTextGeoms(st)
-
-    for (const outline of textOutlines) {
-      const alignedOutline = outline.map((point) => [
-        point[0] + xOffset + st.anchor_position.x,
-        point[1] + yOffset + st.anchor_position.y,
-      ]) as Vec2[]
-      const textPath = line(alignedOutline)
-
-      const fontSize = st.font_size || 0.25
-      const expansionDelta = Math.min(
-        Math.max(0.01, fontSize * 0.1),
-        fontSize * 0.05,
-      )
-      const expandedPath = expand(
-        { delta: expansionDelta, corners: "round" },
-        textPath,
-      )
-      let textGeom: any
-      if (st.layer === "bottom") {
-        textGeom = translate(
-          [0, 0, -this.ctx.pcbThickness / 2 - M], // Position above board
-          extrudeLinear({ height: 0.012 }, expandedPath),
-        )
-      } else {
-        textGeom = translate(
-          [0, 0, this.ctx.pcbThickness / 2 + M], // Position above board
-          extrudeLinear({ height: 0.012 }, expandedPath),
-        )
-      }
-      textGeom = colorize([1, 1, 1], textGeom) // White
-      this.silkscreenTextGeoms.push(textGeom)
-    }
-  }
-
-  private processSilkscreenPath(sp: PcbSilkscreenPath) {
-    const pathGeom = createSilkscreenPathGeom(sp, this.ctx)
-    if (pathGeom) {
-      this.silkscreenPathGeoms.push(pathGeom)
-    }
-  }
-
-  private processSilkscreenLine(sl: PcbSilkscreenLine) {
-    const lineGeom = createSilkscreenLineGeom(sl, this.ctx)
-    if (lineGeom) {
-      this.silkscreenLineGeoms.push(lineGeom)
-    }
-  }
-
-  private processSilkscreenCircle(sc: PcbSilkscreenCircle) {
-    const circleGeom = createSilkscreenCircleGeom(sc, this.ctx)
-    if (circleGeom) {
-      this.silkscreenCircleGeoms.push(circleGeom)
-    }
-  }
-
-  private processSilkscreenRect(sr: PcbSilkscreenRect) {
-    const rectGeom = createSilkscreenRectGeom(sr, this.ctx)
-    if (rectGeom) {
-      this.silkscreenRectGeoms.push(rectGeom)
-    }
-  }
-
   private finalize() {
     if (!this.boardGeom) return
     // Colorize the final board geometry
@@ -1105,11 +960,6 @@ export class BoardGeomBuilder {
       ...this.traceGeoms,
       ...this.viaGeoms,
       ...this.copperPourGeoms,
-      ...this.silkscreenTextGeoms,
-      ...this.silkscreenLineGeoms,
-      ...this.silkscreenCircleGeoms,
-      ...this.silkscreenRectGeoms,
-      ...this.silkscreenPathGeoms,
     ]
 
     if (this.onCompleteCallback) {

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -117,6 +117,14 @@ const BoardMeshes = ({
       else if (mesh.name.includes("bottom-soldermask")) {
         shouldShow = visibility.bottomMask
       }
+      // Top copper text
+      else if (mesh.name.includes("top-copper-text")) {
+        shouldShow = visibility.topCopper
+      }
+      // Bottom copper text
+      else if (mesh.name.includes("bottom-copper-text")) {
+        shouldShow = visibility.bottomCopper
+      }
 
       if (shouldShow) {
         rootObject.add(mesh)

--- a/src/geoms/constants.ts
+++ b/src/geoms/constants.ts
@@ -23,7 +23,7 @@ export const colors = {
 export const MANIFOLD_Z_OFFSET = 0.001 // Small offset to prevent Z-fighting
 export const SMOOTH_CIRCLE_SEGMENTS = 32 // Number of segments for smooth circles
 export const DEFAULT_SMT_PAD_THICKNESS = 0.035 // Typical 1oz copper thickness in mm
-export const TRACE_TEXTURE_RESOLUTION = 50 // pixels per mm for trace texture
+export const TRACE_TEXTURE_RESOLUTION = 150 // pixels per mm for trace texture
 export const boardMaterialColors: Record<PcbBoard["material"], RGB> = {
   fr1: colors.fr1Tan,
   fr4: colors.fr4Tan,

--- a/src/geoms/create-geoms-for-copper-text.ts
+++ b/src/geoms/create-geoms-for-copper-text.ts
@@ -1,0 +1,154 @@
+import { vectorText } from "@jscad/modeling/src/text"
+import {
+  compose,
+  translate,
+  rotate,
+  applyToPoint,
+  Matrix,
+} from "transformation-matrix"
+
+/**
+ * Defines copper text on the PCB - local type definition
+ * since this may not exist in circuit-json yet
+ */
+export interface PcbCopperText {
+  type: "pcb_copper_text"
+  pcb_copper_text_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  font: "tscircuit2024"
+  font_size: number | string
+  pcb_component_id: string
+  text: string
+  is_knockout?: boolean
+  knockout_padding?: {
+    left: number | string
+    top: number | string
+    bottom: number | string
+    right: number | string
+  }
+  ccw_rotation?: number
+  layer: "top" | "bottom"
+  is_mirrored?: boolean
+  anchor_position: { x: number; y: number }
+  anchor_alignment?: string
+}
+
+// Generate 2D text outlines for copper text
+export function createCopperTextGeoms(copperText: PcbCopperText) {
+  const fontSize =
+    typeof copperText.font_size === "number" ? copperText.font_size : 0.2 // Default 0.2mm
+
+  const textOutlines = vectorText({
+    height: fontSize * 0.45,
+    input: copperText.text,
+  })
+
+  let rotationDegrees = copperText.ccw_rotation ?? 0
+
+  // Split number 8 and small e into two parts to fix visual issues
+  textOutlines.forEach((outline) => {
+    if (outline.length === 29) {
+      textOutlines.splice(
+        textOutlines.indexOf(outline),
+        1,
+        outline.slice(0, 15),
+      )
+      textOutlines.splice(
+        textOutlines.indexOf(outline),
+        0,
+        outline.slice(14, 29),
+      )
+    } else if (outline.length === 17) {
+      textOutlines.splice(
+        textOutlines.indexOf(outline),
+        1,
+        outline.slice(0, 10),
+      )
+      textOutlines.splice(
+        textOutlines.indexOf(outline),
+        0,
+        outline.slice(9, 17),
+      )
+    }
+  })
+
+  // Calculate text bounds and center point
+  const points = textOutlines.flatMap((o) => o)
+  const textBounds = {
+    minX: Math.min(...points.map((p) => p[0])),
+    maxX: Math.max(...points.map((p) => p[0])),
+    minY: Math.min(...points.map((p) => p[1])),
+    maxY: Math.max(...points.map((p) => p[1])),
+  }
+  const centerX = (textBounds.minX + textBounds.maxX) / 2
+  const centerY = (textBounds.minY + textBounds.maxY) / 2
+
+  // Calculate offset based on anchor alignment
+  let xOffset = -centerX
+  let yOffset = -centerY
+
+  const anchorAlignment = copperText.anchor_alignment ?? "center"
+
+  if (anchorAlignment.includes("right")) {
+    xOffset = -textBounds.maxX
+  } else if (anchorAlignment.includes("left")) {
+    xOffset = -textBounds.minX
+  }
+
+  if (anchorAlignment.includes("top")) {
+    yOffset = -textBounds.maxY
+  } else if (anchorAlignment.includes("bottom")) {
+    yOffset = -textBounds.minY
+  }
+
+  // Compose transform: mirror if bottom layer or is_mirrored, then apply rotation
+  const transforms: Matrix[] = []
+
+  // Handle mirroring:
+  // - Bottom layer: auto-mirror unless is_mirrored is explicitly false
+  // - Top layer: only mirror if is_mirrored is explicitly true
+  const shouldMirror =
+    copperText.layer === "bottom"
+      ? copperText.is_mirrored !== false
+      : copperText.is_mirrored === true
+
+  if (shouldMirror) {
+    transforms.push(
+      translate(centerX, centerY),
+      { a: -1, b: 0, c: 0, d: 1, e: 0, f: 0 }, // horizontal flip matrix
+      translate(-centerX, -centerY),
+    )
+
+    // Reverse the rotation direction for mirrored text
+    rotationDegrees = -rotationDegrees
+  }
+
+  // Apply rotation if rotation degrees are specified
+  if (rotationDegrees) {
+    const rad = (rotationDegrees * Math.PI) / 180
+    transforms.push(
+      translate(centerX, centerY),
+      rotate(rad),
+      translate(-centerX, -centerY),
+    )
+  }
+
+  let transformedOutlines = textOutlines
+
+  if (transforms.length > 0) {
+    const matrix = compose(...transforms)
+    transformedOutlines = textOutlines.map((outline) =>
+      outline.map(([x, y]) => {
+        const { x: nx, y: ny } = applyToPoint(matrix, { x, y })
+        return [nx, ny]
+      }),
+    )
+  }
+
+  return {
+    textOutlines: transformedOutlines,
+    xOffset,
+    yOffset,
+  }
+}

--- a/src/hooks/useManifoldBoardBuilder.ts
+++ b/src/hooks/useManifoldBoardBuilder.ts
@@ -36,6 +36,7 @@ import { manifoldMeshToThreeGeometry } from "../utils/manifold-mesh-to-three-geo
 import { createSilkscreenTextureForLayer } from "../utils/silkscreen-texture"
 import { createSoldermaskTextureForLayer } from "../utils/soldermask-texture"
 import { createTraceTextureForLayer } from "../utils/trace-texture"
+import { createCopperTextTextureForLayer } from "../utils/copper-text-texture"
 
 export interface ManifoldGeoms {
   board?: {
@@ -75,6 +76,8 @@ export interface ManifoldTextures {
   bottomSilkscreen?: THREE.CanvasTexture | null
   topSoldermask?: THREE.CanvasTexture | null
   bottomSoldermask?: THREE.CanvasTexture | null
+  topCopperText?: THREE.CanvasTexture | null
+  bottomCopperText?: THREE.CanvasTexture | null
 }
 
 interface UseManifoldBoardBuilderResult {
@@ -448,6 +451,25 @@ export const useManifoldBoardBuilder = (
         soldermaskColor,
         traceTextureResolution: TRACE_TEXTURE_RESOLUTION,
       })
+
+      // --- Process Copper Text (as Textures) ---
+      const copperColorArr = defaultColors.copper
+      const copperColor = `rgb(${Math.round(copperColorArr[0] * 255)}, ${Math.round(copperColorArr[1] * 255)}, ${Math.round(copperColorArr[2] * 255)})`
+      currentTextures.topCopperText = createCopperTextTextureForLayer({
+        layer: "top",
+        circuitJson,
+        boardData,
+        copperColor,
+        traceTextureResolution: TRACE_TEXTURE_RESOLUTION,
+      })
+      currentTextures.bottomCopperText = createCopperTextTextureForLayer({
+        layer: "bottom",
+        circuitJson,
+        boardData,
+        copperColor,
+        traceTextureResolution: TRACE_TEXTURE_RESOLUTION,
+      })
+
       setTextures(currentTextures)
     } catch (e: any) {
       console.error("Error processing geometry with Manifold in hook:", e)

--- a/src/three-components/JscadBoardTextures.tsx
+++ b/src/three-components/JscadBoardTextures.tsx
@@ -7,10 +7,12 @@ import { useLayerVisibility } from "../contexts/LayerVisibilityContext"
 import { createSoldermaskTextureForLayer } from "../utils/soldermask-texture"
 import { createSilkscreenTextureForLayer } from "../utils/silkscreen-texture"
 import { createTraceTextureForLayer } from "../utils/trace-texture"
+import { createCopperTextTextureForLayer } from "../utils/copper-text-texture"
 import {
   colors as defaultColors,
   soldermaskColors,
   TRACE_TEXTURE_RESOLUTION,
+  BOARD_SURFACE_OFFSET,
 } from "../geoms/constants"
 
 interface JscadBoardTexturesProps {
@@ -86,6 +88,20 @@ export function JscadBoardTextures({
         circuitJson,
         boardData,
         traceColor: traceColorWithMask,
+        traceTextureResolution: TRACE_TEXTURE_RESOLUTION,
+      }),
+      topCopperText: createCopperTextTextureForLayer({
+        layer: "top",
+        circuitJson,
+        boardData,
+        copperColor: `rgb(${Math.round(defaultColors.copper[0] * 255)}, ${Math.round(defaultColors.copper[1] * 255)}, ${Math.round(defaultColors.copper[2] * 255)})`,
+        traceTextureResolution: TRACE_TEXTURE_RESOLUTION,
+      }),
+      bottomCopperText: createCopperTextTextureForLayer({
+        layer: "bottom",
+        circuitJson,
+        boardData,
+        copperColor: `rgb(${Math.round(defaultColors.copper[0] * 255)}, ${Math.round(defaultColors.copper[1] * 255)}, ${Math.round(defaultColors.copper[2] * 255)})`,
         traceTextureResolution: TRACE_TEXTURE_RESOLUTION,
       }),
     }
@@ -212,6 +228,34 @@ export function JscadBoardTextures({
       if (bottomSilkscreenMesh) {
         meshes.push(bottomSilkscreenMesh)
         rootObject.add(bottomSilkscreenMesh)
+      }
+    }
+
+    // Top copper text
+    if (visibility.topCopper) {
+      const topCopperTextMesh = createTexturePlane(
+        textures.topCopperText,
+        pcbThickness / 2 + BOARD_SURFACE_OFFSET.copper,
+        false,
+        "jscad-top-copper-text",
+      )
+      if (topCopperTextMesh) {
+        meshes.push(topCopperTextMesh)
+        rootObject.add(topCopperTextMesh)
+      }
+    }
+
+    // Bottom copper text
+    if (visibility.bottomCopper) {
+      const bottomCopperTextMesh = createTexturePlane(
+        textures.bottomCopperText,
+        -pcbThickness / 2 - BOARD_SURFACE_OFFSET.copper,
+        true,
+        "jscad-bottom-copper-text",
+      )
+      if (bottomCopperTextMesh) {
+        meshes.push(bottomCopperTextMesh)
+        rootObject.add(bottomCopperTextMesh)
       }
     }
 

--- a/src/utils/copper-text-texture.ts
+++ b/src/utils/copper-text-texture.ts
@@ -1,0 +1,387 @@
+import * as THREE from "three"
+import { vectorText } from "@jscad/modeling/src/text"
+import {
+  compose,
+  translate,
+  rotate,
+  applyToPoint,
+  Matrix,
+} from "transformation-matrix"
+import type { AnyCircuitElement } from "circuit-json"
+import type { PcbCopperText } from "../geoms/create-geoms-for-copper-text"
+
+/**
+ * Parse a dimension value that could be a number or string (e.g., "0.5mm")
+ */
+function parseDimension(
+  value: number | string | undefined,
+  defaultValue: number,
+): number {
+  if (value === undefined) return defaultValue
+  if (typeof value === "number") return value
+  // Simple parsing - strip 'mm' suffix if present
+  const num = parseFloat(value.replace(/mm$/, ""))
+  return isNaN(num) ? defaultValue : num
+}
+
+/**
+ * Determine if text should be mirrored based on layer and is_mirrored property
+ * - Bottom layer: auto-mirror unless is_mirrored is explicitly false
+ * - Top layer: only mirror if is_mirrored is explicitly true
+ */
+function shouldMirrorText(text: PcbCopperText): boolean {
+  if (text.layer === "bottom") {
+    // Bottom layer should auto-mirror unless explicitly set to false
+    return text.is_mirrored !== false
+  }
+  // For top layer, only mirror if explicitly requested
+  return text.is_mirrored === true
+}
+
+/**
+ * Get text metrics (bounds and dimensions) from text outlines
+ */
+function getTextMetrics(outlines: Array<Array<[number, number]>>) {
+  const points = outlines.flat()
+  if (points.length === 0) {
+    return {
+      minX: 0,
+      maxX: 0,
+      minY: 0,
+      maxY: 0,
+      width: 0,
+      height: 0,
+      centerX: 0,
+      centerY: 0,
+    }
+  }
+  const minX = Math.min(...points.map((p) => p[0]))
+  const maxX = Math.max(...points.map((p) => p[0]))
+  const minY = Math.min(...points.map((p) => p[1]))
+  const maxY = Math.max(...points.map((p) => p[1]))
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    width: maxX - minX,
+    height: maxY - minY,
+    centerX: (minX + maxX) / 2,
+    centerY: (minY + maxY) / 2,
+  }
+}
+
+/**
+ * Process raw text outlines to fix visual issues with certain characters
+ */
+function processTextOutlines(
+  rawOutlines: any[],
+): Array<Array<[number, number]>> {
+  const processed: Array<Array<[number, number]>> = []
+  rawOutlines.forEach((outline: any) => {
+    // Split number 8 and small e into two parts to fix visual issues
+    if (outline.length === 29) {
+      processed.push(outline.slice(0, 15) as Array<[number, number]>)
+      processed.push(outline.slice(14, 29) as Array<[number, number]>)
+    } else if (outline.length === 17) {
+      processed.push(outline.slice(0, 10) as Array<[number, number]>)
+      processed.push(outline.slice(9, 17) as Array<[number, number]>)
+    } else {
+      processed.push(outline as Array<[number, number]>)
+    }
+  })
+  return processed
+}
+
+/**
+ * Calculate alignment offset based on text bounds and anchor alignment
+ */
+function getAlignmentOffset(
+  metrics: ReturnType<typeof getTextMetrics>,
+  alignment: string,
+): { x: number; y: number } {
+  let xOff = -metrics.centerX // default: center
+  let yOff = -metrics.centerY // default: center
+
+  // Horizontal alignment
+  if (alignment.includes("left")) {
+    xOff = -metrics.minX
+  } else if (alignment.includes("right")) {
+    xOff = -metrics.maxX
+  }
+
+  // Vertical alignment
+  if (alignment.includes("top")) {
+    yOff = -metrics.maxY
+  } else if (alignment.includes("bottom")) {
+    yOff = -metrics.minY
+  }
+
+  return { x: xOff, y: yOff }
+}
+
+/**
+ * Build transformation matrix for text (mirroring + rotation)
+ */
+function buildTransformMatrix(
+  text: PcbCopperText,
+  metrics: ReturnType<typeof getTextMetrics>,
+): { matrix: Matrix | undefined; rotationDeg: number } {
+  const transformMatrices: Matrix[] = []
+  let rotationDeg = text.ccw_rotation ?? 0
+
+  const shouldMirror = shouldMirrorText(text)
+  if (shouldMirror) {
+    // Mirror around center point
+    transformMatrices.push(
+      translate(metrics.centerX, metrics.centerY),
+      { a: -1, b: 0, c: 0, d: 1, e: 0, f: 0 }, // horizontal flip
+      translate(-metrics.centerX, -metrics.centerY),
+    )
+    // Reverse rotation direction for mirrored text
+    rotationDeg = -rotationDeg
+  }
+
+  if (rotationDeg) {
+    const rad = (rotationDeg * Math.PI) / 180
+    transformMatrices.push(
+      translate(metrics.centerX, metrics.centerY),
+      rotate(rad),
+      translate(-metrics.centerX, -metrics.centerY),
+    )
+  }
+
+  const matrix =
+    transformMatrices.length > 0 ? compose(...transformMatrices) : undefined
+  return { matrix, rotationDeg }
+}
+
+/**
+ * Draw text strokes on canvas
+ */
+function drawTextStrokes(
+  ctx: CanvasRenderingContext2D,
+  outlines: Array<Array<[number, number]>>,
+  transform: Matrix | undefined,
+  offset: { x: number; y: number },
+  anchorPos: { x: number; y: number },
+  canvasXFromPcb: (x: number) => number,
+  canvasYFromPcb: (y: number) => number,
+) {
+  outlines.forEach((segment) => {
+    ctx.beginPath()
+    segment.forEach((p, index) => {
+      let transformedP = { x: p[0], y: p[1] }
+      if (transform) {
+        transformedP = applyToPoint(transform, transformedP)
+      }
+      const pcbX = transformedP.x + offset.x + anchorPos.x
+      const pcbY = transformedP.y + offset.y + anchorPos.y
+      const canvasX = canvasXFromPcb(pcbX)
+      const canvasY = canvasYFromPcb(pcbY)
+      if (index === 0) ctx.moveTo(canvasX, canvasY)
+      else ctx.lineTo(canvasX, canvasY)
+    })
+    ctx.stroke()
+  })
+}
+
+/**
+ * Draw a rotated rectangle on canvas
+ */
+function drawRotatedRect(
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  centerY: number,
+  width: number,
+  height: number,
+  rotationRad: number,
+) {
+  ctx.save()
+  ctx.translate(centerX, centerY)
+  ctx.rotate(-rotationRad) // Canvas rotation is clockwise, we use CCW
+  ctx.fillRect(-width / 2, -height / 2, width, height)
+  ctx.restore()
+}
+
+/**
+ * Draw knockout text - a filled rectangle with text cut out
+ */
+function drawKnockoutText(
+  ctx: CanvasRenderingContext2D,
+  text: PcbCopperText,
+  outlines: Array<Array<[number, number]>>,
+  metrics: ReturnType<typeof getTextMetrics>,
+  transform: Matrix | undefined,
+  rotationDeg: number,
+  canvasXFromPcb: (x: number) => number,
+  canvasYFromPcb: (y: number) => number,
+  traceTextureResolution: number,
+  copperColor: string,
+) {
+  const fontSize = typeof text.font_size === "number" ? text.font_size : 0.2
+
+  // Parse knockout padding (defaults based on font size, matching pcb-viewer)
+  const padding = {
+    left: parseDimension(text.knockout_padding?.left, fontSize * 0.5),
+    right: parseDimension(text.knockout_padding?.right, fontSize * 0.5),
+    top: parseDimension(text.knockout_padding?.top, fontSize * 0.3),
+    bottom: parseDimension(text.knockout_padding?.bottom, fontSize * 0.3),
+  }
+
+  // Calculate rectangle dimensions
+  const rectWidth = metrics.width + padding.left + padding.right
+  const rectHeight = metrics.height + padding.top + padding.bottom
+
+  // Rectangle is centered at anchor position
+  const rectCenterCanvasX = canvasXFromPcb(text.anchor_position.x)
+  const rectCenterCanvasY = canvasYFromPcb(text.anchor_position.y)
+  const rectWidthPx = rectWidth * traceTextureResolution
+  const rectHeightPx = rectHeight * traceTextureResolution
+
+  // Draw filled rectangle (apply rotation if any)
+  ctx.fillStyle = copperColor
+  const rotationRad = (rotationDeg * Math.PI) / 180
+  drawRotatedRect(
+    ctx,
+    rectCenterCanvasX,
+    rectCenterCanvasY,
+    rectWidthPx,
+    rectHeightPx,
+    rotationRad,
+  )
+
+  // Calculate text offset to center it in the rectangle
+  // For knockout, text is always centered in the rectangle
+  const textOffset = {
+    x: -metrics.centerX,
+    y: -metrics.centerY,
+  }
+
+  // Switch to "cut out" mode - drawing will remove pixels
+  ctx.globalCompositeOperation = "destination-out"
+
+  // Draw text strokes (will cut holes in the rectangle)
+  drawTextStrokes(
+    ctx,
+    outlines,
+    transform,
+    textOffset,
+    text.anchor_position,
+    canvasXFromPcb,
+    canvasYFromPcb,
+  )
+
+  // Reset to normal mode
+  ctx.globalCompositeOperation = "source-over"
+}
+
+export function createCopperTextTextureForLayer({
+  layer,
+  circuitJson,
+  boardData,
+  copperColor = "rgb(230, 153, 51)", // Same as colors.copper [0.9, 0.6, 0.2]
+  traceTextureResolution,
+}: {
+  layer: "top" | "bottom"
+  circuitJson: AnyCircuitElement[]
+  boardData: any
+  copperColor?: string
+  traceTextureResolution: number
+}): THREE.CanvasTexture | null {
+  const copperTexts = circuitJson.filter(
+    (e) => e.type === "pcb_copper_text",
+  ) as PcbCopperText[]
+
+  const textsOnLayer = copperTexts.filter((t) => t.layer === layer)
+
+  if (textsOnLayer.length === 0) {
+    return null
+  }
+
+  const canvas = document.createElement("canvas")
+  const canvasWidth = Math.floor(boardData.width * traceTextureResolution)
+  const canvasHeight = Math.floor(boardData.height * traceTextureResolution)
+  canvas.width = canvasWidth
+  canvas.height = canvasHeight
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return null
+
+  if (layer === "bottom") {
+    ctx.translate(0, canvasHeight)
+    ctx.scale(1, -1)
+  }
+
+  ctx.strokeStyle = copperColor
+  ctx.fillStyle = copperColor
+
+  const canvasXFromPcb = (pcbX: number) =>
+    (pcbX - boardData.center.x + boardData.width / 2) * traceTextureResolution
+  const canvasYFromPcb = (pcbY: number) =>
+    (-(pcbY - boardData.center.y) + boardData.height / 2) *
+    traceTextureResolution
+
+  // Draw each copper text
+  textsOnLayer.forEach((textS: PcbCopperText) => {
+    const fontSize = typeof textS.font_size === "number" ? textS.font_size : 0.2
+
+    // Stroke width for text
+    const textStrokeWidth =
+      Math.max(0.02, fontSize * 0.08) * traceTextureResolution
+    ctx.lineWidth = textStrokeWidth
+    ctx.lineCap = "round"
+    ctx.lineJoin = "round"
+
+    // Generate text outlines
+    const rawTextOutlines = vectorText({
+      height: fontSize * 0.45,
+      input: textS.text,
+    })
+    const processedOutlines = processTextOutlines(rawTextOutlines)
+    const metrics = getTextMetrics(processedOutlines)
+
+    // Build transformation matrix
+    const { matrix: transform, rotationDeg } = buildTransformMatrix(
+      textS,
+      metrics,
+    )
+
+    if (textS.is_knockout) {
+      // Draw knockout text (filled rect with text cut out)
+      drawKnockoutText(
+        ctx,
+        textS,
+        processedOutlines,
+        metrics,
+        transform,
+        rotationDeg,
+        canvasXFromPcb,
+        canvasYFromPcb,
+        traceTextureResolution,
+        copperColor,
+      )
+    } else {
+      // Draw normal text
+      const alignment = textS.anchor_alignment || "center"
+      const offset = getAlignmentOffset(metrics, alignment)
+
+      drawTextStrokes(
+        ctx,
+        processedOutlines,
+        transform,
+        offset,
+        textS.anchor_position,
+        canvasXFromPcb,
+        canvasYFromPcb,
+      )
+    }
+  })
+
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.generateMipmaps = true
+  texture.minFilter = THREE.LinearMipmapLinearFilter
+  texture.magFilter = THREE.LinearFilter
+  texture.anisotropy = 16
+  texture.needsUpdate = true
+  return texture
+}

--- a/src/utils/manifold/create-three-texture-meshes.ts
+++ b/src/utils/manifold/create-three-texture-meshes.ts
@@ -125,5 +125,26 @@ export function createTextureMeshes(
   )
   if (bottomSoldermaskMesh) meshes.push(bottomSoldermaskMesh)
 
+  // Copper text meshes - positioned at copper layer (same as traces/pads)
+  const topCopperTextMesh = createTexturePlane(
+    textures.topCopperText,
+    pcbThickness / 2 + BOARD_SURFACE_OFFSET.copper,
+    false,
+    "copper-text",
+    false,
+    2, // Render after soldermask
+  )
+  if (topCopperTextMesh) meshes.push(topCopperTextMesh)
+
+  const bottomCopperTextMesh = createTexturePlane(
+    textures.bottomCopperText,
+    -pcbThickness / 2 - BOARD_SURFACE_OFFSET.copper,
+    true,
+    "copper-text",
+    false,
+    2, // Render after soldermask
+  )
+  if (bottomCopperTextMesh) meshes.push(bottomCopperTextMesh)
+
   return meshes
 }

--- a/stories/CopperText.stories.tsx
+++ b/stories/CopperText.stories.tsx
@@ -1,0 +1,516 @@
+import { CadViewer } from "src/CadViewer"
+
+export const CopperTextBasic = () => {
+  return (
+    <CadViewer
+      circuitJson={
+        [
+          {
+            type: "pcb_board",
+            center: { x: 0, y: 0 },
+            width: 20,
+            height: 15,
+            subcircuit_id: "pcb_generic_component_0",
+            material: "fr4",
+            num_layers: 2,
+            pcb_board_id: "pcb_board_0",
+            thickness: 1.6,
+            is_subcircuit: false,
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_0",
+            font: "tscircuit2024",
+            font_size: 1,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: 3 },
+            anchor_alignment: "center",
+            text: "COPPER TEXT",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_1",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: 0 },
+            anchor_alignment: "center",
+            text: "Smaller Text",
+          },
+          // SMT pads for comparison - copper text should match this color
+          {
+            type: "pcb_smtpad",
+            layer: "top",
+            pcb_smtpad_id: "pcb_smtpad_0",
+            pcb_component_id: "pcb_generic_component_0",
+            width: 2,
+            height: 1,
+            x: -5,
+            y: -3,
+            shape: "rect",
+          },
+          {
+            type: "pcb_smtpad",
+            layer: "top",
+            pcb_smtpad_id: "pcb_smtpad_1",
+            pcb_component_id: "pcb_generic_component_0",
+            width: 2,
+            height: 1,
+            x: 5,
+            y: -3,
+            shape: "rect",
+          },
+        ] as any
+      }
+    />
+  )
+}
+
+export const CopperTextBottomLayer = () => {
+  return (
+    <CadViewer
+      circuitJson={
+        [
+          {
+            type: "pcb_board",
+            center: { x: 0, y: 0 },
+            width: 20,
+            height: 15,
+            subcircuit_id: "pcb_generic_component_0",
+            material: "fr4",
+            num_layers: 2,
+            pcb_board_id: "pcb_board_0",
+            thickness: 1.6,
+            is_subcircuit: false,
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_top",
+            font: "tscircuit2024",
+            font_size: 0.8,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: 2 },
+            anchor_alignment: "center",
+            text: "TOP LAYER",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "bottom",
+            pcb_copper_text_id: "pcb_copper_text_bottom",
+            font: "tscircuit2024",
+            font_size: 0.8,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: -2 },
+            anchor_alignment: "center",
+            text: "BOTTOM LAYER",
+          },
+          // Bottom layer SMT pad for comparison
+          {
+            type: "pcb_smtpad",
+            layer: "bottom",
+            pcb_smtpad_id: "pcb_smtpad_bottom",
+            pcb_component_id: "pcb_generic_component_0",
+            width: 2,
+            height: 1,
+            x: -5,
+            y: -2,
+            shape: "rect",
+          },
+        ] as any
+      }
+    />
+  )
+}
+
+export const CopperTextRotation = () => {
+  return (
+    <CadViewer
+      circuitJson={
+        [
+          {
+            type: "pcb_board",
+            center: { x: 0, y: 0 },
+            width: 20,
+            height: 20,
+            subcircuit_id: "pcb_generic_component_0",
+            material: "fr4",
+            num_layers: 2,
+            pcb_board_id: "pcb_board_0",
+            thickness: 1.6,
+            is_subcircuit: false,
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_0",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: 4 },
+            anchor_alignment: "center",
+            text: "0 DEG",
+            ccw_rotation: 0,
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_45",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 4, y: 0 },
+            anchor_alignment: "center",
+            text: "45 DEG",
+            ccw_rotation: 45,
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_90",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: -4 },
+            anchor_alignment: "center",
+            text: "90 DEG",
+            ccw_rotation: 90,
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_180",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -4, y: 0 },
+            anchor_alignment: "center",
+            text: "180 DEG",
+            ccw_rotation: 180,
+          },
+        ] as any
+      }
+    />
+  )
+}
+
+export const CopperTextAnchorAlignment = () => {
+  return (
+    <CadViewer
+      circuitJson={
+        [
+          {
+            type: "pcb_board",
+            center: { x: 0, y: 0 },
+            width: 25,
+            height: 20,
+            subcircuit_id: "pcb_generic_component_0",
+            material: "fr4",
+            num_layers: 2,
+            pcb_board_id: "pcb_board_0",
+            thickness: 1.6,
+            is_subcircuit: false,
+          },
+          // Reference point - a small SMT pad at origin
+          {
+            type: "pcb_smtpad",
+            layer: "top",
+            pcb_smtpad_id: "ref_pad",
+            pcb_component_id: "pcb_generic_component_0",
+            width: 0.5,
+            height: 0.5,
+            x: 0,
+            y: 0,
+            shape: "rect",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_tl",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -6, y: 5 },
+            anchor_alignment: "top_left",
+            text: "top_left",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_tc",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: 5 },
+            anchor_alignment: "top_center",
+            text: "top_center",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_tr",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 6, y: 5 },
+            anchor_alignment: "top_right",
+            text: "top_right",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_cl",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -6, y: 0 },
+            anchor_alignment: "center_left",
+            text: "center_left",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_c",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: 0 },
+            anchor_alignment: "center",
+            text: "center",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_cr",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 6, y: 0 },
+            anchor_alignment: "center_right",
+            text: "center_right",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_bl",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -6, y: -5 },
+            anchor_alignment: "bottom_left",
+            text: "bottom_left",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_bc",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: -5 },
+            anchor_alignment: "bottom_center",
+            text: "bottom_center",
+          },
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_br",
+            font: "tscircuit2024",
+            font_size: 0.5,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 6, y: -5 },
+            anchor_alignment: "bottom_right",
+            text: "bottom_right",
+          },
+        ] as any
+      }
+    />
+  )
+}
+
+export const CopperTextKnockout = () => {
+  return (
+    <CadViewer
+      circuitJson={
+        [
+          {
+            type: "pcb_board",
+            center: { x: 0, y: 0 },
+            width: 30,
+            height: 20,
+            subcircuit_id: "pcb_generic_component_0",
+            material: "fr4",
+            num_layers: 2,
+            pcb_board_id: "pcb_board_0",
+            thickness: 1.6,
+            is_subcircuit: false,
+          },
+          // Normal text for comparison
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_normal",
+            font: "tscircuit2024",
+            font_size: 0.8,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -8, y: 4 },
+            anchor_alignment: "center",
+            text: "NORMAL",
+          },
+          // Knockout text (default padding)
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_knockout",
+            font: "tscircuit2024",
+            font_size: 0.8,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 8, y: 4 },
+            anchor_alignment: "center",
+            text: "KNOCKOUT",
+            is_knockout: true,
+          },
+          // Knockout with custom padding
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_knockout_padded",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: 0 },
+            anchor_alignment: "center",
+            text: "CUSTOM PAD",
+            is_knockout: true,
+            knockout_padding: {
+              left: 1,
+              right: 1,
+              top: 0.5,
+              bottom: 0.5,
+            },
+          },
+          // Knockout with rotation
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "pcb_copper_text_knockout_rotated",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -8, y: -4 },
+            anchor_alignment: "center",
+            text: "ROTATED",
+            is_knockout: true,
+            ccw_rotation: 45,
+          },
+          // Knockout on bottom layer
+          {
+            type: "pcb_copper_text",
+            layer: "bottom",
+            pcb_copper_text_id: "pcb_copper_text_knockout_bottom",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 8, y: -4 },
+            anchor_alignment: "center",
+            text: "BOTTOM KO",
+            is_knockout: true,
+          },
+        ] as any
+      }
+    />
+  )
+}
+
+export const CopperTextMirroring = () => {
+  return (
+    <CadViewer
+      circuitJson={
+        [
+          {
+            type: "pcb_board",
+            center: { x: 0, y: 0 },
+            width: 30,
+            height: 25,
+            subcircuit_id: "pcb_generic_component_0",
+            material: "fr4",
+            num_layers: 2,
+            pcb_board_id: "pcb_board_0",
+            thickness: 1.6,
+            is_subcircuit: false,
+          },
+          // Top layer - normal (not mirrored)
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "top_normal",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -8, y: 8 },
+            anchor_alignment: "center",
+            text: "TOP NORMAL",
+          },
+          // Top layer - explicitly mirrored
+          {
+            type: "pcb_copper_text",
+            layer: "top",
+            pcb_copper_text_id: "top_mirrored",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 8, y: 8 },
+            anchor_alignment: "center",
+            text: "TOP MIRRORED",
+            is_mirrored: true,
+          },
+          // Bottom layer - auto-mirrored (default)
+          {
+            type: "pcb_copper_text",
+            layer: "bottom",
+            pcb_copper_text_id: "bottom_auto",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: -8, y: 0 },
+            anchor_alignment: "center",
+            text: "BTM AUTO MIRROR",
+          },
+          // Bottom layer - explicitly NOT mirrored
+          {
+            type: "pcb_copper_text",
+            layer: "bottom",
+            pcb_copper_text_id: "bottom_not_mirrored",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 8, y: 0 },
+            anchor_alignment: "center",
+            text: "BTM NO MIRROR",
+            is_mirrored: false,
+          },
+          // Bottom layer with rotation + auto-mirror
+          {
+            type: "pcb_copper_text",
+            layer: "bottom",
+            pcb_copper_text_id: "bottom_rotated",
+            font: "tscircuit2024",
+            font_size: 0.6,
+            pcb_component_id: "pcb_generic_component_0",
+            anchor_position: { x: 0, y: -8 },
+            anchor_alignment: "center",
+            text: "BTM ROT 45",
+            ccw_rotation: 45,
+          },
+        ] as any
+      }
+    />
+  )
+}
+
+export default {
+  title: "Copper Text",
+  component: CopperTextBasic,
+}


### PR DESCRIPTION
 Summary
 
- Add support for rendering `pcb_copper_text` elements in the 3D PCB viewer
- Implement knockout text feature (filled rectangle with text cut out)
- Fix text mirroring logic to match pcb-viewer behavior
- Improve text clarity by increasing texture resolution
 
 Changes
 
 New Features
 
**Copper Text Rendering**

- Renders `pcb_copper_text` circuit JSON elements on both top and bottom layers
- Uses texture-based rendering for visibility at all distances and angles
- Supports all 9-point anchor alignments and CCW rotation
**Knockout Text**

- Draws a filled copper rectangle with text cut out (transparent)
- Configurable padding via `knockout_padding` property
- Supports rotation - rectangle rotates with the text

**Mirroring Logic** (matches pcb-viewer behavior)

- Bottom layer: auto-mirrors text unless `is_mirrored: false`
- Top layer: only mirrors if `is_mirrored: true`

 Improvements
 
- Increased `TRACE_TEXTURE_RESOLUTION` from 50 to 150 pixels/mm for crisper small text
- Removed redundant 3D silkscreen geometry from JSCAD (now uses textures like Manifold)