### PR TITLE
Remove processing of traces from BoardGeomBuilder

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -78,13 +78,12 @@ const createCenteredRectPadGeom = (
 
 type BuilderState =
   | "initializing"
+  | "processing_pads"
+  | "processing_copper_pours"
   | "processing_plated_holes"
   | "processing_holes"
-  | "processing_pads"
-  | "processing_traces"
-  | "processing_vias"
   | "processing_cutouts"
-  | "processing_copper_pours"
+  | "processing_vias"
   | "finalizing"
   | "done"
 
@@ -97,7 +96,6 @@ const buildStateOrder: BuilderState[] = [
   "processing_holes",
   "processing_cutouts",
 
-  "processing_traces",
   "processing_vias",
   "finalizing",
   "done",


### PR DESCRIPTION
This pull request removes the code responsible for generating and processing PCB trace geometries in the `BoardGeomBuilder` class. The trace-related logic, including storage, processing, and rendering, has been eliminated from the codebase.

Removed trace geometry handling:

* Removed the `traceGeoms` property and all logic related to processing traces, including the `processTrace` method and the `"processing_traces"` state in the builder's state machine. [[1]](diffhunk://#diff-54202078e45a6f607f1d26081355b61abf2471d14e36443ec0e3c8d3b1a03751L120) [[2]](diffhunk://#diff-54202078e45a6f607f1d26081355b61abf2471d14e36443ec0e3c8d3b1a03751L279-L288) [[3]](diffhunk://#diff-54202078e45a6f607f1d26081355b61abf2471d14e36443ec0e3c8d3b1a03751L798-L918)
* Removed the inclusion of `traceGeoms` from the final geometry output in the `BoardGeomBuilder`.