### PR TITLE
fix: Add global model cache to prevent duplicate loading (#93)

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -55,18 +55,18 @@ async function loadModelFromUrl(url: string): Promise<THREE.Object3D | null> {
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
   // Clean the URL (remove cache busting parameters)
   const cleanUrl = url.replace(/&cachebust_origin=$/, "")
-  
+
   const cache = window.TSCIRCUIT_3D_MODEL_CACHE
 
   // Check if model is already in cache
   if (cache.has(cleanUrl)) {
     const cacheItem = cache.get(cleanUrl)!
-    
+
     // If we have a cached result, clone it to avoid sharing the same object
     if (cacheItem.result) {
       return cacheItem.result.clone()
     }
-    
+
     // If we're still loading, wait for the existing promise and clone the result
     return cacheItem.promise.then((result) => {
       return result ? result.clone() : null


### PR DESCRIPTION
## Summary
- Adds a global model cache (`window.TSCIRCUIT_3D_MODEL_CACHE`) to prevent duplicate OBJ/GLTF model loading, which was causing browser lag when the same model URL was requested multiple times
- Clones cached results to avoid shared object mutations
- Fixes formatting (trailing whitespace) that caused CI format-check failure on #678

Supersedes #678 with the format fix included.

## Test plan
- [ ] Verify that loading a board with duplicate 3D models no longer causes repeated network requests
- [ ] Verify that cached models are properly cloned (no shared state between instances)
- [ ] Verify format-check CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)