### PR TITLE
Strictify TypeScript across viewer code – eliminate any usages and export missing prop types

### DIFF
--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -1,4 +1,3 @@
-import type React from "react"
 import { useState, useCallback, useRef, useEffect } from "react"
 import * as THREE from "three"
 
@@ -27,7 +26,12 @@ import { ContextMenu } from "./components/ContextMenu"
 import { KeyboardShortcutsDialog } from "./components/KeyboardShortcutsDialog"
 import type { CameraController, CameraPreset } from "./hooks/cameraAnimation"
 
-const CadViewerInner = (props: any) => {
+import type { Props as JscadProps } from "./CadViewerJscad"
+import type { CadViewerManifoldProps } from "./CadViewerManifold"
+
+export type CadViewerProps = JscadProps | CadViewerManifoldProps
+
+const CadViewerInner = (props: CadViewerProps) => {
   const [engine, setEngine] = useState<"jscad" | "manifold">("manifold")
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [isKeyboardShortcutsDialogOpen, setIsKeyboardShortcutsDialogOpen] =
@@ -243,7 +247,7 @@ const CadViewerInner = (props: any) => {
     >
       {engine === "jscad" ? (
         <CadViewerJscad
-          {...props}
+          {...(props as JscadProps)}
           autoRotateDisabled={props.autoRotateDisabled || !autoRotate}
           cameraType={cameraType}
           onUserInteraction={handleUserInteraction}
@@ -251,7 +255,7 @@ const CadViewerInner = (props: any) => {
         />
       ) : (
         <CadViewerManifold
-          {...props}
+          {...(props as CadViewerManifoldProps)}
           autoRotateDisabled={props.autoRotateDisabled || !autoRotate}
           cameraType={cameraType}
           onUserInteraction={handleUserInteraction}
@@ -308,7 +312,7 @@ const CadViewerInner = (props: any) => {
   )
 }
 
-export const CadViewer = (props: any) => {
+export const CadViewer = (props: CadViewerProps) => {
   return (
     <CameraControllerProvider
       defaultTarget={DEFAULT_TARGET}

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -16,7 +16,7 @@ import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
 import { JscadBoardTextures } from "./three-components/JscadBoardTextures"
 import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json"
 
-interface Props {
+export interface Props {
   /**
    * @deprecated Use circuitJson instead.
    */

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -121,7 +121,7 @@ const BoardMeshes = ({
   return null
 }
 
-type CadViewerManifoldProps = {
+export type CadViewerManifoldProps = {
   autoRotateDisabled?: boolean
   clickToInteractEnabled?: boolean
   cameraType?: "orthographic" | "perspective"

--- a/src/contexts/CameraControllerContext.tsx
+++ b/src/contexts/CameraControllerContext.tsx
@@ -18,7 +18,10 @@ import type {
 const CAMERA_KEY = "cadViewerCameraStateSession"
 
 // Camera session storage functions
-export const saveCameraToSession = (camera: THREE.Camera, controls: any) => {
+export const saveCameraToSession = (
+  camera: THREE.Camera,
+  controls: ThreeOrbitControls,
+) => {
   try {
     const savedCameraSession = {
       position: camera.position.toArray(),
@@ -35,7 +38,7 @@ export const saveCameraToSession = (camera: THREE.Camera, controls: any) => {
 
 export const loadCameraFromSession = (
   camera: THREE.Camera,
-  controls: any,
+  controls: ThreeOrbitControls,
 ): boolean => {
   try {
     const raw = sessionStorage.getItem(CAMERA_KEY)
@@ -79,8 +82,14 @@ interface CameraControllerContextValue {
   setCameraPosition: (position: readonly [number, number, number]) => void
   cameraRotation: THREE.Euler
   setCameraRotation: (rotation: THREE.Euler) => void
-  saveCameraToSession: (camera: THREE.Camera, controls: any) => void
-  loadCameraFromSession: (camera: THREE.Camera, controls: any) => boolean
+  saveCameraToSession: (
+    camera: THREE.Camera,
+    controls: ThreeOrbitControls,
+  ) => void
+  loadCameraFromSession: (
+    camera: THREE.Camera,
+    controls: ThreeOrbitControls,
+  ) => boolean
 }
 
 const CameraControllerContext = createContext<


### PR DESCRIPTION
This pull request improves type safety and code clarity in the CAD viewer codebase by introducing and exporting explicit prop types for the main viewer components and updating function signatures to use more specific types. The changes also update the context API to reflect these improvements.

**Type safety and prop type improvements:**

* Introduced and exported `CadViewerProps` as a union of `JscadProps` and `CadViewerManifoldProps`, and updated the `CadViewer` and `CadViewerInner` components to use this type instead of `any` (`src/CadViewer.tsx`). [[1]](diffhunk://#diff-c2f34587e037745be098526705ed329a797c71cee92d446a1dabd699afea6c6bL30-R34) [[2]](diffhunk://#diff-c2f34587e037745be098526705ed329a797c71cee92d446a1dabd699afea6c6bL311-R315)
* Exported the `Props` interface from `src/CadViewerJscad.tsx` for use as `JscadProps` elsewhere in the codebase.
* Exported the `CadViewerManifoldProps` type from `src/CadViewerManifold.tsx` for use in the main viewer component.

**Function signature and context API updates:**

* Updated the `saveCameraToSession` and `loadCameraFromSession` functions in `src/contexts/CameraControllerContext.tsx` to require a `ThreeOrbitControls` type for the `controls` parameter instead of `any`, and updated the context value accordingly. [[1]](diffhunk://#diff-048e3706c262f4d15d0be76f92dcc5ef18c62efe9fd0ad7a1bf6d4c921813d0aL21-R24) [[2]](diffhunk://#diff-048e3706c262f4d15d0be76f92dcc5ef18c62efe9fd0ad7a1bf6d4c921813d0aL38-R41) [[3]](diffhunk://#diff-048e3706c262f4d15d0be76f92dcc5ef18c62efe9fd0ad7a1bf6d4c921813d0aL82-R92)

These changes improve code maintainability and reduce the risk of runtime errors by making prop and function types more explicit throughout the codebase.