### PR TITLE
Add support for faux boards with adjustable opacity in rendering

### DIFF
--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -144,6 +144,7 @@ export const CadViewerJscad = forwardRef<
         <JscadBoardTextures
           circuitJson={internalCircuitJson}
           pcbThickness={pcbThickness}
+          isFaux={isFauxBoard}
         />
         {cad_components.map((cad_component) => (
           <ThreeErrorBoundary

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -271,12 +271,13 @@ try {
     error: builderError,
     isLoading: builderIsLoading,
     boardData,
+    isFauxBoard,
   } = useManifoldBoardBuilder(manifoldJSModule, circuitJson)
 
   const geometryMeshes = useMemo(() => createGeometryMeshes(geoms), [geoms])
   const textureMeshes = useMemo(
-    () => createTextureMeshes(textures, boardData, pcbThickness),
-    [textures, boardData, pcbThickness],
+    () => createTextureMeshes(textures, boardData, pcbThickness, isFauxBoard),
+    [textures, boardData, pcbThickness, isFauxBoard],
   )
 
   const cadComponents = useMemo(

--- a/src/geoms/constants.ts
+++ b/src/geoms/constants.ts
@@ -24,6 +24,8 @@ export const MANIFOLD_Z_OFFSET = 0.001 // Small offset to prevent Z-fighting
 export const SMOOTH_CIRCLE_SEGMENTS = 32 // Number of segments for smooth circles
 export const DEFAULT_SMT_PAD_THICKNESS = 0.035 // Typical 1oz copper thickness in mm
 export const TRACE_TEXTURE_RESOLUTION = 150 // pixels per mm for trace texture
+
+export const FAUX_BOARD_OPACITY = 0.6 // Opacity for faux boards (60% transparent)
 export const boardMaterialColors: Record<PcbBoard["material"], RGB> = {
   fr1: colors.fr1Tan,
   fr4: colors.fr4Tan,

--- a/src/textures/create-three-texture-meshes.ts
+++ b/src/textures/create-three-texture-meshes.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three"
 import type { PcbBoard } from "circuit-json"
 import type { LayerTextures } from "./index"
-import { BOARD_SURFACE_OFFSET } from "../geoms/constants"
+import { BOARD_SURFACE_OFFSET, FAUX_BOARD_OPACITY } from "../geoms/constants"
 import { calculateOutlineBounds } from "../utils/outline-bounds"
 
 type TextureType =
@@ -20,6 +20,7 @@ interface TexturePlaneConfig {
   textureType: TextureType
   usePolygonOffset?: boolean
   renderOrder?: number
+  isFaux?: boolean
 }
 
 function createTexturePlane(
@@ -33,6 +34,7 @@ function createTexturePlane(
     textureType,
     usePolygonOffset = false,
     renderOrder = 0,
+    isFaux = false,
   } = config
 
   if (!texture) return null
@@ -51,6 +53,7 @@ function createTexturePlane(
     polygonOffset: usePolygonOffset,
     polygonOffsetFactor: usePolygonOffset ? -4 : 0, // Increased for better z-fighting prevention
     polygonOffsetUnits: usePolygonOffset ? -4 : 0,
+    opacity: isFaux ? FAUX_BOARD_OPACITY : 1.0,
   })
   const mesh = new THREE.Mesh(planeGeom, material)
   mesh.position.set(
@@ -70,6 +73,7 @@ export function createTextureMeshes(
   textures: LayerTextures | null,
   boardData: PcbBoard | null,
   pcbThickness: number | null,
+  isFaux: boolean = false,
 ): THREE.Mesh[] {
   const meshes: THREE.Mesh[] = []
   if (!textures || !boardData || pcbThickness === null) return meshes
@@ -82,6 +86,7 @@ export function createTextureMeshes(
       textureType: "trace",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -96,6 +101,7 @@ export function createTextureMeshes(
       textureType: "trace-with-mask",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -109,6 +115,7 @@ export function createTextureMeshes(
       textureType: "silkscreen",
       usePolygonOffset: false,
       renderOrder: 3, // Render after traces
+      isFaux,
     },
     boardData,
   )
@@ -122,6 +129,7 @@ export function createTextureMeshes(
       textureType: "trace",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -136,6 +144,7 @@ export function createTextureMeshes(
       textureType: "trace-with-mask",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -149,6 +158,7 @@ export function createTextureMeshes(
       textureType: "silkscreen",
       usePolygonOffset: false,
       renderOrder: 3, // Render after traces
+      isFaux,
     },
     boardData,
   )
@@ -165,6 +175,7 @@ export function createTextureMeshes(
       textureType: "soldermask",
       usePolygonOffset: true, // Enable polygon offset
       renderOrder: 1, // Render after board (renderOrder)
+      isFaux,
     },
     boardData,
   )
@@ -178,6 +189,7 @@ export function createTextureMeshes(
       textureType: "soldermask",
       usePolygonOffset: true, // Enable polygon offset
       renderOrder: 1, // Render after board (renderOrder)
+      isFaux,
     },
     boardData,
   )
@@ -192,6 +204,7 @@ export function createTextureMeshes(
       textureType: "copper-text",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -205,6 +218,7 @@ export function createTextureMeshes(
       textureType: "copper-text",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -219,6 +233,7 @@ export function createTextureMeshes(
       textureType: "copper",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -232,6 +247,7 @@ export function createTextureMeshes(
       textureType: "copper",
       usePolygonOffset: false,
       renderOrder: 2, // Render after soldermask
+      isFaux,
     },
     boardData,
   )
@@ -245,6 +261,7 @@ export function createTextureMeshes(
       textureType: "panel-outlines",
       usePolygonOffset: false,
       renderOrder: 4,
+      isFaux,
     },
     boardData,
   )
@@ -258,6 +275,7 @@ export function createTextureMeshes(
       textureType: "panel-outlines",
       usePolygonOffset: false,
       renderOrder: 4,
+      isFaux,
     },
     boardData,
   )

--- a/src/three-components/JscadBoardTextures.tsx
+++ b/src/three-components/JscadBoardTextures.tsx
@@ -14,17 +14,20 @@ import {
   soldermaskColors,
   TRACE_TEXTURE_RESOLUTION,
   BOARD_SURFACE_OFFSET,
+  FAUX_BOARD_OPACITY,
 } from "../geoms/constants"
 import { calculateOutlineBounds } from "../utils/outline-bounds"
 
 interface JscadBoardTexturesProps {
   circuitJson: AnyCircuitElement[]
   pcbThickness: number
+  isFaux?: boolean
 }
 
 export function JscadBoardTextures({
   circuitJson,
   pcbThickness,
+  isFaux = false,
 }: JscadBoardTexturesProps) {
   const { rootObject } = useThree()
   const { visibility } = useLayerVisibility()
@@ -177,6 +180,7 @@ export function JscadBoardTextures({
         polygonOffset: usePolygonOffset,
         polygonOffsetFactor: usePolygonOffset ? -1 : 0,
         polygonOffsetUnits: usePolygonOffset ? -1 : 0,
+        opacity: isFaux ? FAUX_BOARD_OPACITY : 1.0,
       })
       const mesh = new THREE.Mesh(planeGeom, material)
       mesh.position.set(

--- a/src/utils/create-board-material.ts
+++ b/src/utils/create-board-material.ts
@@ -1,5 +1,6 @@
 import * as THREE from "three"
 import type { PcbBoard } from "circuit-json"
+import { FAUX_BOARD_OPACITY } from "../geoms/constants"
 
 type BoardMaterialType = PcbBoard["material"]
 
@@ -29,7 +30,7 @@ export const createBoardMaterial = ({
       sheen: 0.0,
       clearcoat: 0.0,
       transparent: isFaux,
-      opacity: isFaux ? 0.6 : 1.0,
+      opacity: isFaux ? FAUX_BOARD_OPACITY : 1.0,
       flatShading: true,
     })
   }
@@ -41,6 +42,6 @@ export const createBoardMaterial = ({
     metalness: 0.1,
     roughness: 0.8,
     transparent: true,
-    opacity: isFaux ? 0.6 : 0.9,
+    opacity: isFaux ? FAUX_BOARD_OPACITY : 0.9,
   })
 }


### PR DESCRIPTION
This pull request introduces a consistent approach to rendering "faux" (simulated or preview) PCB boards with partial transparency throughout the 3D viewer. The main changes add a shared opacity constant for faux boards and propagate the `isFaux` flag through the relevant components and rendering functions, ensuring all board materials and textures use the same transparency value when in faux mode.

**Faux board transparency and rendering improvements:**

* Added a new constant `FAUX_BOARD_OPACITY` in `src/geoms/constants.ts` to define the opacity for faux boards and used this constant wherever faux board opacity is required. [[1]](diffhunk://#diff-3a3e688de7492e0cb1e8d36d8e95c05fbfe20f01601242fc0f9729804c495592R27-R28) [[2]](diffhunk://#diff-24acd5ed45536a67abfc7ea84bc8214bfae3edef45b69d2557f1babfe1d4b9f4R3)
* Updated the `createBoardMaterial` utility to use `FAUX_BOARD_OPACITY` for setting the opacity of faux boards, ensuring consistent material appearance. [[1]](diffhunk://#diff-24acd5ed45536a67abfc7ea84bc8214bfae3edef45b69d2557f1babfe1d4b9f4L32-R33) [[2]](diffhunk://#diff-24acd5ed45536a67abfc7ea84bc8214bfae3edef45b69d2557f1babfe1d4b9f4L44-R45)
* Modified `createTexturePlane` and `createTextureMeshes` in `src/textures/create-three-texture-meshes.ts` to accept and apply the `isFaux` flag and use the shared opacity constant for faux board textures. [[1]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eL4-R4) [[2]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR23) [[3]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR37) [[4]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR56) [[5]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR76) [[6]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR89) [[7]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR104) [[8]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR118) [[9]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR132) [[10]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR147) [[11]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR161) [[12]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR178) [[13]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR192) [[14]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR207) [[15]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR221) [[16]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR236) [[17]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR250) [[18]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR264) [[19]](diffhunk://#diff-16b590c49516b8c405cd91f24596f305236235c907b38bce3ce5a080bcca136eR278)
* Passed the `isFaux` prop through the `JscadBoardTextures` component and ensured it is used when creating texture planes, so all board textures respect the faux board opacity. [[1]](diffhunk://#diff-4c7908a23c1b33c8eaea9b64488b08d9575d9f958b117c98fa04c5ea7da19fe5R17-R30) [[2]](diffhunk://#diff-4c7908a23c1b33c8eaea9b64488b08d9575d9f958b117c98fa04c5ea7da19fe5R183)
* Updated `CadViewerJscad` and `CadViewerManifold` components to propagate the `isFauxBoard` flag down to the texture rendering logic, ensuring faux mode is consistently applied throughout the viewer. [[1]](diffhunk://#diff-a2815ad1fc1dda89e6d7ef99b74c16a6163129f5be095e145572d296b23e9427R147) [[2]](diffhunk://#diff-f30629e4e7774e601ad379e35852f5bb2e5007623b9d2d63248d70704fbada2dR274-R280)

These changes ensure that faux boards are visually distinct and consistently rendered with partial transparency across all relevant components and rendering paths.

## Before

<img width="657" height="521" alt="Screenshot_20251224_032742" src="https://github.com/user-attachments/assets/f8111e77-ce94-466e-b57c-14649580ac47" />

## After

<img width="657" height="521" alt="image" src="https://github.com/user-attachments/assets/11329a97-9028-4bea-81bd-f93a2b3c0f61" />
