### PR TITLE
Harden Rect Border-Radius Clamping to Match JSCAD Geometry Constraints (EPS-Safe)

### DIFF
--- a/src/utils/rect-border-radius.ts
+++ b/src/utils/rect-border-radius.ts
@@ -1,5 +1,9 @@
 export type RectBorderRadiusInput = number | null | undefined
 
+// Match jscad's EPS constant from @jscad/modeling/src/maths/constants
+// roundedRectangle requires: roundRadius < (size/2 - EPS)
+const JSCAD_EPS = 1e-5
+
 export function clampRectBorderRadius(
   width: number,
   height: number,
@@ -16,7 +20,11 @@ export function clampRectBorderRadius(
   const halfWidth = width / 2
   const halfHeight = height / 2
 
-  return Math.max(0, Math.min(rawRadius, halfWidth, halfHeight))
+  // jscad's roundedRectangle throws if roundRadius >= (halfSize - EPS)
+  // We need roundRadius < halfSize - EPS, so we subtract 2*EPS for safety margin
+  const maxRadius = Math.min(halfWidth, halfHeight) - 2 * JSCAD_EPS
+
+  return Math.max(0, Math.min(rawRadius, maxRadius))
 }
 
 export function extractRectBorderRadius(source: any): RectBorderRadiusInput {


### PR DESCRIPTION
PR Description

This PR fixes a geometry edge case that could cause JSCAD to throw during rounded-rectangle generation by aligning our border-radius clamping logic with JSCAD’s internal constraints.

What changed:

Introduced a JSCAD_EPS constant matching JSCAD’s epsilon.

Updated clampRectBorderRadius to enforce
roundRadius < (min(halfWidth, halfHeight) - EPS), with an additional safety margin.

Prevents invalid radii that previously passed clamping but failed at JSCAD runtime.

Why this matters:

roundedRectangle in JSCAD throws when the radius is equal to or greater than half the rectangle size minus EPS.

Our previous logic allowed borderline values that were mathematically valid but geometrically invalid for JSCAD.

This change guarantees compatibility and eliminates hard-to-debug runtime geometry errors.

Impact:

More robust rectangle handling across fabrication notes, silkscreen, soldermask, and other rounded-rect features.

Consistent behavior between canvas rendering and JSCAD-based geometry generation.

Fewer geometry exceptions in edge cases and automated pipelines.

This is a precision and correctness fix that directly improves stability of rounded-rectangle geometry across the stack.

https://3d-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?path=/story/panel-core-test--panel-core-test