### PR TITLE
Add resolveStaticAsset support for CadViewer model URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Props:
 
 - `circuit-json`: (optional) An array of AnyCircuitElement objects representing the PCB layout.
 - `children`: (optional) React children elements describing the PCB layout (alternative to using `circuit-json`).
+- `resolveStaticAsset`: (optional) Function that receives each component model URL (`obj`, `wrl`, `stl`, `gltf`, `glb`, `step`) and returns the resolved URL to load.
 
 ### `<board>`
 

--- a/src/AnyCadComponent.tsx
+++ b/src/AnyCadComponent.tsx
@@ -13,14 +13,17 @@ import { GltfModel } from "./three-components/GltfModel"
 import { JscadModel } from "./three-components/JscadModel"
 import { MixedStlModel } from "./three-components/MixedStlModel"
 import { StepModel } from "./three-components/StepModel"
+import { resolveModelUrl } from "./utils/resolve-model-url"
 import { tuple } from "./utils/tuple"
 
 export const AnyCadComponent = ({
   cad_component,
   circuitJson,
+  resolveStaticAsset,
 }: {
   cad_component: CadComponent
   circuitJson: AnyCircuitElement[]
+  resolveStaticAsset?: (modelUrl: string) => string
 }) => {
   const pcbThickness = usePcbThickness(circuitJson)
   const [isHovered, setIsHovered] = useState(false)
@@ -60,12 +63,22 @@ export const AnyCadComponent = ({
     return platedHoles.length > 0
   }, [circuitJson, cad_component.pcb_component_id])
 
-  const url =
+  const resolveModelUrlWithStaticResolver = useCallback(
+    (modelUrl?: string) => resolveModelUrl(modelUrl, resolveStaticAsset),
+    [resolveStaticAsset],
+  )
+
+  const url = resolveModelUrlWithStaticResolver(
     cad_component.model_obj_url ??
-    cad_component.model_wrl_url ??
-    cad_component.model_stl_url
-  const gltfUrl = cad_component.model_glb_url ?? cad_component.model_gltf_url
-  const stepUrl = cad_component.model_step_url
+      cad_component.model_wrl_url ??
+      cad_component.model_stl_url,
+  )
+  const gltfUrl = resolveModelUrlWithStaticResolver(
+    cad_component.model_glb_url ?? cad_component.model_gltf_url,
+  )
+  const stepUrl = resolveModelUrlWithStaticResolver(
+    cad_component.model_step_url,
+  )
   const pcbComponent = circuitJson.find(
     (elm) =>
       elm.type === "pcb_component" &&

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -24,8 +24,10 @@ interface Props {
   circuitJson?: AnyCircuitElement[]
   autoRotateDisabled?: boolean
   clickToInteractEnabled?: boolean
+  cameraType?: "orthographic" | "perspective"
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
+  resolveStaticAsset?: (modelUrl: string) => string
 }
 
 export const CadViewerJscad = forwardRef<
@@ -40,6 +42,7 @@ export const CadViewerJscad = forwardRef<
       clickToInteractEnabled,
       onUserInteraction,
       onCameraControllerReady,
+      resolveStaticAsset,
     },
     ref,
   ) => {
@@ -157,6 +160,7 @@ export const CadViewerJscad = forwardRef<
               key={cad_component.cad_component_id}
               cad_component={cad_component}
               circuitJson={internalCircuitJson}
+              resolveStaticAsset={resolveStaticAsset}
             />
           </ThreeErrorBoundary>
         ))}

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -159,8 +159,10 @@ const BoardMeshes = ({
 type CadViewerManifoldProps = {
   autoRotateDisabled?: boolean
   clickToInteractEnabled?: boolean
+  cameraType?: "orthographic" | "perspective"
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
+  resolveStaticAsset?: (modelUrl: string) => string
 } & (
   | { circuitJson: AnyCircuitElement[]; children?: React.ReactNode }
   | { circuitJson?: never; children: React.ReactNode }
@@ -175,6 +177,7 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
   onUserInteraction,
   children,
   onCameraControllerReady,
+  resolveStaticAsset,
 }) => {
   const childrenCircuitJson = useConvertChildrenToCircuitJson(children)
   const circuitJson = useMemo(() => {
@@ -370,6 +373,7 @@ try {
           <AnyCadComponent
             cad_component={cad_component}
             circuitJson={circuitJson}
+            resolveStaticAsset={resolveStaticAsset}
           />
         </ThreeErrorBoundary>
       ))}

--- a/src/utils/resolve-model-url.ts
+++ b/src/utils/resolve-model-url.ts
@@ -1,0 +1,7 @@
+export const resolveModelUrl = (
+  modelUrl: string | undefined,
+  resolveStaticAsset?: (modelUrl: string) => string,
+) => {
+  if (!modelUrl) return undefined
+  return resolveStaticAsset ? resolveStaticAsset(modelUrl) : modelUrl
+}

--- a/stories/ResolveStaticAsset.stories.tsx
+++ b/stories/ResolveStaticAsset.stories.tsx
@@ -1,0 +1,37 @@
+import { CadViewer } from "src/CadViewer"
+import myGlb from "./assets/myGlb.glb?url"
+
+export const ResolveStaticAssetForModelUrls = () => {
+  return (
+    <CadViewer
+      resolveStaticAsset={(modelUrl) => {
+        if (modelUrl === "@assets/myGlb.glb") {
+          return myGlb
+        }
+        return modelUrl
+      }}
+    >
+      <board width="5mm" height="5mm">
+        <chip
+          name="ResolvedGlb"
+          footprint={
+            <footprint>
+              <hole diameter="0.9mm" pcbX={0} pcbY={0} />
+            </footprint>
+          }
+          cadModel={{
+            gltfUrl: "@assets/myGlb.glb",
+            rotationOffset: { x: 90, y: 0, z: 0 },
+            positionOffset: { x: 0, y: 0, z: 0.6 },
+          }}
+        />
+      </board>
+    </CadViewer>
+  )
+}
+
+ResolveStaticAssetForModelUrls.storyName = "Resolve Static Asset"
+
+export default {
+  title: "Models/Resolve Static Asset",
+}

--- a/tests/resolve-model-url.test.ts
+++ b/tests/resolve-model-url.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { resolveModelUrl } from "../src/utils/resolve-model-url"
+
+test("returns the original model URL when no resolver is provided", () => {
+  expect(resolveModelUrl("/models/chip.glb")).toBe("/models/chip.glb")
+})
+
+test("uses resolveStaticAsset to resolve model URLs", () => {
+  const resolved = resolveModelUrl("/models/chip.glb", (modelUrl) => {
+    return `https://cdn.example.com${modelUrl}`
+  })
+
+  expect(resolved).toBe("https://cdn.example.com/models/chip.glb")
+})
+
+test("returns undefined for empty model URL input", () => {
+  expect(resolveModelUrl(undefined, (modelUrl) => modelUrl)).toBeUndefined()
+})


### PR DESCRIPTION
### Motivation

- Allow consumers to map placeholder or repo-relative model identifiers to real CDN/bundled URLs before the viewer attempts to load 3D models.

### Description

- Add a small utility `resolveModelUrl` in `src/utils/resolve-model-url.ts` that applies an optional `resolveStaticAsset` function to a model URL. 
- Plumb the `resolveStaticAsset` prop through `CadViewer` into both engines by adding the prop to `CadViewerJscad` and `CadViewerManifold` and passing it to `AnyCadComponent`.
- Apply the resolver inside `AnyCadComponent` so OBJ/WRL/STL, GLTF/GLB and STEP URLs are transformed before loading.
- Add a Storybook example `stories/ResolveStaticAsset.stories.tsx` demonstrating mapping a placeholder URL to a bundled `.glb`, and update `README.md` to document the new `resolveStaticAsset` prop.

### Testing

- Ran unit tests: `bun test tests/resolve-model-url.test.ts` which passed (3 tests, 0 failures). 
- Built the package: `bun run build` (TypeScript build and type declarations succeeded).
- The story demonstrating the prop was added as `stories/ResolveStaticAsset.stories.tsx` for manual verification in Storybook.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698777592444832797cd851edb31b25d)