### PR TITLE
Correct Bottom-Layer CAD Rotation to Bottom Component 

### DIFF
--- a/src/AnyCadComponent.tsx
+++ b/src/AnyCadComponent.tsx
@@ -6,6 +6,7 @@ import type {
 } from "circuit-json"
 import { useCallback, useMemo, useState } from "react"
 import { useLayerVisibility } from "./contexts/LayerVisibilityContext"
+import { usePcbThickness } from "./hooks/usePcbThickness"
 import { Html } from "./react-three/Html"
 import { FootprinterModel } from "./three-components/FootprinterModel"
 import { GltfModel } from "./three-components/GltfModel"
@@ -13,7 +14,6 @@ import { JscadModel } from "./three-components/JscadModel"
 import { MixedStlModel } from "./three-components/MixedStlModel"
 import { StepModel } from "./three-components/StepModel"
 import { tuple } from "./utils/tuple"
-import { usePcbThickness } from "./hooks/usePcbThickness"
 
 export const AnyCadComponent = ({
   cad_component,
@@ -85,7 +85,7 @@ export const AnyCadComponent = ({
 
     if (layer === "bottom") {
       // Flip 180° around X axis for bottom layer components
-      return tuple(baseRotation[0] + Math.PI, baseRotation[1], baseRotation[2])
+      return tuple(baseRotation[0] + Math.PI, baseRotation[1], -baseRotation[2])
     }
     return baseRotation
   }, [cad_component.rotation, layer])


### PR DESCRIPTION
PR Description

This PR fixes incorrect orientation of bottom-layer CAD components by correcting how Z-axis rotation is handled during layer flipping.

What changed:

Updated bottom-layer rotation logic to:

Flip 180° around the X axis, and

Invert the Z rotation instead of leaving it unchanged.

Ensures rotations behave consistently with how PCB components are mirrored when placed on the bottom side.

Why this matters:

Bottom-layer components were previously rotated but not mirrored correctly, leading to visually incorrect orientation (effectively a double error: flipped but still clockwise).

Proper PCB mirroring requires both an axis flip and Z-rotation inversion.

This fix aligns 3D CAD rendering with real PCB fabrication and assembly semantics.

Impact:

Correct visual orientation for bottom-mounted components.

Eliminates mirrored or backward CAD models on the PCB underside.

Improves accuracy of 3D viewer for assembly checks and mechanical validation.

This is a targeted but critical geometry fix that restores correctness for bottom-layer CAD rendering.


https://3d-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?path=/story/cad-component-bottom-rotation--cad-component-bottom-rotation


Before 

<img width="1881" height="1050" alt="image" src="https://github.com/user-attachments/assets/127655ad-4127-4756-a07a-855bd5cff6bf" />