### PR TITLE
fix: use position.z from circuit-json instead of overriding it

### DIFF
--- a/src/AnyCadComponent.tsx
+++ b/src/AnyCadComponent.tsx
@@ -104,23 +104,16 @@ export const AnyCadComponent = ({
     return baseRotation
   }, [cad_component.rotation, layer])
 
-  // Adjust position based on layer to place components on top/bottom of board
+  // Use position.z from circuit-json directly — core already calculates the
+  // correct z including board thickness offset and zOffsetFromSurface
   const adjustedPosition = useMemo(() => {
     if (!cad_component.position) return undefined
-    let z: number
-    if (layer === "top") {
-      z = pcbThickness / 2
-    } else if (layer === "bottom") {
-      z = -(pcbThickness / 2)
-    } else {
-      z = cad_component.position.z // Fallback
-    }
-    return [cad_component.position.x, cad_component.position.y, z] as [
-      number,
-      number,
-      number,
-    ]
-  }, [cad_component.position, layer, pcbThickness])
+    return [
+      cad_component.position.x,
+      cad_component.position.y,
+      cad_component.position.z,
+    ] as [number, number, number]
+  }, [cad_component.position])
 
   let modelComponent: React.ReactNode = null
 


### PR DESCRIPTION
## What

Fixes the 3D viewer ignoring `zOffsetFromSurface` by using the z position that core already computed instead of recalculating it.

## Why

Core already bakes the correct z into `position.z`:
```
z = boardThickness/2 + zOffsetFromSurface + positionOffset.z
```

But `AnyCadComponent.tsx` was throwing this away and replacing it with just `pcbThickness / 2`, making `zOffsetFromSurface` useless.

## Changes

- Use `cad_component.position.z` directly instead of overriding it per-layer
- Removed the layer-based recalculation since core handles this already

## Testing

Existing tests pass. Core's `cadmodel-z-offset-from-surface.test.tsx` confirms position.z is computed correctly.

Fixes tscircuit/tscircuit.com#2697