### PR TITLE
Fix silkscreen stroke handling with core coverage stories & updating tscircuit package

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-use-gesture": "^9.1.3",
     "semver": "^7.7.0",
     "strip-ansi": "^7.1.0",
-    "tscircuit": "^0.0.1056",
+    "tscircuit": "^0.0.1123",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
     "vite": "^7.1.5",

--- a/src/utils/silkscreen-texture.ts
+++ b/src/utils/silkscreen-texture.ts
@@ -272,7 +272,7 @@ export function createSilkscreenTextureForLayer({
       halfHeightPx,
     )
 
-    const hasStroke = rect.has_stroke ?? false
+    const hasStroke = rect.stroke_width ?? false
     const isFilled = rect.is_filled ?? true
     const isDashed = rect.is_stroke_dashed ?? false
     const strokeWidthPx = hasStroke

--- a/stories/SilkscreenCoreTest.stories.tsx
+++ b/stories/SilkscreenCoreTest.stories.tsx
@@ -1,0 +1,42 @@
+import { CadViewer } from "src/CadViewer"
+import { Circuit } from "@tscircuit/core"
+
+const createCircuit = () => {
+  const circuit = new Circuit()
+
+  circuit.add(
+    <board width="30mm" height="30mm">
+      <silkscreenrect height="1mm" width="1mm" layer="top" />
+      <silkscreencircle radius="1mm" layer="top" pcbX="7mm" pcbY="1mm" />
+      <silkscreenline
+        strokeWidth="0.1mm"
+        layer="top"
+        x1="3mm"
+        y1="3mm"
+        x2="5mm"
+        y2="5mm"
+      />
+      <silkscreenpath
+        layer="top"
+        route={[
+          { x: "1mm", y: "1mm" },
+          { x: "2mm", y: "2mm" },
+          { x: "3mm", y: "1mm" },
+        ]}
+      />
+      <silkscreentext layer="top" pcbX="1mm" pcbY="5mm" text="Tscircuit" />
+    </board>,
+  )
+
+  return circuit.getCircuitJson()
+}
+
+export const SilkscreenCoreTestStory = () => {
+  const circuitJson = createCircuit()
+  return <CadViewer circuitJson={circuitJson} />
+}
+
+export default {
+  title: "Silkscreen Core Test",
+  component: SilkscreenCoreTestStory,
+}


### PR DESCRIPTION
Ref: https://linear.app/tscircuit/issue/TSC-302/silkscreenrect-should-render-in-3d-viewer

the issue was that the core silkscreenrect don't insert has_stroke and I don't think we need it.

replaced the logic with if we have stroke width `hasStroke = true`


test: https://3d-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?path=/story/silkscreen-core-test--silkscreen-core-test-story