### PR TITLE
Split pill and rotated_pill hole shape handling in soldermask texture

### DIFF
--- a/src/utils/soldermask-texture.ts
+++ b/src/utils/soldermask-texture.ts
@@ -1,6 +1,6 @@
 // Utility for creating soldermask textures for PCB layers
 import * as THREE from "three"
-import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import type { AnyCircuitElement, PcbBoard, PcbHole } from "circuit-json"
 import { su } from "@tscircuit/circuit-json-util"
 import {
   extractRectBorderRadius,
@@ -443,13 +443,13 @@ export function createSoldermaskTextureForLayer({
 
   // Get all non-plated holes (they go through both layers, so cut out on both)
   const pcbHoles = su(circuitJson).pcb_hole.list()
-  pcbHoles.forEach((hole: any) => {
+  pcbHoles.forEach((hole: PcbHole) => {
     const x = hole.x as number
     const y = hole.y as number
     const canvasX = canvasXFromPcb(x)
     const canvasY = canvasYFromPcb(y)
 
-    const holeShape = hole.hole_shape || hole.shape
+    const holeShape = hole.hole_shape
 
     if (holeShape === "circle" && typeof hole.hole_diameter === "number") {
       const canvasRadius = (hole.hole_diameter / 2) * traceTextureResolution
@@ -457,7 +457,25 @@ export function createSoldermaskTextureForLayer({
       ctx.arc(canvasX, canvasY, canvasRadius, 0, 2 * Math.PI)
       ctx.fill()
     } else if (
-      (holeShape === "pill" || holeShape === "rotated_pill") &&
+      holeShape === "pill" &&
+      typeof hole.hole_width === "number" &&
+      typeof hole.hole_height === "number"
+    ) {
+      const width = hole.hole_width * traceTextureResolution
+      const height = hole.hole_height * traceTextureResolution
+      const radius = Math.min(width, height) / 2
+
+      ctx.beginPath()
+      ctx.roundRect(
+        canvasX - width / 2,
+        canvasY - height / 2,
+        width,
+        height,
+        radius,
+      )
+      ctx.fill()
+    } else if (
+      holeShape === "rotated_pill" &&
       typeof hole.hole_width === "number" &&
       typeof hole.hole_height === "number"
     ) {


### PR DESCRIPTION
```
Property 'ccw_rotation' does not exist on type 'PcbHolePill | PcbHoleRotatedPill'.
  Property 'ccw_rotation' does not exist on type 'PcbHolePill'.ts(2339
```