### PR TITLE
fix: Add global model cache to prevent duplicate loading and browser lag (#93)

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,7 +4,24 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+// Global cache for loaded 3D models
+interface ModelCacheItem {
+  promise: Promise<THREE.Object3D | null>
+  result: THREE.Object3D | null
+}
+
+declare global {
+  interface Window {
+    TSCIRCUIT_3D_MODEL_CACHE: Map<string, ModelCacheItem>
+  }
+}
+
+// Initialize global cache
+if (typeof window !== "undefined" && !window.TSCIRCUIT_3D_MODEL_CACHE) {
+  window.TSCIRCUIT_3D_MODEL_CACHE = new Map<string, ModelCacheItem>()
+}
+
+async function loadModelFromUrl(url: string): Promise<THREE.Object3D | null> {
   if (url.endsWith(".stl")) {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
@@ -33,4 +50,40 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
 
   console.error("Unsupported file format or failed to load 3D model.")
   return null
+}
+
+export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+  // Clean the URL (remove cache busting parameters)
+  const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+  
+  const cache = window.TSCIRCUIT_3D_MODEL_CACHE
+
+  // Check if model is already in cache
+  if (cache.has(cleanUrl)) {
+    const cacheItem = cache.get(cleanUrl)!
+    
+    // If we have a cached result, clone it to avoid sharing the same object
+    if (cacheItem.result) {
+      return cacheItem.result.clone()
+    }
+    
+    // If we're still loading, wait for the existing promise and clone the result
+    return cacheItem.promise.then((result) => {
+      return result ? result.clone() : null
+    })
+  }
+
+  // If not in cache, create a new loading promise
+  const promise = loadModelFromUrl(cleanUrl).then((result) => {
+    // Store the result in cache
+    if (result) {
+      cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+    }
+    return result
+  })
+
+  // Store the promise in cache immediately
+  cache.set(cleanUrl, { promise, result: null })
+
+  return promise
 }


### PR DESCRIPTION
## Description

This PR fixes the laggy browser issue caused by duplicate model loading by implementing a global model cache for all 3D model types (OBJ, STL, GLTF, GLB, WRL).

## Problem

The current implementation in `load3DModel()` creates new loader instances and loads models from scratch every time they're requested, even if the same model URL has been loaded before. This causes:
- Duplicate network requests for the same model files
- Redundant parsing and geometry creation
- Excessive memory usage
- Browser lag, especially with complex models or multiple instances

Example project showing the issue: https://tscircuit.com/editor?snippet_id=22c651e7-a6d2-436d-b2b6-ba0b0921e95e

## Solution

Implemented a global model cache (`TSCIRCUIT_3D_MODEL_CACHE`) that:

1. **Caches loaded models** - Stores successfully loaded models in a global Map keyed by URL
2. **Deduplicates in-flight requests** - If a model is currently being loaded, subsequent requests wait for the same promise instead of creating new requests
3. **Returns cloned instances** - Each request gets a cloned copy of the cached model to avoid sharing the same Three.js object (which would cause issues with transformations)
4. **Handles all model types** - Works with OBJ, STL, GLTF, GLB, and WRL files
5. **URL cleaning** - Removes cache-busting parameters before caching to maximize cache hits

## Changes

### Modified Files
- `src/utils/load-model.ts` - Added global caching mechanism

### Key Implementation Details

```typescript
// Global cache structure
interface ModelCacheItem {
  promise: Promise<THREE.Object3D | null>
  result: THREE.Object3D | null
}

window.TSCIRCUIT_3D_MODEL_CACHE = new Map<string, ModelCacheItem>()
```

**Cache Flow:**
1. Clean URL (remove cache-busting params)
2. Check if model exists in cache
   - If cached with result → return cloned copy
   - If loading in progress → wait for promise, then clone
3. If not in cache → load model, store promise immediately, store result when loaded

## Benefits

✅ **Performance**: Models are loaded once and reused  
✅ **Memory efficient**: Single copy of geometry data per unique model  
✅ **Network efficient**: No duplicate HTTP requests  
✅ **Browser responsiveness**: Eliminates lag from redundant loading  
✅ **Backward compatible**: No API changes, drop-in replacement  

## Testing

Tested with:
- Multiple instances of the same OBJ model
- Mixed model types (OBJ, STL, GLTF)
- Concurrent requests for the same model
- Cache-busting URLs

## Notes

- This implementation is similar to the existing `useGlobalObjLoader` hook but applies to the lower-level `load3DModel` utility
- The cache persists for the lifetime of the page, which is appropriate for 3D models
- Cloning ensures each component can transform its model independently

## Closes

Closes #93

## Bounty

This PR addresses the $5 bounty issue.