### PR TITLE
Force WebGL context loss on OrientationCubeCanvas cleanup to prevent GPU leaks

### DIFF
--- a/src/three-components/OrientationCubeCanvas.tsx
+++ b/src/three-components/OrientationCubeCanvas.tsx
@@ -185,6 +185,7 @@ export const OrientationCubeCanvas = () => {
 
       scene.clear()
       renderer.dispose()
+      renderer.forceContextLoss()
 
       if (canvasRef.current && containerRef.current) {
         containerRef.current.removeChild(canvasRef.current)


### PR DESCRIPTION
Explicitly calls renderer.forceContextLoss() during unmount

Ensures the WebGL context is fully released, not just the scene and renderer objects

Prevents GPU memory/context leaks during remounts or viewer reinitialization

Improves stability in long-running sessions and repeated canvas lifecycles

This change tightens resource cleanup and avoids lingering WebGL contexts that renderer.dispose() alone does not fully release.