### PR TITLE
chore: update jscad-electronics dependency to version 0.0.118

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "bun-match-svg": "^0.0.9",
     "bun-types": "1.2.1",
     "debug": "^4.4.0",
-    "jscad-electronics": "^0.0.109",
+    "jscad-electronics": "^0.0.118",
     "jscad-planner": "^0.0.13",
     "jsdom": "^26.0.0",
     "manifold-3d": "^3.2.1",


### PR DESCRIPTION
This pull request  update  `package.json` dependencies by bumping the version of the `jscad-electronics` package.

- Dependency update:
  * Upgraded the `jscad-electronics` package from version `^0.0.109` to `^0.0.118` in `package.json`, which may include bug fixes or new features from upstream.