### PR TITLE
fix: improve GLB model lighting to address dark appearance

### DIFF
--- a/src/react-three/Lights.tsx
+++ b/src/react-three/Lights.tsx
@@ -6,7 +6,7 @@ export const Lights: React.FC = () => {
   const { scene } = useThree()
 
   const ambientLight = useMemo(
-    () => new THREE.AmbientLight(0xffffff, Math.PI / 2),
+    () => new THREE.AmbientLight(0xffffff, Math.PI * 0.75),
     [],
   )
   const pointLight = useMemo(() => {
@@ -15,16 +15,23 @@ export const Lights: React.FC = () => {
     light.decay = 0
     return light
   }, [])
+  const directionalLight = useMemo(() => {
+    const light = new THREE.DirectionalLight(0xffffff, Math.PI * 0.5)
+    light.position.set(5, 10, 7)
+    return light
+  }, [])
 
   useEffect(() => {
     if (!scene) return
     scene.add(ambientLight)
     scene.add(pointLight)
+    scene.add(directionalLight)
     return () => {
       scene.remove(ambientLight)
       scene.remove(pointLight)
+      scene.remove(directionalLight)
     }
-  }, [scene, ambientLight, pointLight])
+  }, [scene, ambientLight, pointLight, directionalLight])
 
   return null
 }

--- a/src/react-three/configure-renderer.ts
+++ b/src/react-three/configure-renderer.ts
@@ -8,5 +8,6 @@ import * as THREE from "three"
 export const configureRenderer = (renderer: THREE.WebGLRenderer) => {
   renderer.outputColorSpace = THREE.SRGBColorSpace
   renderer.toneMapping = THREE.ACESFilmicToneMapping
-  renderer.toneMappingExposure = 1
+  // Controls overall scene brightness for tone mapping
+  renderer.toneMappingExposure = 1.2
 }

--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -5,7 +5,7 @@ import { useThree } from "src/react-three/ThreeContext"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
 
-const DEFAULT_ENV_MAP_INTENSITY = 1.25
+const DEFAULT_ENV_MAP_INTENSITY = 1.75
 
 export function GltfModel({
   gltfUrl,


### PR DESCRIPTION
Fixes #507 - GLB 3D models appearing too dark in the viewer.

## Root Cause

ACES Filmic tone mapping compresses both highlights and shadows, requiring higher lighting values to achieve visually correct brightness. The existing ambient + single point light setup was insufficient for physically-based rendering of GLB models.

## Changes

### Lighting (src/react-three/Lights.tsx)
- Increased ambient light intensity: pi/2 (~1.57) to pi*0.75 (~2.36)
- Added directional light (intensity pi*0.5, position 5,10,7) for depth/highlights
- Preserved existing point light unchanged

### Renderer (src/react-three/configure-renderer.ts)
- Increased tone mapping exposure: 1.0 to 1.2
- Compensates for ACES filmic shadow compression

### Environment Map (src/three-components/GltfModel.tsx)
- Increased default env map intensity: 1.25 to 1.75
- Improves PBR material illumination from environment reflections

## What is NOT Changed
- Tone mapping algorithm (ACES Filmic is correct)
- Environment map generation
- Material properties on individual models
- Translucent model rendering
- Color space (SRGB)

> Note: This PR was generated with AI assistance.