### PR TITLE
Fix:  JSCAD trace rendering with Manifold (green masked traces above copper)

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -885,9 +885,11 @@ export class BoardGeomBuilder {
     const finishSegment = () => {
       if (currentSegmentPoints.length >= 2 && currentLayer) {
         const layerSign = currentLayer === "bottom" ? -1 : 1
+        // Place traces slightly closer to the board surface than
+        // BOARD_SURFACE_OFFSET.traces to sit a bit lower visually.
+        const traceOffset = BOARD_SURFACE_OFFSET.traces - 0.002
         const zCenter =
-          (layerSign * this.ctx.pcbThickness) / 2 +
-          layerSign * BOARD_SURFACE_OFFSET.traces
+          (layerSign * this.ctx.pcbThickness) / 2 + layerSign * traceOffset
 
         const linePath = line(currentSegmentPoints)
         // Use the width of the starting point of the segment for consistency

--- a/src/three-components/JscadBoardTextures.tsx
+++ b/src/three-components/JscadBoardTextures.tsx
@@ -11,6 +11,7 @@ import {
   colors as defaultColors,
   soldermaskColors,
   TRACE_TEXTURE_RESOLUTION,
+  BOARD_SURFACE_OFFSET,
 } from "../geoms/constants"
 
 interface JscadBoardTexturesProps {
@@ -160,11 +161,11 @@ export function JscadBoardTextures({
     }
 
     // Top trace with mask (visible traces through soldermask)
-    // Place this above the 3D copper traces so the texture is on top visually.
+    // Place traces just above the 3D copper traces but still below pads.
     if (visibility.topCopper && visibility.topMask) {
       const topTraceWithMaskMesh = createTexturePlane(
         textures.topTraceWithMask,
-        pcbThickness / 2 + SURFACE_OFFSET + 0.008,
+        pcbThickness / 2 + BOARD_SURFACE_OFFSET.traces + 0.004,
         false,
         "jscad-top-trace-with-mask",
       )
@@ -174,13 +175,11 @@ export function JscadBoardTextures({
       }
     }
 
-    // Bottom trace with mask
-    // Place this below the 3D copper traces (on the bottom side), so the texture
-    // is still the outermost visible layer.
+    // Bottom trace with mask - mirror ordering: board < copper traces < mask < pads
     if (visibility.bottomCopper && visibility.bottomMask) {
       const bottomTraceWithMaskMesh = createTexturePlane(
         textures.bottomTraceWithMask,
-        -pcbThickness / 2 - SURFACE_OFFSET - 0.008,
+        -pcbThickness / 2 - BOARD_SURFACE_OFFSET.traces - 0.005,
         true,
         "jscad-bottom-trace-with-mask",
       )


### PR DESCRIPTION
Use the same green trace‑with‑mask color as Manifold (fr4TracesWithMaskGreen via traceColorWithMask).
Add top/bottom trace‑with‑mask textures in 
JscadBoardTextures
 and position them slightly above the board so they visually sit over the copper traces.
Keep 3D copper traces from 
BoardGeomBuilder.processTrace
, but use the texture layer for the green masked look.


<img width="966" height="834" alt="bbb" src="https://github.com/user-attachments/assets/4a468552-2dc1-4429-94e5-995d1bb6b097" />





<img width="1040" height="866" alt="aaa" src="https://github.com/user-attachments/assets/c056c8dd-c46a-4922-ae57-01281ef347be" />
