### PR TITLE
fix: Add global model cache to prevent duplicate loading and browser lag

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,7 +4,30 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+// Define the type for our cache
+interface ModelCacheItem {
+  promise: Promise<THREE.Object3D | null>
+  result: THREE.Object3D | null
+}
+
+declare global {
+  interface Window {
+    TSCIRCUIT_3D_MODEL_CACHE: Map<string, ModelCacheItem>
+  }
+}
+
+// Ensure the global cache exists
+if (typeof window !== "undefined" && !window.TSCIRCUIT_3D_MODEL_CACHE) {
+  window.TSCIRCUIT_3D_MODEL_CACHE = new Map<string, ModelCacheItem>()
+}
+
+// Helper function to clean URL (remove cache-busting parameters)
+function cleanUrl(url: string): string {
+  return url.replace(/[?&]cachebust[^&]*(&|$)/g, "").replace(/&$/, "")
+}
+
+// Internal function that does the actual loading
+async function loadModelInternal(url: string): Promise<THREE.Object3D | null> {
   if (url.endsWith(".stl")) {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
@@ -33,4 +56,50 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
 
   console.error("Unsupported file format or failed to load 3D model.")
   return null
+}
+
+export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+  // Skip caching in non-browser environments
+  if (typeof window === "undefined") {
+    return loadModelInternal(url)
+  }
+
+  const cache = window.TSCIRCUIT_3D_MODEL_CACHE
+  const cacheKey = cleanUrl(url)
+
+  // Check if model is already cached
+  if (cache.has(cacheKey)) {
+    const cacheItem = cache.get(cacheKey)!
+
+    // If we have a result, clone it to avoid sharing the same Three.js object
+    if (cacheItem.result) {
+      return cacheItem.result.clone()
+    }
+
+    // If still loading, wait for the promise and then clone
+    return cacheItem.promise.then((result) => {
+      return result ? result.clone() : null
+    })
+  }
+
+  // If not in cache, create a new promise and cache it
+  const promise = loadModelInternal(url)
+    .then((result) => {
+      if (result) {
+        // Store the result in cache
+        cache.set(cacheKey, { ...cache.get(cacheKey)!, result })
+      }
+      return result
+    })
+    .catch((error) => {
+      console.error(`Failed to load 3D model from ${url}:`, error)
+      // Remove failed load from cache so it can be retried
+      cache.delete(cacheKey)
+      return null
+    })
+
+  // Immediately store the promise in cache to prevent duplicate requests
+  cache.set(cacheKey, { promise, result: null })
+
+  return promise
 }


### PR DESCRIPTION
## Summary

This PR fixes the browser lag issue caused by duplicate model loading by implementing a global model cache for the `load3DModel` utility function.

## Problem

The current implementation in `load3DModel()` creates new loader instances and loads models from scratch every time they're requested, even if the same model URL has been loaded before. This causes:
- Duplicate network requests for the same model files
- Redundant parsing and geometry creation
- Excessive memory usage
- Browser lag, especially with complex models or multiple instances

Example project showing the issue: https://tscircuit.com/editor?snippet_id=22c651e7-a6d2-436d-b2b6-ba0b0921e95e

## Solution

Implemented a global model cache (`TSCIRCUIT_3D_MODEL_CACHE`) that:

1. **Caches loaded models** - Stores successfully loaded models in a global Map keyed by cleaned URL
2. **Deduplicates in-flight requests** - If a model is currently being loaded, subsequent requests wait for the same promise instead of creating new requests
3. **Returns cloned instances** - Each request gets a cloned copy of the cached model to avoid sharing the same Three.js object (which would cause issues with transformations)
4. **Handles all model types** - Works with OBJ, STL, GLTF, GLB, and WRL files
5. **URL cleaning** - Removes cache-busting parameters before caching to maximize cache hits
6. **Error handling** - Removes failed loads from cache to allow retries

## Key Implementation Details

```typescript
// Global cache structure
interface ModelCacheItem {
  promise: Promise<THREE.Object3D | null>
  result: THREE.Object3D | null
}

window.TSCIRCUIT_3D_MODEL_CACHE = new Map<string, ModelCacheItem>()
```

**Cache Flow:**
1. Clean URL (remove cache-busting params)
2. Check if model exists in cache
   - If cached with result → return cloned copy
   - If loading in progress → wait for promise, then clone
3. If not in cache → load model, store promise immediately, store result when loaded

## Benefits

✅ **Performance**: Models are loaded once and reused  
✅ **Memory efficient**: Single copy of geometry data per unique model  
✅ **Network efficient**: No duplicate HTTP requests  
✅ **Browser responsiveness**: Eliminates lag from redundant loading  
✅ **Backward compatible**: No API changes, drop-in replacement  

## Testing

- Built successfully with `bun run build`
- Code formatted with `bun run format`
- Similar pattern to existing `useGlobalObjLoader` hook
- Works in non-browser environments (SSR-safe)

## Notes

- This implementation is similar to the existing `useGlobalObjLoader` hook but applies to the lower-level `load3DModel` utility used in `renderComponent`
- The cache persists for the lifetime of the page, which is appropriate for 3D models
- Cloning ensures each component can transform its model independently
- Failed loads are removed from cache to allow retries

/claim #93