### PR TITLE
fix: correct bottom layer component positioning and rotation (#106)

### DIFF
--- a/src/utils/render-component.tsx
+++ b/src/utils/render-component.tsx
@@ -10,10 +10,21 @@ import * as jscadModeling from "@jscad/modeling"
 import { load3DModel } from "./load-model"
 import type { CadComponent } from "circuit-json"
 
+// Standard PCB thickness is 1.4mm, so components sit at ±0.7mm from center
+const DEFAULT_BOARD_HALF_THICKNESS = 0.7
+
 export async function renderComponent(
   component: CadComponent,
   scene: THREE.Scene,
 ) {
+  // Determine z-offset based on component layer
+  // Top layer (default): components sit above the board (+0.7mm)
+  // Bottom layer: components sit below the board (-0.7mm)
+  const isBottomLayer = component.layer === "bottom"
+  const layerZOffset = isBottomLayer
+    ? -DEFAULT_BOARD_HALF_THICKNESS
+    : DEFAULT_BOARD_HALF_THICKNESS
+
   // Handle STL/OBJ models first
   const url =
     component.model_obj_url ??
@@ -28,7 +39,7 @@ export async function renderComponent(
         model.position.set(
           component.position.x ?? 0,
           component.position.y ?? 0,
-          (component.position.z ?? 0) + 0.5,
+          (component.position.z ?? 0) + layerZOffset,
         )
       }
       if (component.rotation) {
@@ -37,6 +48,10 @@ export async function renderComponent(
           THREE.MathUtils.degToRad(component.rotation.y ?? 0),
           THREE.MathUtils.degToRad(component.rotation.z ?? 0),
         )
+      }
+      // Flip bottom layer components 180° around X axis
+      if (isBottomLayer) {
+        model.rotateX(Math.PI)
       }
       scene.add(model)
       return
@@ -63,7 +78,7 @@ export async function renderComponent(
         mesh.position.set(
           component.position.x ?? 0,
           component.position.y ?? 0,
-          (component.position.z ?? 0) + 0.5,
+          (component.position.z ?? 0) + layerZOffset,
         )
       }
       if (component.rotation) {
@@ -72,6 +87,10 @@ export async function renderComponent(
           THREE.MathUtils.degToRad(component.rotation.y ?? 0),
           THREE.MathUtils.degToRad(component.rotation.z ?? 0),
         )
+      }
+      // Flip bottom layer components 180° around X axis
+      if (isBottomLayer) {
+        mesh.rotateX(Math.PI)
       }
       scene.add(mesh)
     }
@@ -109,7 +128,7 @@ export async function renderComponent(
         mesh.position.set(
           component.position.x ?? 0,
           component.position.y ?? 0,
-          (component.position.z ?? 0) + 0.5,
+          (component.position.z ?? 0) + layerZOffset,
         )
       }
       if (component.rotation) {
@@ -118,6 +137,10 @@ export async function renderComponent(
           THREE.MathUtils.degToRad(component.rotation.y ?? 0),
           THREE.MathUtils.degToRad(component.rotation.z ?? 0),
         )
+      }
+      // Flip bottom layer components 180° around X axis
+      if (isBottomLayer) {
+        mesh.rotateX(Math.PI)
       }
       scene.add(mesh)
     }
@@ -137,8 +160,12 @@ export async function renderComponent(
     mesh.position.set(
       component.position.x ?? 0,
       component.position.y ?? 0,
-      (component.position.z ?? 0) + 0.5,
+      (component.position.z ?? 0) + layerZOffset,
     )
+  }
+  // Flip bottom layer components 180° around X axis
+  if (isBottomLayer) {
+    mesh.rotateX(Math.PI)
   }
   scene.add(mesh)
 }


### PR DESCRIPTION
## Summary
Fixes #106 — Components on the bottom layer appear offset from their correct position in the 3D viewer.

## Root Cause
All components received a hardcoded `+0.5mm` z-offset regardless of which PCB layer they belong to. Bottom layer components should be positioned below the board surface, not above it.

## Changes

### `src/utils/render-component.tsx`
- Added `DEFAULT_BOARD_HALF_THICKNESS = 0.7` constant (standard 1.4mm PCB / 2)
- Top layer components: `z + 0.7mm` (above board surface)
- Bottom layer components: `z - 0.7mm` (below board surface) + 180° X-axis rotation
- Fix applied consistently across **all 4 model types**: GLTF/STL/OBJ, JSCAD, footprinter, and fallback box

## Before / After

| | Before | After |
|---|--------|-------|
| Top layer | `z + 0.5` (hardcoded) | `z + 0.7` (correct half-thickness) |
| Bottom layer | `z + 0.5` (wrong, same as top) | `z - 0.7` + 180° flip |

## Testing
- Existing stories: `bottomLayer.stories.tsx`, `CadComponentBottomRotation.stories.tsx`
- No new dependencies
- Minimal, focused change (1 file, 31 additions, 4 deletions)

---
*This PR was developed with AI assistance. All changes reviewed for correctness.*