### PR TITLE
Fix translucent rendering updates for STEP-backed glTF models

### DIFF
--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -38,26 +38,7 @@ export function GltfModel({
       gltfUrl,
       (gltf) => {
         if (!isMounted) return
-        const scene = gltf.scene
-
-        scene.traverse((child) => {
-          if (child instanceof THREE.Mesh && child.material) {
-            const setMaterialTransparency = (mat: THREE.Material) => {
-              mat.transparent = isTranslucent
-              mat.opacity = isTranslucent ? 0.5 : 1
-              mat.depthWrite = !isTranslucent
-              mat.needsUpdate = true
-            }
-
-            if (Array.isArray(child.material)) {
-              child.material.forEach(setMaterialTransparency)
-            } else {
-              setMaterialTransparency(child.material)
-            }
-          }
-        })
-
-        setModel(scene)
+        setModel(gltf.scene)
       },
       undefined,
       (error) => {
@@ -73,7 +54,30 @@ export function GltfModel({
     return () => {
       isMounted = false
     }
-  }, [gltfUrl, isTranslucent])
+  }, [gltfUrl])
+
+  useEffect(() => {
+    if (!model) return
+
+    const setMaterialTransparency = (material: THREE.Material) => {
+      material.transparent = isTranslucent
+      material.opacity = isTranslucent ? 0.5 : 1
+      material.depthWrite = !isTranslucent
+      material.needsUpdate = true
+    }
+
+    model.traverse((child) => {
+      if (!(child instanceof THREE.Mesh) || !child.material) {
+        return
+      }
+
+      if (Array.isArray(child.material)) {
+        child.material.forEach(setMaterialTransparency)
+      } else {
+        setMaterialTransparency(child.material)
+      }
+    })
+  }, [model, isTranslucent])
 
   useEffect(() => {
     if (!model) return


### PR DESCRIPTION
### Motivation

- STEP files are converted to GLB and cached, but toggling the "show as translucent model" flag did not always update already-loaded glTF materials.
- Material transparency updates were applied only during model load, causing the UI toggle to require a reload to take effect for STEP-backed models.

### Description

- Load the glTF once and keep loading tied only to `gltfUrl` so the model is not reloaded when translucency changes.
- Move material translucency updates into a dedicated effect that runs when the loaded `model` or `isTranslucent` changes, and apply `transparent`, `opacity`, `depthWrite`, and `needsUpdate` to each material.
- Support both single-material and multi-material meshes during translucency updates so all mesh materials reflect the current `isTranslucent` state.

### Testing

- `bunx tsc --noEmit` completed successfully and reported no type errors.
- `bun test tests` executed 12 tests across 7 files with 10 passing and 2 failing tests in `tests/preprocess-circuit-json.test.ts`, which are unrelated to the glTF translucency changes.
- `bun run format` ran and formatted files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698fbcc53de0832e98481a0c42a8f597)