### PR TITLE
Implement SVG Board Textures (#534)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
+    "@resvg/resvg-wasm": "^2.6.2",
     "circuit-json": "^0.0.405",
     "circuit-to-canvas": "^0.0.92",
     "react-hot-toast": "^2.6.0",
@@ -37,16 +38,17 @@
     "troika-three-text": "^0.52.4"
   },
   "peerDependencies": {
-    "zod": "3",
+    "@tscircuit/circuit-json-util": "*",
+    "@tscircuit/core": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "@tscircuit/core": "*",
-    "@tscircuit/circuit-json-util": "*"
+    "zod": "3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.4",
     "@chromatic-com/storybook": "^1.9.0",
     "@jscad/modeling": "^2.12.5",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@storybook/blocks": "9.0.0-alpha.17",
     "@storybook/react-vite": "^9.1.5",
     "@tscircuit/alphabet": "^0.0.22",
@@ -56,7 +58,6 @@
     "@types/react": "19",
     "@types/react-dom": "19",
     "@types/three": "^0.165.0",
-    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@vitejs/plugin-react": "^4.3.4",
     "bun-match-svg": "^0.0.9",
     "bun-types": "1.2.1",

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -1,34 +1,34 @@
-import { su } from "@tscircuit/circuit-json-util";
-import type { AnyCircuitElement } from "circuit-json";
-import type * as React from "react";
-import { forwardRef, useMemo } from "react";
-import type * as THREE from "three";
-import { AnyCadComponent } from "./AnyCadComponent";
-import { CadViewerContainer } from "./CadViewerContainer";
-import type { CameraController } from "./hooks/cameraAnimation";
-import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup";
-import { useStlsFromGeom } from "./hooks/use-stls-from-geom";
-import { useBoardGeomBuilder } from "./hooks/useBoardGeomBuilder";
-import { usePcbThickness } from "./hooks/usePcbThickness";
-import { Error3d } from "./three-components/Error3d";
-import { VisibleSTLModel } from "./three-components/VisibleSTLModel";
-import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary";
-import { JscadBoardTextures } from "./three-components/JscadBoardTextures";
-import { SvgBoardTextures } from "./three-components/SvgBoardTextures";
-import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json";
+import { su } from "@tscircuit/circuit-json-util"
+import type { AnyCircuitElement } from "circuit-json"
+import type * as React from "react"
+import { forwardRef, useMemo } from "react"
+import type * as THREE from "three"
+import { AnyCadComponent } from "./AnyCadComponent"
+import { CadViewerContainer } from "./CadViewerContainer"
+import type { CameraController } from "./hooks/cameraAnimation"
+import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup"
+import { useStlsFromGeom } from "./hooks/use-stls-from-geom"
+import { useBoardGeomBuilder } from "./hooks/useBoardGeomBuilder"
+import { usePcbThickness } from "./hooks/usePcbThickness"
+import { Error3d } from "./three-components/Error3d"
+import { VisibleSTLModel } from "./three-components/VisibleSTLModel"
+import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
+import { JscadBoardTextures } from "./three-components/JscadBoardTextures"
+import { SvgBoardTextures } from "./three-components/SvgBoardTextures"
+import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json"
 
 interface Props {
   /**
    * @deprecated Use circuitJson instead.
    */
-  soup?: AnyCircuitElement[];
-  circuitJson?: AnyCircuitElement[];
-  autoRotateDisabled?: boolean;
-  clickToInteractEnabled?: boolean;
-  cameraType?: "orthographic" | "perspective";
-  onUserInteraction?: () => void;
-  onCameraControllerReady?: (controller: CameraController | null) => void;
-  resolveStaticAsset?: (modelUrl: string) => string;
+  soup?: AnyCircuitElement[]
+  circuitJson?: AnyCircuitElement[]
+  autoRotateDisabled?: boolean
+  clickToInteractEnabled?: boolean
+  cameraType?: "orthographic" | "perspective"
+  onUserInteraction?: () => void
+  onCameraControllerReady?: (controller: CameraController | null) => void
+  resolveStaticAsset?: (modelUrl: string) => string
 }
 
 export const CadViewerJscad = forwardRef<
@@ -47,93 +47,93 @@ export const CadViewerJscad = forwardRef<
     },
     ref,
   ) => {
-    const childrenSoup = useConvertChildrenToCircuitJson(children);
+    const childrenSoup = useConvertChildrenToCircuitJson(children)
     const internalCircuitJson = useMemo(() => {
       return addFauxBoardIfNeeded(
         circuitJson ?? childrenSoup,
-      ) as AnyCircuitElement[];
-    }, [circuitJson, childrenSoup]);
+      ) as AnyCircuitElement[]
+    }, [circuitJson, childrenSoup])
 
     // Use the new hook to manage board geometry building
-    const boardGeom = useBoardGeomBuilder(internalCircuitJson);
+    const boardGeom = useBoardGeomBuilder(internalCircuitJson)
 
     const initialCameraPosition = useMemo(() => {
-      if (!internalCircuitJson) return [5, -5, 5] as const;
+      if (!internalCircuitJson) return [5, -5, 5] as const
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0];
-        if (!board) return [5, -5, 5] as const;
-        const { width, height } = board;
+        const board = su(internalCircuitJson as any).pcb_board.list()[0]
+        if (!board) return [5, -5, 5] as const
+        const { width, height } = board
 
         if (!width && !height) {
-          return [5, -5, 5] as const;
+          return [5, -5, 5] as const
         }
 
-        const minCameraDistance = 5;
-        const adjustedBoardWidth = Math.max(width!, minCameraDistance);
-        const adjustedBoardHeight = Math.max(height!, minCameraDistance);
-        const largestDim = Math.max(adjustedBoardWidth, adjustedBoardHeight);
+        const minCameraDistance = 5
+        const adjustedBoardWidth = Math.max(width!, minCameraDistance)
+        const adjustedBoardHeight = Math.max(height!, minCameraDistance)
+        const largestDim = Math.max(adjustedBoardWidth, adjustedBoardHeight)
         // Position the camera for a top-front-right view
         return [
           largestDim * 0.4, // Move right
           -largestDim * 0.7, // Move back (negative Y)
           largestDim * 0.9, // Keep height but slightly lower than top-down
-        ] as const;
+        ] as const
       } catch (e) {
-        console.error(e);
-        return [5, -5, 5] as const;
+        console.error(e)
+        return [5, -5, 5] as const
       }
-    }, [internalCircuitJson]);
+    }, [internalCircuitJson])
 
     const isFauxBoard = useMemo(() => {
-      if (!internalCircuitJson) return false;
+      if (!internalCircuitJson) return false
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0];
-        return !!board && board.pcb_board_id === "faux-board";
+        const board = su(internalCircuitJson as any).pcb_board.list()[0]
+        return !!board && board.pcb_board_id === "faux-board"
       } catch (e) {
-        return false;
+        return false
       }
-    }, [internalCircuitJson]);
+    }, [internalCircuitJson])
 
     const boardDimensions = useMemo(() => {
-      if (!internalCircuitJson) return undefined;
+      if (!internalCircuitJson) return undefined
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0];
-        if (!board) return undefined;
-        return { width: board.width ?? 0, height: board.height ?? 0 };
+        const board = su(internalCircuitJson as any).pcb_board.list()[0]
+        if (!board) return undefined
+        return { width: board.width ?? 0, height: board.height ?? 0 }
       } catch (e) {
-        console.error(e);
-        return undefined;
+        console.error(e)
+        return undefined
       }
-    }, [internalCircuitJson]);
+    }, [internalCircuitJson])
 
     const boardCenter = useMemo(() => {
-      if (!internalCircuitJson) return undefined;
+      if (!internalCircuitJson) return undefined
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0];
-        if (!board || !board.center) return undefined;
-        return { x: board.center.x, y: board.center.y };
+        const board = su(internalCircuitJson as any).pcb_board.list()[0]
+        if (!board || !board.center) return undefined
+        return { x: board.center.x, y: board.center.y }
       } catch (e) {
-        console.error(e);
-        return undefined;
+        console.error(e)
+        return undefined
       }
-    }, [internalCircuitJson]);
+    }, [internalCircuitJson])
 
     const boardData = useMemo(() => {
-      if (!internalCircuitJson) return null;
+      if (!internalCircuitJson) return null
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0];
-        return board ?? null;
+        const board = su(internalCircuitJson as any).pcb_board.list()[0]
+        return board ?? null
       } catch (e) {
-        return null;
+        return null
       }
-    }, [internalCircuitJson]);
+    }, [internalCircuitJson])
 
-    const pcbThickness = usePcbThickness(internalCircuitJson);
+    const pcbThickness = usePcbThickness(internalCircuitJson)
 
     // Use the state `boardGeom` which starts simplified and gets updated
-    const { stls: boardStls, loading } = useStlsFromGeom(boardGeom);
+    const { stls: boardStls, loading } = useStlsFromGeom(boardGeom)
 
-    const cad_components = su(internalCircuitJson).cad_component.list();
+    const cad_components = su(internalCircuitJson).cad_component.list()
 
     return (
       <CadViewerContainer
@@ -182,6 +182,6 @@ export const CadViewerJscad = forwardRef<
           </ThreeErrorBoundary>
         ))}
       </CadViewerContainer>
-    );
+    )
   },
-);
+)

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -1,33 +1,34 @@
-import { su } from "@tscircuit/circuit-json-util"
-import type { AnyCircuitElement } from "circuit-json"
-import type * as React from "react"
-import { forwardRef, useMemo } from "react"
-import type * as THREE from "three"
-import { AnyCadComponent } from "./AnyCadComponent"
-import { CadViewerContainer } from "./CadViewerContainer"
-import type { CameraController } from "./hooks/cameraAnimation"
-import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup"
-import { useStlsFromGeom } from "./hooks/use-stls-from-geom"
-import { useBoardGeomBuilder } from "./hooks/useBoardGeomBuilder"
-import { usePcbThickness } from "./hooks/usePcbThickness"
-import { Error3d } from "./three-components/Error3d"
-import { VisibleSTLModel } from "./three-components/VisibleSTLModel"
-import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
-import { JscadBoardTextures } from "./three-components/JscadBoardTextures"
-import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json"
+import { su } from "@tscircuit/circuit-json-util";
+import type { AnyCircuitElement } from "circuit-json";
+import type * as React from "react";
+import { forwardRef, useMemo } from "react";
+import type * as THREE from "three";
+import { AnyCadComponent } from "./AnyCadComponent";
+import { CadViewerContainer } from "./CadViewerContainer";
+import type { CameraController } from "./hooks/cameraAnimation";
+import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup";
+import { useStlsFromGeom } from "./hooks/use-stls-from-geom";
+import { useBoardGeomBuilder } from "./hooks/useBoardGeomBuilder";
+import { usePcbThickness } from "./hooks/usePcbThickness";
+import { Error3d } from "./three-components/Error3d";
+import { VisibleSTLModel } from "./three-components/VisibleSTLModel";
+import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary";
+import { JscadBoardTextures } from "./three-components/JscadBoardTextures";
+import { SvgBoardTextures } from "./three-components/SvgBoardTextures";
+import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json";
 
 interface Props {
   /**
    * @deprecated Use circuitJson instead.
    */
-  soup?: AnyCircuitElement[]
-  circuitJson?: AnyCircuitElement[]
-  autoRotateDisabled?: boolean
-  clickToInteractEnabled?: boolean
-  cameraType?: "orthographic" | "perspective"
-  onUserInteraction?: () => void
-  onCameraControllerReady?: (controller: CameraController | null) => void
-  resolveStaticAsset?: (modelUrl: string) => string
+  soup?: AnyCircuitElement[];
+  circuitJson?: AnyCircuitElement[];
+  autoRotateDisabled?: boolean;
+  clickToInteractEnabled?: boolean;
+  cameraType?: "orthographic" | "perspective";
+  onUserInteraction?: () => void;
+  onCameraControllerReady?: (controller: CameraController | null) => void;
+  resolveStaticAsset?: (modelUrl: string) => string;
 }
 
 export const CadViewerJscad = forwardRef<
@@ -46,83 +47,93 @@ export const CadViewerJscad = forwardRef<
     },
     ref,
   ) => {
-    const childrenSoup = useConvertChildrenToCircuitJson(children)
+    const childrenSoup = useConvertChildrenToCircuitJson(children);
     const internalCircuitJson = useMemo(() => {
       return addFauxBoardIfNeeded(
         circuitJson ?? childrenSoup,
-      ) as AnyCircuitElement[]
-    }, [circuitJson, childrenSoup])
+      ) as AnyCircuitElement[];
+    }, [circuitJson, childrenSoup]);
 
     // Use the new hook to manage board geometry building
-    const boardGeom = useBoardGeomBuilder(internalCircuitJson)
+    const boardGeom = useBoardGeomBuilder(internalCircuitJson);
 
     const initialCameraPosition = useMemo(() => {
-      if (!internalCircuitJson) return [5, -5, 5] as const
+      if (!internalCircuitJson) return [5, -5, 5] as const;
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0]
-        if (!board) return [5, -5, 5] as const
-        const { width, height } = board
+        const board = su(internalCircuitJson as any).pcb_board.list()[0];
+        if (!board) return [5, -5, 5] as const;
+        const { width, height } = board;
 
         if (!width && !height) {
-          return [5, -5, 5] as const
+          return [5, -5, 5] as const;
         }
 
-        const minCameraDistance = 5
-        const adjustedBoardWidth = Math.max(width!, minCameraDistance)
-        const adjustedBoardHeight = Math.max(height!, minCameraDistance)
-        const largestDim = Math.max(adjustedBoardWidth, adjustedBoardHeight)
+        const minCameraDistance = 5;
+        const adjustedBoardWidth = Math.max(width!, minCameraDistance);
+        const adjustedBoardHeight = Math.max(height!, minCameraDistance);
+        const largestDim = Math.max(adjustedBoardWidth, adjustedBoardHeight);
         // Position the camera for a top-front-right view
         return [
           largestDim * 0.4, // Move right
           -largestDim * 0.7, // Move back (negative Y)
           largestDim * 0.9, // Keep height but slightly lower than top-down
-        ] as const
+        ] as const;
       } catch (e) {
-        console.error(e)
-        return [5, -5, 5] as const
+        console.error(e);
+        return [5, -5, 5] as const;
       }
-    }, [internalCircuitJson])
+    }, [internalCircuitJson]);
 
     const isFauxBoard = useMemo(() => {
-      if (!internalCircuitJson) return false
+      if (!internalCircuitJson) return false;
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0]
-        return !!board && board.pcb_board_id === "faux-board"
+        const board = su(internalCircuitJson as any).pcb_board.list()[0];
+        return !!board && board.pcb_board_id === "faux-board";
       } catch (e) {
-        return false
+        return false;
       }
-    }, [internalCircuitJson])
+    }, [internalCircuitJson]);
 
     const boardDimensions = useMemo(() => {
-      if (!internalCircuitJson) return undefined
+      if (!internalCircuitJson) return undefined;
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0]
-        if (!board) return undefined
-        return { width: board.width ?? 0, height: board.height ?? 0 }
+        const board = su(internalCircuitJson as any).pcb_board.list()[0];
+        if (!board) return undefined;
+        return { width: board.width ?? 0, height: board.height ?? 0 };
       } catch (e) {
-        console.error(e)
-        return undefined
+        console.error(e);
+        return undefined;
       }
-    }, [internalCircuitJson])
+    }, [internalCircuitJson]);
 
     const boardCenter = useMemo(() => {
-      if (!internalCircuitJson) return undefined
+      if (!internalCircuitJson) return undefined;
       try {
-        const board = su(internalCircuitJson as any).pcb_board.list()[0]
-        if (!board || !board.center) return undefined
-        return { x: board.center.x, y: board.center.y }
+        const board = su(internalCircuitJson as any).pcb_board.list()[0];
+        if (!board || !board.center) return undefined;
+        return { x: board.center.x, y: board.center.y };
       } catch (e) {
-        console.error(e)
-        return undefined
+        console.error(e);
+        return undefined;
       }
-    }, [internalCircuitJson])
+    }, [internalCircuitJson]);
 
-    const pcbThickness = usePcbThickness(internalCircuitJson)
+    const boardData = useMemo(() => {
+      if (!internalCircuitJson) return null;
+      try {
+        const board = su(internalCircuitJson as any).pcb_board.list()[0];
+        return board ?? null;
+      } catch (e) {
+        return null;
+      }
+    }, [internalCircuitJson]);
+
+    const pcbThickness = usePcbThickness(internalCircuitJson);
 
     // Use the state `boardGeom` which starts simplified and gets updated
-    const { stls: boardStls, loading } = useStlsFromGeom(boardGeom)
+    const { stls: boardStls, loading } = useStlsFromGeom(boardGeom);
 
-    const cad_components = su(internalCircuitJson).cad_component.list()
+    const cad_components = su(internalCircuitJson).cad_component.list();
 
     return (
       <CadViewerContainer
@@ -149,6 +160,12 @@ export const CadViewerJscad = forwardRef<
           pcbThickness={pcbThickness}
           isFaux={isFauxBoard}
         />
+        <SvgBoardTextures
+          circuitJson={internalCircuitJson}
+          boardData={boardData}
+          pcbThickness={pcbThickness}
+          isFaux={isFauxBoard}
+        />
         {cad_components.map((cad_component) => (
           <ThreeErrorBoundary
             key={cad_component.cad_component_id}
@@ -165,6 +182,6 @@ export const CadViewerJscad = forwardRef<
           </ThreeErrorBoundary>
         ))}
       </CadViewerContainer>
-    )
+    );
   },
-)
+);

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -1,27 +1,28 @@
-import { su } from "@tscircuit/circuit-json-util"
-import type { AnyCircuitElement, CadComponent } from "circuit-json"
-import type { ManifoldToplevel } from "manifold-3d"
-import type React from "react"
-import { useEffect, useMemo, useState } from "react"
-import * as THREE from "three"
-import { AnyCadComponent } from "./AnyCadComponent"
-import { CadViewerContainer } from "./CadViewerContainer"
-import { useLayerVisibility } from "./contexts/LayerVisibilityContext"
-import type { CameraController } from "./hooks/cameraAnimation"
-import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup"
-import { useManifoldBoardBuilder } from "./hooks/useManifoldBoardBuilder"
-import { useThree } from "./react-three/ThreeContext"
-import { createTextureMeshes } from "./textures"
-import { Error3d } from "./three-components/Error3d"
-import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
-import { createGeometryMeshes } from "./utils/manifold/create-three-geometry-meshes"
-import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json"
+import { su } from "@tscircuit/circuit-json-util";
+import type { AnyCircuitElement, CadComponent } from "circuit-json";
+import type { ManifoldToplevel } from "manifold-3d";
+import type React from "react";
+import { useEffect, useMemo, useState } from "react";
+import * as THREE from "three";
+import { AnyCadComponent } from "./AnyCadComponent";
+import { CadViewerContainer } from "./CadViewerContainer";
+import { useLayerVisibility } from "./contexts/LayerVisibilityContext";
+import type { CameraController } from "./hooks/cameraAnimation";
+import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup";
+import { useManifoldBoardBuilder } from "./hooks/useManifoldBoardBuilder";
+import { useThree } from "./react-three/ThreeContext";
+import { createTextureMeshes } from "./textures";
+import { Error3d } from "./three-components/Error3d";
+import { SvgBoardTextures } from "./three-components/SvgBoardTextures";
+import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary";
+import { createGeometryMeshes } from "./utils/manifold/create-three-geometry-meshes";
+import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json";
 
 declare global {
   interface Window {
-    ManifoldModule: any
-    MANIFOLD?: any
-    MANIFOLD_MODULE?: any
+    ManifoldModule: any;
+    MANIFOLD?: any;
+    MANIFOLD_MODULE?: any;
   }
 }
 
@@ -29,20 +30,20 @@ const BoardMeshes = ({
   geometryMeshes,
   textureMeshes,
 }: {
-  geometryMeshes: THREE.Mesh[]
-  textureMeshes: THREE.Mesh[]
+  geometryMeshes: THREE.Mesh[];
+  textureMeshes: THREE.Mesh[];
 }) => {
-  const { rootObject } = useThree()
-  const { visibility } = useLayerVisibility()
+  const { rootObject } = useThree();
+  const { visibility } = useLayerVisibility();
 
   const disposeMesh = (mesh: THREE.Mesh) => {
-    mesh.geometry.dispose()
+    mesh.geometry.dispose();
     const materials = Array.isArray(mesh.material)
       ? mesh.material
-      : [mesh.material]
+      : [mesh.material];
 
     for (const material of materials) {
-      if (!material) continue
+      if (!material) continue;
 
       const textureProps = [
         "map",
@@ -56,84 +57,84 @@ const BoardMeshes = ({
         "normalMap",
         "roughnessMap",
         "specularMap",
-      ] as const
+      ] as const;
       const typedMaterial = material as THREE.Material &
-        Record<(typeof textureProps)[number], THREE.Texture | null | undefined>
+        Record<(typeof textureProps)[number], THREE.Texture | null | undefined>;
 
       for (const prop of textureProps) {
-        const texture = typedMaterial[prop]
+        const texture = typedMaterial[prop];
         if (texture && texture instanceof THREE.Texture) {
-          texture.dispose()
-          typedMaterial[prop] = null
+          texture.dispose();
+          typedMaterial[prop] = null;
         }
       }
 
-      material.dispose()
+      material.dispose();
     }
-  }
+  };
 
   useEffect(() => {
-    if (!rootObject) return
+    if (!rootObject) return;
 
     geometryMeshes.forEach((mesh) => {
-      let shouldShow = true
+      let shouldShow = true;
       if (mesh.name === "board-geom") {
-        shouldShow = visibility.boardBody
+        shouldShow = visibility.boardBody;
       } else if (
         mesh.name.includes("plated_hole") ||
         mesh.name.includes("via")
       ) {
-        shouldShow = visibility.topCopper || visibility.bottomCopper
+        shouldShow = visibility.topCopper || visibility.bottomCopper;
       }
 
       if (shouldShow) {
-        rootObject.add(mesh)
+        rootObject.add(mesh);
       }
-    })
+    });
 
     return () => {
       geometryMeshes.forEach((mesh) => {
         if (mesh.parent === rootObject) {
-          rootObject.remove(mesh)
+          rootObject.remove(mesh);
         }
-        disposeMesh(mesh)
-      })
-    }
-  }, [rootObject, geometryMeshes, visibility])
+        disposeMesh(mesh);
+      });
+    };
+  }, [rootObject, geometryMeshes, visibility]);
 
   useEffect(() => {
-    if (!rootObject) return
+    if (!rootObject) return;
 
     textureMeshes.forEach((mesh) => {
-      rootObject.add(mesh)
-    })
+      rootObject.add(mesh);
+    });
 
     return () => {
       textureMeshes.forEach((mesh) => {
         if (mesh.parent === rootObject) {
-          rootObject.remove(mesh)
+          rootObject.remove(mesh);
         }
-        disposeMesh(mesh)
-      })
-    }
-  }, [rootObject, textureMeshes])
+        disposeMesh(mesh);
+      });
+    };
+  }, [rootObject, textureMeshes]);
 
-  return null
-}
+  return null;
+};
 
 type CadViewerManifoldProps = {
-  autoRotateDisabled?: boolean
-  clickToInteractEnabled?: boolean
-  cameraType?: "orthographic" | "perspective"
-  onUserInteraction?: () => void
-  onCameraControllerReady?: (controller: CameraController | null) => void
-  resolveStaticAsset?: (modelUrl: string) => string
+  autoRotateDisabled?: boolean;
+  clickToInteractEnabled?: boolean;
+  cameraType?: "orthographic" | "perspective";
+  onUserInteraction?: () => void;
+  onCameraControllerReady?: (controller: CameraController | null) => void;
+  resolveStaticAsset?: (modelUrl: string) => string;
 } & (
   | { circuitJson: AnyCircuitElement[]; children?: React.ReactNode }
   | { circuitJson?: never; children: React.ReactNode }
-)
+);
 
-const MANIFOLD_CDN_BASE_URL = "https://cdn.jsdelivr.net/npm/manifold-3d@3.2.1"
+const MANIFOLD_CDN_BASE_URL = "https://cdn.jsdelivr.net/npm/manifold-3d@3.2.1";
 
 const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
   circuitJson: circuitJsonProp,
@@ -144,17 +145,17 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
   onCameraControllerReady,
   resolveStaticAsset,
 }) => {
-  const childrenCircuitJson = useConvertChildrenToCircuitJson(children)
+  const childrenCircuitJson = useConvertChildrenToCircuitJson(children);
   const circuitJson = useMemo(() => {
-    const rawCircuitJson = circuitJsonProp ?? childrenCircuitJson
-    return addFauxBoardIfNeeded(rawCircuitJson)
-  }, [circuitJsonProp, childrenCircuitJson])
+    const rawCircuitJson = circuitJsonProp ?? childrenCircuitJson;
+    return addFauxBoardIfNeeded(rawCircuitJson);
+  }, [circuitJsonProp, childrenCircuitJson]);
 
-  const [manifoldJSModule, setManifoldJSModule] = useState<any | null>(null)
+  const [manifoldJSModule, setManifoldJSModule] = useState<any | null>(null);
   const [manifoldLoadingError, setManifoldLoadingError] = useState<
     string | null
-  >(null)
-  const { visibility } = useLayerVisibility()
+  >(null);
+  const { visibility } = useLayerVisibility();
 
   useEffect(() => {
     if (
@@ -162,50 +163,50 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
       typeof window.ManifoldModule === "object" &&
       window.ManifoldModule.setup
     ) {
-      setManifoldJSModule(window.ManifoldModule)
-      return
+      setManifoldJSModule(window.ManifoldModule);
+      return;
     }
 
     const initManifold = async (ManifoldModule: any) => {
       try {
-        const loadedModule: ManifoldToplevel = await ManifoldModule()
-        loadedModule.setup()
-        window.ManifoldModule = loadedModule
-        setManifoldJSModule(loadedModule)
+        const loadedModule: ManifoldToplevel = await ManifoldModule();
+        loadedModule.setup();
+        window.ManifoldModule = loadedModule;
+        setManifoldJSModule(loadedModule);
       } catch (error) {
-        console.error("Failed to initialize Manifold:", error)
+        console.error("Failed to initialize Manifold:", error);
         setManifoldLoadingError(
           `Failed to initialize Manifold: ${error instanceof Error ? error.message : "Unknown error"}`,
-        )
+        );
       }
-    }
+    };
 
     const existingManifold =
-      window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE
+      window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE;
     if (existingManifold) {
-      window.ManifoldModule = existingManifold
-      initManifold(window.ManifoldModule)
-      return
+      window.ManifoldModule = existingManifold;
+      initManifold(window.ManifoldModule);
+      return;
     }
 
-    const eventName = "manifoldLoaded"
+    const eventName = "manifoldLoaded";
     const handleLoad = () => {
       const loadedManifold =
-        window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE
+        window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE;
       if (loadedManifold) {
-        window.ManifoldModule = loadedManifold
-        initManifold(window.ManifoldModule)
+        window.ManifoldModule = loadedManifold;
+        initManifold(window.ManifoldModule);
       } else {
-        const errText = "ManifoldModule not found on window after script load."
-        console.error(errText)
-        setManifoldLoadingError(errText)
+        const errText = "ManifoldModule not found on window after script load.";
+        console.error(errText);
+        setManifoldLoadingError(errText);
       }
-    }
+    };
 
-    window.addEventListener(eventName, handleLoad, { once: true })
+    window.addEventListener(eventName, handleLoad, { once: true });
 
-    const script = document.createElement("script")
-    script.type = "module"
+    const script = document.createElement("script");
+    script.type = "module";
     script.innerHTML = `
 try {
   const { default: ManifoldModule } = await import('${MANIFOLD_CDN_BASE_URL}/manifold.js');
@@ -215,23 +216,23 @@ try {
 } finally {
   window.dispatchEvent(new CustomEvent('${eventName}'));
 }
-    `.trim()
+    `.trim();
 
     const scriptError = (err: any) => {
-      const errText = "Failed to load Manifold loader script."
-      console.error(errText, err)
-      setManifoldLoadingError(errText)
-      window.removeEventListener(eventName, handleLoad)
-    }
+      const errText = "Failed to load Manifold loader script.";
+      console.error(errText, err);
+      setManifoldLoadingError(errText);
+      window.removeEventListener(eventName, handleLoad);
+    };
 
-    script.addEventListener("error", scriptError)
-    document.body.appendChild(script)
+    script.addEventListener("error", scriptError);
+    document.body.appendChild(script);
 
     return () => {
-      window.removeEventListener(eventName, handleLoad)
-      script.removeEventListener("error", scriptError)
-    }
-  }, [])
+      window.removeEventListener(eventName, handleLoad);
+      script.removeEventListener("error", scriptError);
+    };
+  }, []);
 
   const {
     geoms,
@@ -241,44 +242,44 @@ try {
     isLoading: builderIsLoading,
     boardData,
     isFauxBoard,
-  } = useManifoldBoardBuilder(manifoldJSModule, circuitJson, visibility)
+  } = useManifoldBoardBuilder(manifoldJSModule, circuitJson, visibility);
 
-  const geometryMeshes = useMemo(() => createGeometryMeshes(geoms), [geoms])
+  const geometryMeshes = useMemo(() => createGeometryMeshes(geoms), [geoms]);
   const textureMeshes = useMemo(
     () => createTextureMeshes(textures, boardData, pcbThickness, isFauxBoard),
     [textures, boardData, pcbThickness, isFauxBoard],
-  )
+  );
 
   const cadComponents = useMemo(
     () => su(circuitJson).cad_component.list(),
     [circuitJson],
-  )
+  );
 
   const boardDimensions = useMemo(() => {
-    if (!boardData) return undefined
-    const { width = 0, height = 0 } = boardData
-    return { width, height }
-  }, [boardData])
+    if (!boardData) return undefined;
+    const { width = 0, height = 0 } = boardData;
+    return { width, height };
+  }, [boardData]);
 
   const boardCenter = useMemo(() => {
-    if (!boardData) return undefined
-    const { center } = boardData
-    if (!center) return undefined
-    return { x: center.x, y: center.y }
-  }, [boardData])
+    if (!boardData) return undefined;
+    const { center } = boardData;
+    if (!center) return undefined;
+    return { x: center.x, y: center.y };
+  }, [boardData]);
 
   const initialCameraPosition = useMemo(() => {
-    if (!boardData) return [5, -5, 5] as const
-    const { width = 0, height = 0 } = boardData
-    const safeWidth = Math.max(width, 1)
-    const safeHeight = Math.max(height, 1)
-    const largestDim = Math.max(safeWidth, safeHeight, 5)
+    if (!boardData) return [5, -5, 5] as const;
+    const { width = 0, height = 0 } = boardData;
+    const safeWidth = Math.max(width, 1);
+    const safeHeight = Math.max(height, 1);
+    const largestDim = Math.max(safeWidth, safeHeight, 5);
     return [
       largestDim * 0.4, // Move right
       -largestDim * 0.7, // Move back (negative Y)
       largestDim * 0.9, // Keep height but slightly lower than top-down
-    ] as const
-  }, [boardData])
+    ] as const;
+  }, [boardData]);
 
   if (manifoldLoadingError) {
     return (
@@ -292,10 +293,10 @@ try {
       >
         Error: {manifoldLoadingError}
       </div>
-    )
+    );
   }
   if (!manifoldJSModule) {
-    return <div style={{ padding: "1em" }}>Loading Manifold module...</div>
+    return <div style={{ padding: "1em" }}>Loading Manifold module...</div>;
   }
   if (builderError) {
     return (
@@ -309,10 +310,10 @@ try {
       >
         Error: {builderError}
       </div>
-    )
+    );
   }
   if (builderIsLoading) {
-    return <div style={{ padding: "1em" }}>Processing board geometry...</div>
+    return <div style={{ padding: "1em" }}>Processing board geometry...</div>;
   }
 
   return (
@@ -329,6 +330,12 @@ try {
         geometryMeshes={geometryMeshes}
         textureMeshes={textureMeshes}
       />
+      <SvgBoardTextures
+        circuitJson={circuitJson}
+        boardData={boardData}
+        pcbThickness={pcbThickness ?? 1.6}
+        isFaux={isFauxBoard}
+      />
       {cadComponents.map((cad_component: CadComponent) => (
         <ThreeErrorBoundary
           key={cad_component.cad_component_id}
@@ -344,7 +351,7 @@ try {
         </ThreeErrorBoundary>
       ))}
     </CadViewerContainer>
-  )
-}
+  );
+};
 
-export default CadViewerManifold
+export default CadViewerManifold;

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -1,28 +1,28 @@
-import { su } from "@tscircuit/circuit-json-util";
-import type { AnyCircuitElement, CadComponent } from "circuit-json";
-import type { ManifoldToplevel } from "manifold-3d";
-import type React from "react";
-import { useEffect, useMemo, useState } from "react";
-import * as THREE from "three";
-import { AnyCadComponent } from "./AnyCadComponent";
-import { CadViewerContainer } from "./CadViewerContainer";
-import { useLayerVisibility } from "./contexts/LayerVisibilityContext";
-import type { CameraController } from "./hooks/cameraAnimation";
-import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup";
-import { useManifoldBoardBuilder } from "./hooks/useManifoldBoardBuilder";
-import { useThree } from "./react-three/ThreeContext";
-import { createTextureMeshes } from "./textures";
-import { Error3d } from "./three-components/Error3d";
-import { SvgBoardTextures } from "./three-components/SvgBoardTextures";
-import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary";
-import { createGeometryMeshes } from "./utils/manifold/create-three-geometry-meshes";
-import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json";
+import { su } from "@tscircuit/circuit-json-util"
+import type { AnyCircuitElement, CadComponent } from "circuit-json"
+import type { ManifoldToplevel } from "manifold-3d"
+import type React from "react"
+import { useEffect, useMemo, useState } from "react"
+import * as THREE from "three"
+import { AnyCadComponent } from "./AnyCadComponent"
+import { CadViewerContainer } from "./CadViewerContainer"
+import { useLayerVisibility } from "./contexts/LayerVisibilityContext"
+import type { CameraController } from "./hooks/cameraAnimation"
+import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup"
+import { useManifoldBoardBuilder } from "./hooks/useManifoldBoardBuilder"
+import { useThree } from "./react-three/ThreeContext"
+import { createTextureMeshes } from "./textures"
+import { Error3d } from "./three-components/Error3d"
+import { SvgBoardTextures } from "./three-components/SvgBoardTextures"
+import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
+import { createGeometryMeshes } from "./utils/manifold/create-three-geometry-meshes"
+import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json"
 
 declare global {
   interface Window {
-    ManifoldModule: any;
-    MANIFOLD?: any;
-    MANIFOLD_MODULE?: any;
+    ManifoldModule: any
+    MANIFOLD?: any
+    MANIFOLD_MODULE?: any
   }
 }
 
@@ -30,20 +30,20 @@ const BoardMeshes = ({
   geometryMeshes,
   textureMeshes,
 }: {
-  geometryMeshes: THREE.Mesh[];
-  textureMeshes: THREE.Mesh[];
+  geometryMeshes: THREE.Mesh[]
+  textureMeshes: THREE.Mesh[]
 }) => {
-  const { rootObject } = useThree();
-  const { visibility } = useLayerVisibility();
+  const { rootObject } = useThree()
+  const { visibility } = useLayerVisibility()
 
   const disposeMesh = (mesh: THREE.Mesh) => {
-    mesh.geometry.dispose();
+    mesh.geometry.dispose()
     const materials = Array.isArray(mesh.material)
       ? mesh.material
-      : [mesh.material];
+      : [mesh.material]
 
     for (const material of materials) {
-      if (!material) continue;
+      if (!material) continue
 
       const textureProps = [
         "map",
@@ -57,84 +57,84 @@ const BoardMeshes = ({
         "normalMap",
         "roughnessMap",
         "specularMap",
-      ] as const;
+      ] as const
       const typedMaterial = material as THREE.Material &
-        Record<(typeof textureProps)[number], THREE.Texture | null | undefined>;
+        Record<(typeof textureProps)[number], THREE.Texture | null | undefined>
 
       for (const prop of textureProps) {
-        const texture = typedMaterial[prop];
+        const texture = typedMaterial[prop]
         if (texture && texture instanceof THREE.Texture) {
-          texture.dispose();
-          typedMaterial[prop] = null;
+          texture.dispose()
+          typedMaterial[prop] = null
         }
       }
 
-      material.dispose();
+      material.dispose()
     }
-  };
+  }
 
   useEffect(() => {
-    if (!rootObject) return;
+    if (!rootObject) return
 
     geometryMeshes.forEach((mesh) => {
-      let shouldShow = true;
+      let shouldShow = true
       if (mesh.name === "board-geom") {
-        shouldShow = visibility.boardBody;
+        shouldShow = visibility.boardBody
       } else if (
         mesh.name.includes("plated_hole") ||
         mesh.name.includes("via")
       ) {
-        shouldShow = visibility.topCopper || visibility.bottomCopper;
+        shouldShow = visibility.topCopper || visibility.bottomCopper
       }
 
       if (shouldShow) {
-        rootObject.add(mesh);
+        rootObject.add(mesh)
       }
-    });
+    })
 
     return () => {
       geometryMeshes.forEach((mesh) => {
         if (mesh.parent === rootObject) {
-          rootObject.remove(mesh);
+          rootObject.remove(mesh)
         }
-        disposeMesh(mesh);
-      });
-    };
-  }, [rootObject, geometryMeshes, visibility]);
+        disposeMesh(mesh)
+      })
+    }
+  }, [rootObject, geometryMeshes, visibility])
 
   useEffect(() => {
-    if (!rootObject) return;
+    if (!rootObject) return
 
     textureMeshes.forEach((mesh) => {
-      rootObject.add(mesh);
-    });
+      rootObject.add(mesh)
+    })
 
     return () => {
       textureMeshes.forEach((mesh) => {
         if (mesh.parent === rootObject) {
-          rootObject.remove(mesh);
+          rootObject.remove(mesh)
         }
-        disposeMesh(mesh);
-      });
-    };
-  }, [rootObject, textureMeshes]);
+        disposeMesh(mesh)
+      })
+    }
+  }, [rootObject, textureMeshes])
 
-  return null;
-};
+  return null
+}
 
 type CadViewerManifoldProps = {
-  autoRotateDisabled?: boolean;
-  clickToInteractEnabled?: boolean;
-  cameraType?: "orthographic" | "perspective";
-  onUserInteraction?: () => void;
-  onCameraControllerReady?: (controller: CameraController | null) => void;
-  resolveStaticAsset?: (modelUrl: string) => string;
+  autoRotateDisabled?: boolean
+  clickToInteractEnabled?: boolean
+  cameraType?: "orthographic" | "perspective"
+  onUserInteraction?: () => void
+  onCameraControllerReady?: (controller: CameraController | null) => void
+  resolveStaticAsset?: (modelUrl: string) => string
 } & (
   | { circuitJson: AnyCircuitElement[]; children?: React.ReactNode }
   | { circuitJson?: never; children: React.ReactNode }
-);
+)
 
-const MANIFOLD_CDN_BASE_URL = "https://cdn.jsdelivr.net/npm/manifold-3d@3.2.1";
+const MANIFOLD_CDN_BASE_URL = "https://cdn.jsdelivr.net/npm/manifold-3d@3.2.1"
 
 const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
   circuitJson: circuitJsonProp,
@@ -145,17 +145,17 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
   onCameraControllerReady,
   resolveStaticAsset,
 }) => {
-  const childrenCircuitJson = useConvertChildrenToCircuitJson(children);
+  const childrenCircuitJson = useConvertChildrenToCircuitJson(children)
   const circuitJson = useMemo(() => {
-    const rawCircuitJson = circuitJsonProp ?? childrenCircuitJson;
-    return addFauxBoardIfNeeded(rawCircuitJson);
-  }, [circuitJsonProp, childrenCircuitJson]);
+    const rawCircuitJson = circuitJsonProp ?? childrenCircuitJson
+    return addFauxBoardIfNeeded(rawCircuitJson)
+  }, [circuitJsonProp, childrenCircuitJson])
 
-  const [manifoldJSModule, setManifoldJSModule] = useState<any | null>(null);
+  const [manifoldJSModule, setManifoldJSModule] = useState<any | null>(null)
   const [manifoldLoadingError, setManifoldLoadingError] = useState<
     string | null
-  >(null);
-  const { visibility } = useLayerVisibility();
+  >(null)
+  const { visibility } = useLayerVisibility()
 
   useEffect(() => {
     if (
@@ -163,50 +163,50 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
       typeof window.ManifoldModule === "object" &&
       window.ManifoldModule.setup
     ) {
-      setManifoldJSModule(window.ManifoldModule);
-      return;
+      setManifoldJSModule(window.ManifoldModule)
+      return
     }
 
     const initManifold = async (ManifoldModule: any) => {
       try {
-        const loadedModule: ManifoldToplevel = await ManifoldModule();
-        loadedModule.setup();
-        window.ManifoldModule = loadedModule;
-        setManifoldJSModule(loadedModule);
+        const loadedModule: ManifoldToplevel = await ManifoldModule()
+        loadedModule.setup()
+        window.ManifoldModule = loadedModule
+        setManifoldJSModule(loadedModule)
       } catch (error) {
-        console.error("Failed to initialize Manifold:", error);
+        console.error("Failed to initialize Manifold:", error)
         setManifoldLoadingError(
           `Failed to initialize Manifold: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
+        )
       }
-    };
-
-    const existingManifold =
-      window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE;
-    if (existingManifold) {
-      window.ManifoldModule = existingManifold;
-      initManifold(window.ManifoldModule);
-      return;
     }
 
-    const eventName = "manifoldLoaded";
+    const existingManifold =
+      window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE
+    if (existingManifold) {
+      window.ManifoldModule = existingManifold
+      initManifold(window.ManifoldModule)
+      return
+    }
+
+    const eventName = "manifoldLoaded"
     const handleLoad = () => {
       const loadedManifold =
-        window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE;
+        window.ManifoldModule ?? window.MANIFOLD ?? window.MANIFOLD_MODULE
       if (loadedManifold) {
-        window.ManifoldModule = loadedManifold;
-        initManifold(window.ManifoldModule);
+        window.ManifoldModule = loadedManifold
+        initManifold(window.ManifoldModule)
       } else {
-        const errText = "ManifoldModule not found on window after script load.";
-        console.error(errText);
-        setManifoldLoadingError(errText);
+        const errText = "ManifoldModule not found on window after script load."
+        console.error(errText)
+        setManifoldLoadingError(errText)
       }
-    };
+    }
 
-    window.addEventListener(eventName, handleLoad, { once: true });
+    window.addEventListener(eventName, handleLoad, { once: true })
 
-    const script = document.createElement("script");
-    script.type = "module";
+    const script = document.createElement("script")
+    script.type = "module"
     script.innerHTML = `
 try {
   const { default: ManifoldModule } = await import('${MANIFOLD_CDN_BASE_URL}/manifold.js');
@@ -216,23 +216,23 @@ try {
 } finally {
   window.dispatchEvent(new CustomEvent('${eventName}'));
 }
-    `.trim();
+    `.trim()
 
     const scriptError = (err: any) => {
-      const errText = "Failed to load Manifold loader script.";
-      console.error(errText, err);
-      setManifoldLoadingError(errText);
-      window.removeEventListener(eventName, handleLoad);
-    };
+      const errText = "Failed to load Manifold loader script."
+      console.error(errText, err)
+      setManifoldLoadingError(errText)
+      window.removeEventListener(eventName, handleLoad)
+    }
 
-    script.addEventListener("error", scriptError);
-    document.body.appendChild(script);
+    script.addEventListener("error", scriptError)
+    document.body.appendChild(script)
 
     return () => {
-      window.removeEventListener(eventName, handleLoad);
-      script.removeEventListener("error", scriptError);
-    };
-  }, []);
+      window.removeEventListener(eventName, handleLoad)
+      script.removeEventListener("error", scriptError)
+    }
+  }, [])
 
   const {
     geoms,
@@ -242,44 +242,44 @@ try {
     isLoading: builderIsLoading,
     boardData,
     isFauxBoard,
-  } = useManifoldBoardBuilder(manifoldJSModule, circuitJson, visibility);
+  } = useManifoldBoardBuilder(manifoldJSModule, circuitJson, visibility)
 
-  const geometryMeshes = useMemo(() => createGeometryMeshes(geoms), [geoms]);
+  const geometryMeshes = useMemo(() => createGeometryMeshes(geoms), [geoms])
   const textureMeshes = useMemo(
     () => createTextureMeshes(textures, boardData, pcbThickness, isFauxBoard),
     [textures, boardData, pcbThickness, isFauxBoard],
-  );
+  )
 
   const cadComponents = useMemo(
     () => su(circuitJson).cad_component.list(),
     [circuitJson],
-  );
+  )
 
   const boardDimensions = useMemo(() => {
-    if (!boardData) return undefined;
-    const { width = 0, height = 0 } = boardData;
-    return { width, height };
-  }, [boardData]);
+    if (!boardData) return undefined
+    const { width = 0, height = 0 } = boardData
+    return { width, height }
+  }, [boardData])
 
   const boardCenter = useMemo(() => {
-    if (!boardData) return undefined;
-    const { center } = boardData;
-    if (!center) return undefined;
-    return { x: center.x, y: center.y };
-  }, [boardData]);
+    if (!boardData) return undefined
+    const { center } = boardData
+    if (!center) return undefined
+    return { x: center.x, y: center.y }
+  }, [boardData])
 
   const initialCameraPosition = useMemo(() => {
-    if (!boardData) return [5, -5, 5] as const;
-    const { width = 0, height = 0 } = boardData;
-    const safeWidth = Math.max(width, 1);
-    const safeHeight = Math.max(height, 1);
-    const largestDim = Math.max(safeWidth, safeHeight, 5);
+    if (!boardData) return [5, -5, 5] as const
+    const { width = 0, height = 0 } = boardData
+    const safeWidth = Math.max(width, 1)
+    const safeHeight = Math.max(height, 1)
+    const largestDim = Math.max(safeWidth, safeHeight, 5)
     return [
       largestDim * 0.4, // Move right
       -largestDim * 0.7, // Move back (negative Y)
       largestDim * 0.9, // Keep height but slightly lower than top-down
-    ] as const;
-  }, [boardData]);
+    ] as const
+  }, [boardData])
 
   if (manifoldLoadingError) {
     return (
@@ -293,10 +293,10 @@ try {
       >
         Error: {manifoldLoadingError}
       </div>
-    );
+    )
   }
   if (!manifoldJSModule) {
-    return <div style={{ padding: "1em" }}>Loading Manifold module...</div>;
+    return <div style={{ padding: "1em" }}>Loading Manifold module...</div>
   }
   if (builderError) {
     return (
@@ -310,10 +310,10 @@ try {
       >
         Error: {builderError}
       </div>
-    );
+    )
   }
   if (builderIsLoading) {
-    return <div style={{ padding: "1em" }}>Processing board geometry...</div>;
+    return <div style={{ padding: "1em" }}>Processing board geometry...</div>
   }
 
   return (
@@ -351,7 +351,7 @@ try {
         </ThreeErrorBoundary>
       ))}
     </CadViewerContainer>
-  );
-};
+  )
+}
 
-export default CadViewerManifold;
+export default CadViewerManifold

--- a/src/components/AppearanceMenu.tsx
+++ b/src/components/AppearanceMenu.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
-import { useLayerVisibility } from "../contexts/LayerVisibilityContext";
-import type React from "react";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, ChevronRightIcon } from "./Icons";
-import { zIndexMap } from "../../lib/utils/z-index-map";
+import { useState } from "react"
+import { useLayerVisibility } from "../contexts/LayerVisibilityContext"
+import type React from "react"
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { CheckIcon, ChevronRightIcon } from "./Icons"
+import { zIndexMap } from "../../lib/utils/z-index-map"
 
 const itemStyles: React.CSSProperties = {
   padding: "6px 8px",
@@ -20,20 +20,20 @@ const itemStyles: React.CSSProperties = {
   transition: "background-color 0.15s ease, color 0.15s ease",
   fontFamily:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-};
+}
 
 const itemPaddingStyles: React.CSSProperties = {
   paddingLeft: 32,
   paddingTop: 6,
   paddingBottom: 6,
   paddingRight: 8,
-};
+}
 
 const separatorStyles: React.CSSProperties = {
   height: 1,
   backgroundColor: "#ffffff1a",
   margin: "4px 0",
-};
+}
 
 const contentStyles: React.CSSProperties = {
   backgroundColor: "#262626",
@@ -48,7 +48,7 @@ const contentStyles: React.CSSProperties = {
   fontSize: 14,
   fontFamily:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-};
+}
 
 const iconContainerStyles: React.CSSProperties = {
   width: 16,
@@ -57,12 +57,12 @@ const iconContainerStyles: React.CSSProperties = {
   alignItems: "flex-end",
   justifyContent: "center",
   flexShrink: 0,
-};
+}
 
 export const AppearanceMenu = () => {
-  const { visibility, setLayerVisibility } = useLayerVisibility();
-  const [appearanceSubOpen, setAppearanceSubOpen] = useState(false);
-  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+  const { visibility, setLayerVisibility } = useLayerVisibility()
+  const [appearanceSubOpen, setAppearanceSubOpen] = useState(false)
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null)
 
   return (
     <>
@@ -111,11 +111,11 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
+                e.preventDefault()
                 setLayerVisibility(
                   "svgTexturesEnabled",
                   !visibility.svgTexturesEnabled,
-                );
+                )
               }}
               onMouseEnter={() => setHoveredItem("svgTextures")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -149,8 +149,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("boardBody", !visibility.boardBody);
+                e.preventDefault()
+                setLayerVisibility("boardBody", !visibility.boardBody)
               }}
               onMouseEnter={() => setHoveredItem("boardBody")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -172,8 +172,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("topCopper", !visibility.topCopper);
+                e.preventDefault()
+                setLayerVisibility("topCopper", !visibility.topCopper)
               }}
               onMouseEnter={() => setHoveredItem("topCopper")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -195,8 +195,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("bottomCopper", !visibility.bottomCopper);
+                e.preventDefault()
+                setLayerVisibility("bottomCopper", !visibility.bottomCopper)
               }}
               onMouseEnter={() => setHoveredItem("bottomCopper")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -218,8 +218,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("topSilkscreen", !visibility.topSilkscreen);
+                e.preventDefault()
+                setLayerVisibility("topSilkscreen", !visibility.topSilkscreen)
               }}
               onMouseEnter={() => setHoveredItem("topSilkscreen")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -243,11 +243,11 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
+                e.preventDefault()
                 setLayerVisibility(
                   "bottomSilkscreen",
                   !visibility.bottomSilkscreen,
-                );
+                )
               }}
               onMouseEnter={() => setHoveredItem("bottomSilkscreen")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -269,8 +269,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("topMask", !visibility.topMask);
+                e.preventDefault()
+                setLayerVisibility("topMask", !visibility.topMask)
               }}
               onMouseEnter={() => setHoveredItem("topMask")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -292,8 +292,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("bottomMask", !visibility.bottomMask);
+                e.preventDefault()
+                setLayerVisibility("bottomMask", !visibility.bottomMask)
               }}
               onMouseEnter={() => setHoveredItem("bottomMask")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -315,8 +315,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("pcbNotes", !visibility.pcbNotes);
+                e.preventDefault()
+                setLayerVisibility("pcbNotes", !visibility.pcbNotes)
               }}
               onMouseEnter={() => setHoveredItem("pcbNotes")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -338,8 +338,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
-                setLayerVisibility("smtModels", !visibility.smtModels);
+                e.preventDefault()
+                setLayerVisibility("smtModels", !visibility.smtModels)
               }}
               onMouseEnter={() => setHoveredItem("smtModels")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -363,11 +363,11 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault();
+                e.preventDefault()
                 setLayerVisibility(
                   "throughHoleModels",
                   !visibility.throughHoleModels,
-                );
+                )
               }}
               onMouseEnter={() => setHoveredItem("throughHoleModels")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -384,5 +384,5 @@ export const AppearanceMenu = () => {
         </DropdownMenu.Portal>
       </DropdownMenu.Sub>
     </>
-  );
-};
+  )
+}

--- a/src/components/AppearanceMenu.tsx
+++ b/src/components/AppearanceMenu.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react"
-import { useLayerVisibility } from "../contexts/LayerVisibilityContext"
-import type React from "react"
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, ChevronRightIcon } from "./Icons"
-import { zIndexMap } from "../../lib/utils/z-index-map"
+import { useState } from "react";
+import { useLayerVisibility } from "../contexts/LayerVisibilityContext";
+import type React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { CheckIcon, ChevronRightIcon } from "./Icons";
+import { zIndexMap } from "../../lib/utils/z-index-map";
 
 const itemStyles: React.CSSProperties = {
   padding: "6px 8px",
@@ -20,20 +20,20 @@ const itemStyles: React.CSSProperties = {
   transition: "background-color 0.15s ease, color 0.15s ease",
   fontFamily:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-}
+};
 
 const itemPaddingStyles: React.CSSProperties = {
   paddingLeft: 32,
   paddingTop: 6,
   paddingBottom: 6,
   paddingRight: 8,
-}
+};
 
 const separatorStyles: React.CSSProperties = {
   height: 1,
   backgroundColor: "#ffffff1a",
   margin: "4px 0",
-}
+};
 
 const contentStyles: React.CSSProperties = {
   backgroundColor: "#262626",
@@ -48,7 +48,7 @@ const contentStyles: React.CSSProperties = {
   fontSize: 14,
   fontFamily:
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-}
+};
 
 const iconContainerStyles: React.CSSProperties = {
   width: 16,
@@ -57,12 +57,12 @@ const iconContainerStyles: React.CSSProperties = {
   alignItems: "flex-end",
   justifyContent: "center",
   flexShrink: 0,
-}
+};
 
 export const AppearanceMenu = () => {
-  const { visibility, setLayerVisibility } = useLayerVisibility()
-  const [appearanceSubOpen, setAppearanceSubOpen] = useState(false)
-  const [hoveredItem, setHoveredItem] = useState<string | null>(null)
+  const { visibility, setLayerVisibility } = useLayerVisibility();
+  const [appearanceSubOpen, setAppearanceSubOpen] = useState(false);
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
 
   return (
     <>
@@ -107,12 +107,50 @@ export const AppearanceMenu = () => {
               style={{
                 ...itemStyles,
                 backgroundColor:
+                  hoveredItem === "svgTextures" ? "#404040" : "transparent",
+              }}
+              onSelect={(e) => e.preventDefault()}
+              onPointerDown={(e) => {
+                e.preventDefault();
+                setLayerVisibility(
+                  "svgTexturesEnabled",
+                  !visibility.svgTexturesEnabled,
+                );
+              }}
+              onMouseEnter={() => setHoveredItem("svgTextures")}
+              onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("svgTextures")}
+            >
+              <span style={iconContainerStyles}>
+                {visibility.svgTexturesEnabled && <CheckIcon />}
+              </span>
+              <span style={{ flex: 1, display: "flex", alignItems: "center" }}>
+                SVG Board Textures
+              </span>
+              <span
+                style={{
+                  fontSize: 10,
+                  opacity: 0.6,
+                  backgroundColor: "rgba(161, 161, 170, 0.15)",
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  fontWeight: 500,
+                }}
+              >
+                experimental
+              </span>
+            </DropdownMenu.Item>
+
+            <DropdownMenu.Item
+              style={{
+                ...itemStyles,
+                backgroundColor:
                   hoveredItem === "boardBody" ? "#404040" : "transparent",
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("boardBody", !visibility.boardBody)
+                e.preventDefault();
+                setLayerVisibility("boardBody", !visibility.boardBody);
               }}
               onMouseEnter={() => setHoveredItem("boardBody")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -134,8 +172,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("topCopper", !visibility.topCopper)
+                e.preventDefault();
+                setLayerVisibility("topCopper", !visibility.topCopper);
               }}
               onMouseEnter={() => setHoveredItem("topCopper")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -157,8 +195,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("bottomCopper", !visibility.bottomCopper)
+                e.preventDefault();
+                setLayerVisibility("bottomCopper", !visibility.bottomCopper);
               }}
               onMouseEnter={() => setHoveredItem("bottomCopper")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -180,8 +218,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("topSilkscreen", !visibility.topSilkscreen)
+                e.preventDefault();
+                setLayerVisibility("topSilkscreen", !visibility.topSilkscreen);
               }}
               onMouseEnter={() => setHoveredItem("topSilkscreen")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -205,11 +243,11 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
+                e.preventDefault();
                 setLayerVisibility(
                   "bottomSilkscreen",
                   !visibility.bottomSilkscreen,
-                )
+                );
               }}
               onMouseEnter={() => setHoveredItem("bottomSilkscreen")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -231,8 +269,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("topMask", !visibility.topMask)
+                e.preventDefault();
+                setLayerVisibility("topMask", !visibility.topMask);
               }}
               onMouseEnter={() => setHoveredItem("topMask")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -254,8 +292,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("bottomMask", !visibility.bottomMask)
+                e.preventDefault();
+                setLayerVisibility("bottomMask", !visibility.bottomMask);
               }}
               onMouseEnter={() => setHoveredItem("bottomMask")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -277,8 +315,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("pcbNotes", !visibility.pcbNotes)
+                e.preventDefault();
+                setLayerVisibility("pcbNotes", !visibility.pcbNotes);
               }}
               onMouseEnter={() => setHoveredItem("pcbNotes")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -300,8 +338,8 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
-                setLayerVisibility("smtModels", !visibility.smtModels)
+                e.preventDefault();
+                setLayerVisibility("smtModels", !visibility.smtModels);
               }}
               onMouseEnter={() => setHoveredItem("smtModels")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -325,11 +363,11 @@ export const AppearanceMenu = () => {
               }}
               onSelect={(e) => e.preventDefault()}
               onPointerDown={(e) => {
-                e.preventDefault()
+                e.preventDefault();
                 setLayerVisibility(
                   "throughHoleModels",
                   !visibility.throughHoleModels,
-                )
+                );
               }}
               onMouseEnter={() => setHoveredItem("throughHoleModels")}
               onMouseLeave={() => setHoveredItem(null)}
@@ -346,5 +384,5 @@ export const AppearanceMenu = () => {
         </DropdownMenu.Portal>
       </DropdownMenu.Sub>
     </>
-  )
-}
+  );
+};

--- a/src/contexts/LayerVisibilityContext.tsx
+++ b/src/contexts/LayerVisibilityContext.tsx
@@ -5,37 +5,59 @@ import React, {
   useEffect,
   useCallback,
   useMemo,
-} from "react"
+} from "react";
 
 export interface LayerVisibilityState {
-  boardBody: boolean
-  topCopper: boolean
-  bottomCopper: boolean
-  adhesive: boolean
-  solderPaste: boolean
-  topSilkscreen: boolean
-  bottomSilkscreen: boolean
-  topMask: boolean
-  bottomMask: boolean
-  throughHoleModels: boolean
-  smtModels: boolean
-  translucentModels: boolean
-  modelsNotInPosFile: boolean
-  modelsMarkedDNP: boolean
-  modelBoundingBoxes: boolean
-  threedAxis: boolean
-  pcbNotes: boolean
-  backgroundStart: boolean
-  backgroundEnd: boolean
+  boardBody: boolean;
+  topCopper: boolean;
+  bottomCopper: boolean;
+  adhesive: boolean;
+  solderPaste: boolean;
+  topSilkscreen: boolean;
+  bottomSilkscreen: boolean;
+  topMask: boolean;
+  bottomMask: boolean;
+  throughHoleModels: boolean;
+  smtModels: boolean;
+  translucentModels: boolean;
+  modelsNotInPosFile: boolean;
+  modelsMarkedDNP: boolean;
+  modelBoundingBoxes: boolean;
+  threedAxis: boolean;
+  pcbNotes: boolean;
+  backgroundStart: boolean;
+  backgroundEnd: boolean;
+  /**
+   * Enable SVG-based high-quality texture rendering for PCB faces
+   * When enabled, uses resvg-wasm to generate raster textures from SVG
+   * @default false
+   */
+  svgTexturesEnabled: boolean;
+  /**
+   * Resolution for SVG textures in pixels per mm
+   * Higher values give sharper textures but use more memory
+   * @default 150
+   */
+  svgTextureResolution: number;
+  /**
+   * Enable SVG texture on top face
+   * @default true
+   */
+  svgTextureTop: boolean;
+  /**
+   * Enable SVG texture on bottom face
+   * @default true
+   */
+  svgTextureBottom: boolean;
 }
 
 interface LayerVisibilityContextType {
-  visibility: LayerVisibilityState
+  visibility: LayerVisibilityState;
   setLayerVisibility: (
     layer: keyof LayerVisibilityState,
     visible: boolean,
-  ) => void
-  resetToDefaults: () => void
+  ) => void;
+  resetToDefaults: () => void;
 }
 
 const defaultVisibility: LayerVisibilityState = {
@@ -58,31 +80,35 @@ const defaultVisibility: LayerVisibilityState = {
   pcbNotes: false,
   backgroundStart: true,
   backgroundEnd: true,
-}
+  svgTexturesEnabled: false,
+  svgTextureResolution: 150,
+  svgTextureTop: true,
+  svgTextureBottom: true,
+};
 
 const LayerVisibilityContext = createContext<
   LayerVisibilityContextType | undefined
->(undefined)
+>(undefined);
 
 export const LayerVisibilityProvider: React.FC<{
-  children: React.ReactNode
+  children: React.ReactNode;
 }> = ({ children }) => {
   const [visibility, setVisibility] =
-    useState<LayerVisibilityState>(defaultVisibility)
+    useState<LayerVisibilityState>(defaultVisibility);
 
   const setLayerVisibility = useCallback(
     (layer: keyof LayerVisibilityState, visible: boolean) => {
       setVisibility((prev) => ({
         ...prev,
         [layer]: visible,
-      }))
+      }));
     },
     [],
-  )
+  );
 
   const resetToDefaults = useCallback(() => {
-    setVisibility(defaultVisibility)
-  }, [])
+    setVisibility(defaultVisibility);
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -91,21 +117,21 @@ export const LayerVisibilityProvider: React.FC<{
       resetToDefaults,
     }),
     [visibility, setLayerVisibility, resetToDefaults],
-  )
+  );
 
   return (
     <LayerVisibilityContext.Provider value={value}>
       {children}
     </LayerVisibilityContext.Provider>
-  )
-}
+  );
+};
 
 export const useLayerVisibility = () => {
-  const context = useContext(LayerVisibilityContext)
+  const context = useContext(LayerVisibilityContext);
   if (!context) {
     throw new Error(
       "useLayerVisibility must be used within a LayerVisibilityProvider",
-    )
+    );
   }
-  return context
-}
+  return context;
+};

--- a/src/contexts/LayerVisibilityContext.tsx
+++ b/src/contexts/LayerVisibilityContext.tsx
@@ -5,59 +5,59 @@ import React, {
   useEffect,
   useCallback,
   useMemo,
-} from "react";
+} from "react"
 
 export interface LayerVisibilityState {
-  boardBody: boolean;
-  topCopper: boolean;
-  bottomCopper: boolean;
-  adhesive: boolean;
-  solderPaste: boolean;
-  topSilkscreen: boolean;
-  bottomSilkscreen: boolean;
-  topMask: boolean;
-  bottomMask: boolean;
-  throughHoleModels: boolean;
-  smtModels: boolean;
-  translucentModels: boolean;
-  modelsNotInPosFile: boolean;
-  modelsMarkedDNP: boolean;
-  modelBoundingBoxes: boolean;
-  threedAxis: boolean;
-  pcbNotes: boolean;
-  backgroundStart: boolean;
-  backgroundEnd: boolean;
+  boardBody: boolean
+  topCopper: boolean
+  bottomCopper: boolean
+  adhesive: boolean
+  solderPaste: boolean
+  topSilkscreen: boolean
+  bottomSilkscreen: boolean
+  topMask: boolean
+  bottomMask: boolean
+  throughHoleModels: boolean
+  smtModels: boolean
+  translucentModels: boolean
+  modelsNotInPosFile: boolean
+  modelsMarkedDNP: boolean
+  modelBoundingBoxes: boolean
+  threedAxis: boolean
+  pcbNotes: boolean
+  backgroundStart: boolean
+  backgroundEnd: boolean
   /**
    * Enable SVG-based high-quality texture rendering for PCB faces
    * When enabled, uses resvg-wasm to generate raster textures from SVG
    * @default false
    */
-  svgTexturesEnabled: boolean;
+  svgTexturesEnabled: boolean
   /**
    * Resolution for SVG textures in pixels per mm
    * Higher values give sharper textures but use more memory
    * @default 150
    */
-  svgTextureResolution: number;
+  svgTextureResolution: number
   /**
    * Enable SVG texture on top face
    * @default true
    */
-  svgTextureTop: boolean;
+  svgTextureTop: boolean
   /**
    * Enable SVG texture on bottom face
    * @default true
    */
-  svgTextureBottom: boolean;
+  svgTextureBottom: boolean
 }
 
 interface LayerVisibilityContextType {
-  visibility: LayerVisibilityState;
+  visibility: LayerVisibilityState
   setLayerVisibility: (
     layer: keyof LayerVisibilityState,
     visible: boolean,
-  ) => void;
-  resetToDefaults: () => void;
+  ) => void
+  resetToDefaults: () => void
 }
 
 const defaultVisibility: LayerVisibilityState = {
@@ -84,31 +84,31 @@ const defaultVisibility: LayerVisibilityState = {
   svgTextureResolution: 150,
   svgTextureTop: true,
   svgTextureBottom: true,
-};
+}
 
 const LayerVisibilityContext = createContext<
   LayerVisibilityContextType | undefined
->(undefined);
+>(undefined)
 
 export const LayerVisibilityProvider: React.FC<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }> = ({ children }) => {
   const [visibility, setVisibility] =
-    useState<LayerVisibilityState>(defaultVisibility);
+    useState<LayerVisibilityState>(defaultVisibility)
 
   const setLayerVisibility = useCallback(
     (layer: keyof LayerVisibilityState, visible: boolean) => {
       setVisibility((prev) => ({
         ...prev,
         [layer]: visible,
-      }));
+      }))
     },
     [],
-  );
+  )
 
   const resetToDefaults = useCallback(() => {
-    setVisibility(defaultVisibility);
-  }, []);
+    setVisibility(defaultVisibility)
+  }, [])
 
   const value = useMemo(
     () => ({
@@ -117,21 +117,21 @@ export const LayerVisibilityProvider: React.FC<{
       resetToDefaults,
     }),
     [visibility, setLayerVisibility, resetToDefaults],
-  );
+  )
 
   return (
     <LayerVisibilityContext.Provider value={value}>
       {children}
     </LayerVisibilityContext.Provider>
-  );
-};
+  )
+}
 
 export const useLayerVisibility = () => {
-  const context = useContext(LayerVisibilityContext);
+  const context = useContext(LayerVisibilityContext)
   if (!context) {
     throw new Error(
       "useLayerVisibility must be used within a LayerVisibilityProvider",
-    );
+    )
   }
-  return context;
-};
+  return context
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,7 +1,7 @@
-export * from "./exporter/gltf.ts";
-export * from "./useManifoldBoardBuilder.ts";
+export * from "./exporter/gltf.ts"
+export * from "./useManifoldBoardBuilder.ts"
 export {
   useSvgBoardTextures,
   usePreloadResvgWasm,
   type SvgTexturesResult,
-} from "./useSvgBoardTextures.ts";
+} from "./useSvgBoardTextures.ts"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,7 @@
-export * from "./exporter/gltf.ts"
-export * from "./useManifoldBoardBuilder.ts"
+export * from "./exporter/gltf.ts";
+export * from "./useManifoldBoardBuilder.ts";
+export {
+  useSvgBoardTextures,
+  usePreloadResvgWasm,
+  type SvgTexturesResult,
+} from "./useSvgBoardTextures.ts";

--- a/src/hooks/useSvgBoardTextures.ts
+++ b/src/hooks/useSvgBoardTextures.ts
@@ -1,0 +1,223 @@
+import { useEffect, useState, useCallback, useRef } from "react"
+import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import * as THREE from "three"
+import type { LayerVisibilityState } from "../contexts/LayerVisibilityContext"
+import {
+  createSvgBasedTexture,
+  type SvgTextureOptions,
+  initResvgWasm,
+  isResvgInitialized,
+} from "../textures"
+
+export interface SvgTexturesResult {
+  topTexture: THREE.DataTexture | null
+  bottomTexture: THREE.DataTexture | null
+  isLoading: boolean
+  error: string | null
+}
+
+/**
+ * Hook for generating high-quality SVG-based PCB textures.
+ *
+ * This hook uses resvg-wasm to render SVG representations of the PCB
+ * to high-resolution raster textures. This provides better quality
+ * than canvas-based rendering, especially for text and fine details.
+ *
+ * @example
+ * ```tsx
+ * const { topTexture, bottomTexture, isLoading, error } = useSvgBoardTextures({
+ *   circuitJson,
+ *   boardData,
+ *   visibility,
+ * });
+ * ```
+ */
+export function useSvgBoardTextures({
+  circuitJson,
+  boardData,
+  visibility,
+}: {
+  circuitJson: AnyCircuitElement[]
+  boardData: PcbBoard | null
+  visibility: Partial<LayerVisibilityState>
+}): SvgTexturesResult {
+  const [topTexture, setTopTexture] = useState<THREE.DataTexture | null>(null)
+  const [bottomTexture, setBottomTexture] = useState<THREE.DataTexture | null>(
+    null,
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Track mounted state to prevent state updates after unmount
+  const isMountedRef = useRef(true)
+  // Track previous textures for cleanup
+  const prevTexturesRef = useRef<{
+    top: THREE.DataTexture | null
+    bottom: THREE.DataTexture | null
+  }>({ top: null, bottom: null })
+
+  // Cleanup function for textures
+  const cleanupTexture = useCallback((texture: THREE.DataTexture | null) => {
+    if (texture) {
+      texture.dispose()
+    }
+  }, [])
+
+  useEffect(() => {
+    // Reset mounted flag
+    isMountedRef.current = true
+
+    // Check if SVG textures are enabled
+    const svgTexturesEnabled = visibility.svgTexturesEnabled ?? false
+    const svgTextureTop = visibility.svgTextureTop ?? true
+    const svgTextureBottom = visibility.svgTextureBottom ?? true
+    const resolution = visibility.svgTextureResolution ?? 150
+
+    if (!svgTexturesEnabled || !boardData) {
+      // Clean up any existing textures
+      cleanupTexture(prevTexturesRef.current.top)
+      cleanupTexture(prevTexturesRef.current.bottom)
+      prevTexturesRef.current = { top: null, bottom: null }
+      setTopTexture(null)
+      setBottomTexture(null)
+      setIsLoading(false)
+      setError(null)
+      return
+    }
+
+    // Start loading
+    setIsLoading(true)
+    setError(null)
+
+    const generateTextures = async () => {
+      try {
+        // Ensure resvg-wasm is initialized
+        if (!isResvgInitialized()) {
+          await initResvgWasm()
+        }
+
+        const numLayers = boardData.num_layers ?? 2
+
+        // Generate top texture
+        let newTopTexture: THREE.DataTexture | null = null
+        if (svgTextureTop) {
+          const topOptions: SvgTextureOptions = {
+            width: 0, // Will be calculated based on board size
+            height: 0,
+            layer: "top",
+            resolution,
+            colors: {
+              copper: "rgb(200, 150, 50)",
+              silkscreen: "rgb(255, 255, 255)",
+              soldermask: "rgb(4, 15, 7)",
+              substrate: "rgb(153, 110, 71)",
+            },
+          }
+
+          newTopTexture = await createSvgBasedTexture(
+            circuitJson,
+            boardData,
+            topOptions,
+          )
+        }
+
+        // Generate bottom texture
+        let newBottomTexture: THREE.DataTexture | null = null
+        if (svgTextureBottom && numLayers >= 2) {
+          const bottomOptions: SvgTextureOptions = {
+            width: 0,
+            height: 0,
+            layer: "bottom",
+            resolution,
+            colors: {
+              copper: "rgb(200, 150, 50)",
+              silkscreen: "rgb(255, 255, 255)",
+              soldermask: "rgb(4, 15, 7)",
+              substrate: "rgb(153, 110, 71)",
+            },
+          }
+
+          newBottomTexture = await createSvgBasedTexture(
+            circuitJson,
+            boardData,
+            bottomOptions,
+          )
+        }
+
+        // Only update state if still mounted
+        if (isMountedRef.current) {
+          // Clean up old textures
+          cleanupTexture(prevTexturesRef.current.top)
+          cleanupTexture(prevTexturesRef.current.bottom)
+
+          // Store new textures
+          prevTexturesRef.current = {
+            top: newTopTexture,
+            bottom: newBottomTexture,
+          }
+
+          setTopTexture(newTopTexture)
+          setBottomTexture(newBottomTexture)
+          setIsLoading(false)
+        } else {
+          // Component unmounted, clean up new textures
+          cleanupTexture(newTopTexture)
+          cleanupTexture(newBottomTexture)
+        }
+      } catch (err) {
+        console.error("Error generating SVG textures:", err)
+        if (isMountedRef.current) {
+          setError(
+            err instanceof Error ? err.message : "Failed to generate textures",
+          )
+          setIsLoading(false)
+        }
+      }
+    }
+
+    generateTextures()
+
+    // Cleanup
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [
+    circuitJson,
+    boardData,
+    visibility.svgTexturesEnabled,
+    visibility.svgTextureTop,
+    visibility.svgTextureBottom,
+    visibility.svgTextureResolution,
+    cleanupTexture,
+  ])
+
+  // Final cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cleanupTexture(prevTexturesRef.current.top)
+      cleanupTexture(prevTexturesRef.current.bottom)
+      prevTexturesRef.current = { top: null, bottom: null }
+    }
+  }, [cleanupTexture])
+
+  return {
+    topTexture,
+    bottomTexture,
+    isLoading,
+    error,
+  }
+}
+
+/**
+ * Preload the resvg-wasm module.
+ * Call this early in your application to ensure the WASM is ready when needed.
+ */
+export function usePreloadResvgWasm() {
+  useEffect(() => {
+    if (!isResvgInitialized()) {
+      initResvgWasm().catch((error) => {
+        console.warn("Failed to preload resvg-wasm:", error)
+      })
+    }
+  }, [])
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,14 @@
-export { CadViewer } from "./CadViewer.tsx"
-export * from "./convert-circuit-json-to-3d-svg.ts"
-export * from "./hooks/index.ts"
-export * from "./utils/jsdom-shim.ts"
+export { CadViewer } from "./CadViewer.tsx";
+export * from "./convert-circuit-json-to-3d-svg.ts";
+export * from "./hooks/index.ts";
+export * from "./textures/index.ts";
+export * from "./utils/jsdom-shim.ts";
 export {
   CameraControllerProvider,
   useCameraController,
   saveCameraToSession,
   loadCameraFromSession,
-} from "./contexts/CameraControllerContext"
-export { CameraAnimatorWithContext } from "./hooks/cameraAnimation"
-export { useCameraSession } from "./hooks/useCameraSession"
+} from "./contexts/CameraControllerContext";
+export { CameraAnimatorWithContext } from "./hooks/cameraAnimation";
+export { useCameraSession } from "./hooks/useCameraSession";
+export { SvgBoardTextures } from "./three-components/SvgBoardTextures";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,14 @@
-export { CadViewer } from "./CadViewer.tsx";
-export * from "./convert-circuit-json-to-3d-svg.ts";
-export * from "./hooks/index.ts";
-export * from "./textures/index.ts";
-export * from "./utils/jsdom-shim.ts";
+export { CadViewer } from "./CadViewer.tsx"
+export * from "./convert-circuit-json-to-3d-svg.ts"
+export * from "./hooks/index.ts"
+export * from "./textures/index.ts"
+export * from "./utils/jsdom-shim.ts"
 export {
   CameraControllerProvider,
   useCameraController,
   saveCameraToSession,
   loadCameraFromSession,
-} from "./contexts/CameraControllerContext";
-export { CameraAnimatorWithContext } from "./hooks/cameraAnimation";
-export { useCameraSession } from "./hooks/useCameraSession";
-export { SvgBoardTextures } from "./three-components/SvgBoardTextures";
+} from "./contexts/CameraControllerContext"
+export { CameraAnimatorWithContext } from "./hooks/cameraAnimation"
+export { useCameraSession } from "./hooks/useCameraSession"
+export { SvgBoardTextures } from "./three-components/SvgBoardTextures"

--- a/src/textures/create-svg-based-texture.ts
+++ b/src/textures/create-svg-based-texture.ts
@@ -1,27 +1,27 @@
-import type { AnyCircuitElement, PcbBoard } from "circuit-json";
-import { calculateOutlineBounds } from "../utils/outline-bounds";
-import { createSvgFromCircuitJson } from "./svg-from-circuit-json";
-import { convertSvgToPng } from "./resvg-converter";
-import * as THREE from "three";
+import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import { calculateOutlineBounds } from "../utils/outline-bounds"
+import { createSvgFromCircuitJson } from "./svg-from-circuit-json"
+import { convertSvgToPng } from "./resvg-converter"
+import * as THREE from "three"
 
 export interface SvgTextureOptions {
-  width: number;
-  height: number;
-  layer: "top" | "bottom";
+  width: number
+  height: number
+  layer: "top" | "bottom"
   /**
    * Resolution in pixels per mm
    * @default 150
    */
-  resolution?: number;
+  resolution?: number
   /**
    * Color overrides for different elements
    */
   colors?: {
-    copper?: string;
-    silkscreen?: string;
-    soldermask?: string;
-    substrate?: string;
-  };
+    copper?: string
+    silkscreen?: string
+    soldermask?: string
+    substrate?: string
+  }
 }
 
 /**
@@ -33,14 +33,14 @@ export async function createSvgBasedTexture(
   boardData: PcbBoard,
   options: SvgTextureOptions,
 ): Promise<THREE.DataTexture | null> {
-  const { width, height, layer, resolution = 150, colors } = options;
+  const { width, height, layer, resolution = 150, colors } = options
 
-  const bounds = calculateOutlineBounds(boardData);
-  const pixelWidth = Math.floor(bounds.width * resolution);
-  const pixelHeight = Math.floor(bounds.height * resolution);
+  const bounds = calculateOutlineBounds(boardData)
+  const pixelWidth = Math.floor(bounds.width * resolution)
+  const pixelHeight = Math.floor(bounds.height * resolution)
 
   if (pixelWidth <= 0 || pixelHeight <= 0) {
-    return null;
+    return null
   }
 
   try {
@@ -53,25 +53,25 @@ export async function createSvgBasedTexture(
       height: pixelHeight,
       bounds,
       colors,
-    });
+    })
 
     // Convert SVG to PNG using resvg-wasm
     const pngBuffer = await convertSvgToPng(svgString, {
       width: pixelWidth,
       height: pixelHeight,
-    });
+    })
 
     if (!pngBuffer) {
-      return null;
+      return null
     }
 
     // Create Three.js DataTexture from PNG
-    const texture = createTextureFromPng(pngBuffer, pixelWidth, pixelHeight);
+    const texture = createTextureFromPng(pngBuffer, pixelWidth, pixelHeight)
 
-    return texture;
+    return texture
   } catch (error) {
-    console.error("Error creating SVG-based texture:", error);
-    return null;
+    console.error("Error creating SVG-based texture:", error)
+    return null
   }
 }
 
@@ -84,13 +84,13 @@ function createTextureFromPng(
   height: number,
 ): Promise<THREE.DataTexture> {
   // Create a temporary canvas to decode the PNG
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const ctx = canvas.getContext("2d");
+  const canvas = document.createElement("canvas")
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext("2d")
 
   if (!ctx) {
-    throw new Error("Failed to get 2D context");
+    throw new Error("Failed to get 2D context")
   }
 
   // Create blob from buffer and draw to canvas
@@ -98,14 +98,14 @@ function createTextureFromPng(
   const arrayBuffer = pngBuffer.buffer.slice(
     pngBuffer.byteOffset,
     pngBuffer.byteOffset + pngBuffer.byteLength,
-  ) as ArrayBuffer;
-  const blob = new Blob([arrayBuffer], { type: "image/png" });
-  const img = new Image();
+  ) as ArrayBuffer
+  const blob = new Blob([arrayBuffer], { type: "image/png" })
+  const img = new Image()
 
   return new Promise((resolve, reject) => {
     img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      const imageData = ctx.getImageData(0, 0, width, height);
+      ctx.drawImage(img, 0, 0)
+      const imageData = ctx.getImageData(0, 0, width, height)
 
       // Create DataTexture
       const texture = new THREE.DataTexture(
@@ -113,23 +113,23 @@ function createTextureFromPng(
         width,
         height,
         THREE.RGBAFormat,
-      );
-      texture.generateMipmaps = true;
-      texture.minFilter = THREE.LinearMipmapLinearFilter;
-      texture.magFilter = THREE.LinearFilter;
-      texture.anisotropy = 16;
-      texture.needsUpdate = true;
-      texture.flipY = false;
+      )
+      texture.generateMipmaps = true
+      texture.minFilter = THREE.LinearMipmapLinearFilter
+      texture.magFilter = THREE.LinearFilter
+      texture.anisotropy = 16
+      texture.needsUpdate = true
+      texture.flipY = false
 
-      resolve(texture);
-    };
+      resolve(texture)
+    }
 
     img.onerror = () => {
-      reject(new Error("Failed to load PNG image"));
-    };
+      reject(new Error("Failed to load PNG image"))
+    }
 
-    img.src = URL.createObjectURL(blob);
-  });
+    img.src = URL.createObjectURL(blob)
+  })
 }
 
 // Synchronous version that returns a placeholder and loads async
@@ -142,13 +142,13 @@ export function createSvgBasedTextureAsync(
   // Start async loading
   createSvgBasedTexture(circuitJson, boardData, options)
     .then((texture) => {
-      onLoad(texture);
+      onLoad(texture)
     })
     .catch((error) => {
-      console.error("Async texture loading failed:", error);
-      onLoad(null);
-    });
+      console.error("Async texture loading failed:", error)
+      onLoad(null)
+    })
 
   // Return null immediately - texture will be set via callback
-  return null;
+  return null
 }

--- a/src/textures/create-svg-based-texture.ts
+++ b/src/textures/create-svg-based-texture.ts
@@ -1,0 +1,154 @@
+import type { AnyCircuitElement, PcbBoard } from "circuit-json";
+import { calculateOutlineBounds } from "../utils/outline-bounds";
+import { createSvgFromCircuitJson } from "./svg-from-circuit-json";
+import { convertSvgToPng } from "./resvg-converter";
+import * as THREE from "three";
+
+export interface SvgTextureOptions {
+  width: number;
+  height: number;
+  layer: "top" | "bottom";
+  /**
+   * Resolution in pixels per mm
+   * @default 150
+   */
+  resolution?: number;
+  /**
+   * Color overrides for different elements
+   */
+  colors?: {
+    copper?: string;
+    silkscreen?: string;
+    soldermask?: string;
+    substrate?: string;
+  };
+}
+
+/**
+ * Creates a high-quality PNG texture from circuit JSON using SVG rendering via resvg-wasm.
+ * This provides better quality than canvas-based rendering, especially for text and fine details.
+ */
+export async function createSvgBasedTexture(
+  circuitJson: AnyCircuitElement[],
+  boardData: PcbBoard,
+  options: SvgTextureOptions,
+): Promise<THREE.DataTexture | null> {
+  const { width, height, layer, resolution = 150, colors } = options;
+
+  const bounds = calculateOutlineBounds(boardData);
+  const pixelWidth = Math.floor(bounds.width * resolution);
+  const pixelHeight = Math.floor(bounds.height * resolution);
+
+  if (pixelWidth <= 0 || pixelHeight <= 0) {
+    return null;
+  }
+
+  try {
+    // Generate SVG from circuit JSON
+    const svgString = createSvgFromCircuitJson({
+      circuitJson,
+      boardData,
+      layer,
+      width: pixelWidth,
+      height: pixelHeight,
+      bounds,
+      colors,
+    });
+
+    // Convert SVG to PNG using resvg-wasm
+    const pngBuffer = await convertSvgToPng(svgString, {
+      width: pixelWidth,
+      height: pixelHeight,
+    });
+
+    if (!pngBuffer) {
+      return null;
+    }
+
+    // Create Three.js DataTexture from PNG
+    const texture = createTextureFromPng(pngBuffer, pixelWidth, pixelHeight);
+
+    return texture;
+  } catch (error) {
+    console.error("Error creating SVG-based texture:", error);
+    return null;
+  }
+}
+
+/**
+ * Creates a Three.js DataTexture from PNG buffer data
+ */
+function createTextureFromPng(
+  pngBuffer: Uint8Array,
+  width: number,
+  height: number,
+): Promise<THREE.DataTexture> {
+  // Create a temporary canvas to decode the PNG
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    throw new Error("Failed to get 2D context");
+  }
+
+  // Create blob from buffer and draw to canvas
+  // Convert Uint8Array to ArrayBuffer for Blob compatibility
+  const arrayBuffer = pngBuffer.buffer.slice(
+    pngBuffer.byteOffset,
+    pngBuffer.byteOffset + pngBuffer.byteLength,
+  ) as ArrayBuffer;
+  const blob = new Blob([arrayBuffer], { type: "image/png" });
+  const img = new Image();
+
+  return new Promise((resolve, reject) => {
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0);
+      const imageData = ctx.getImageData(0, 0, width, height);
+
+      // Create DataTexture
+      const texture = new THREE.DataTexture(
+        new Uint8Array(imageData.data.buffer),
+        width,
+        height,
+        THREE.RGBAFormat,
+      );
+      texture.generateMipmaps = true;
+      texture.minFilter = THREE.LinearMipmapLinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      texture.anisotropy = 16;
+      texture.needsUpdate = true;
+      texture.flipY = false;
+
+      resolve(texture);
+    };
+
+    img.onerror = () => {
+      reject(new Error("Failed to load PNG image"));
+    };
+
+    img.src = URL.createObjectURL(blob);
+  });
+}
+
+// Synchronous version that returns a placeholder and loads async
+export function createSvgBasedTextureAsync(
+  circuitJson: AnyCircuitElement[],
+  boardData: PcbBoard,
+  options: SvgTextureOptions,
+  onLoad: (texture: THREE.DataTexture | null) => void,
+): THREE.DataTexture | null {
+  // Start async loading
+  createSvgBasedTexture(circuitJson, boardData, options)
+    .then((texture) => {
+      onLoad(texture);
+    })
+    .catch((error) => {
+      console.error("Async texture loading failed:", error);
+      onLoad(null);
+    });
+
+  // Return null immediately - texture will be set via callback
+  return null;
+}

--- a/src/textures/index.ts
+++ b/src/textures/index.ts
@@ -1,21 +1,21 @@
-export type { CombinedBoardTextures } from "./create-combined-board-textures";
-export { createCombinedBoardTextures } from "./create-combined-board-textures";
-export { createCopperTextTextureForLayer } from "./create-copper-text-texture-for-layer";
-export { createCopperPourTextureForLayer } from "./create-copper-pour-texture-for-layer";
-export { createFabricationNoteTextureForLayer } from "./create-fabrication-note-texture-for-layer";
-export { createPcbNoteTextureForLayer } from "./create-pcb-note-texture-for-layer";
-export { createSilkscreenTextureForLayer } from "./create-silkscreen-texture-for-layer";
-export { createSoldermaskTextureForLayer } from "./create-soldermask-texture-for-layer";
-export { createThroughHoleTextureForLayer } from "./create-through-hole-texture-for-layer";
-export { createTextureMeshes } from "./create-three-texture-meshes";
+export type { CombinedBoardTextures } from "./create-combined-board-textures"
+export { createCombinedBoardTextures } from "./create-combined-board-textures"
+export { createCopperTextTextureForLayer } from "./create-copper-text-texture-for-layer"
+export { createCopperPourTextureForLayer } from "./create-copper-pour-texture-for-layer"
+export { createFabricationNoteTextureForLayer } from "./create-fabrication-note-texture-for-layer"
+export { createPcbNoteTextureForLayer } from "./create-pcb-note-texture-for-layer"
+export { createSilkscreenTextureForLayer } from "./create-silkscreen-texture-for-layer"
+export { createSoldermaskTextureForLayer } from "./create-soldermask-texture-for-layer"
+export { createThroughHoleTextureForLayer } from "./create-through-hole-texture-for-layer"
+export { createTextureMeshes } from "./create-three-texture-meshes"
 
 // SVG-based texture generation (new)
-export type { SvgTextureOptions } from "./create-svg-based-texture";
+export type { SvgTextureOptions } from "./create-svg-based-texture"
 export {
   createSvgBasedTexture,
   createSvgBasedTextureAsync,
-} from "./create-svg-based-texture";
-export { createSvgFromCircuitJson } from "./svg-from-circuit-json";
+} from "./create-svg-based-texture"
+export { createSvgFromCircuitJson } from "./svg-from-circuit-json"
 export {
   convertSvgToPng,
   convertSvgToRawPixels,
@@ -23,4 +23,4 @@ export {
   isResvgInitialized,
   preloadResvgWasm,
   type ConvertSvgOptions,
-} from "./resvg-converter";
+} from "./resvg-converter"

--- a/src/textures/index.ts
+++ b/src/textures/index.ts
@@ -1,10 +1,26 @@
-export type { CombinedBoardTextures } from "./create-combined-board-textures"
-export { createCombinedBoardTextures } from "./create-combined-board-textures"
-export { createCopperTextTextureForLayer } from "./create-copper-text-texture-for-layer"
-export { createCopperPourTextureForLayer } from "./create-copper-pour-texture-for-layer"
-export { createFabricationNoteTextureForLayer } from "./create-fabrication-note-texture-for-layer"
-export { createPcbNoteTextureForLayer } from "./create-pcb-note-texture-for-layer"
-export { createSilkscreenTextureForLayer } from "./create-silkscreen-texture-for-layer"
-export { createSoldermaskTextureForLayer } from "./create-soldermask-texture-for-layer"
-export { createThroughHoleTextureForLayer } from "./create-through-hole-texture-for-layer"
-export { createTextureMeshes } from "./create-three-texture-meshes"
+export type { CombinedBoardTextures } from "./create-combined-board-textures";
+export { createCombinedBoardTextures } from "./create-combined-board-textures";
+export { createCopperTextTextureForLayer } from "./create-copper-text-texture-for-layer";
+export { createCopperPourTextureForLayer } from "./create-copper-pour-texture-for-layer";
+export { createFabricationNoteTextureForLayer } from "./create-fabrication-note-texture-for-layer";
+export { createPcbNoteTextureForLayer } from "./create-pcb-note-texture-for-layer";
+export { createSilkscreenTextureForLayer } from "./create-silkscreen-texture-for-layer";
+export { createSoldermaskTextureForLayer } from "./create-soldermask-texture-for-layer";
+export { createThroughHoleTextureForLayer } from "./create-through-hole-texture-for-layer";
+export { createTextureMeshes } from "./create-three-texture-meshes";
+
+// SVG-based texture generation (new)
+export type { SvgTextureOptions } from "./create-svg-based-texture";
+export {
+  createSvgBasedTexture,
+  createSvgBasedTextureAsync,
+} from "./create-svg-based-texture";
+export { createSvgFromCircuitJson } from "./svg-from-circuit-json";
+export {
+  convertSvgToPng,
+  convertSvgToRawPixels,
+  initResvgWasm,
+  isResvgInitialized,
+  preloadResvgWasm,
+  type ConvertSvgOptions,
+} from "./resvg-converter";

--- a/src/textures/resvg-converter.ts
+++ b/src/textures/resvg-converter.ts
@@ -1,0 +1,208 @@
+/**
+ * resvg-wasm integration for converting SVG to PNG
+ * This module handles lazy loading of the wasm module and provides
+ * a simple API for SVG to raster conversion.
+ */
+
+import { initWasm, Resvg } from "@resvg/resvg-wasm";
+
+// URL for the resvg WASM binary (using jsdelivr CDN)
+const RESVG_WASM_URL =
+  "https://cdn.jsdelivr.net/npm/@resvg/resvg-wasm@2.6.2/index_bg.wasm";
+
+let resvgInitialized = false;
+let initializationPromise: Promise<void> | null = null;
+
+/**
+ * Initialize the resvg-wasm module.
+ * This should be called before using convertSvgToPng.
+ */
+export async function initResvgWasm(): Promise<void> {
+  if (resvgInitialized) {
+    return;
+  }
+
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = (async () => {
+    try {
+      await initWasm(RESVG_WASM_URL);
+      resvgInitialized = true;
+    } catch (error) {
+      console.error("Failed to initialize resvg-wasm:", error);
+      throw error;
+    }
+  })();
+
+  return initializationPromise;
+}
+
+/**
+ * Check if resvg-wasm has been initialized
+ */
+export function isResvgInitialized(): boolean {
+  return resvgInitialized;
+}
+
+export interface ConvertSvgOptions {
+  width?: number;
+  height?: number;
+  /**
+   * Background color (default: transparent)
+   */
+  background?: string;
+  /**
+   * Fit mode for SVG rendering
+   * @default "width"
+   */
+  fitMode?: "width" | "height" | "original";
+  /**
+   * Crop mode
+   * @default false
+   */
+  cropToViewport?: boolean;
+}
+
+/**
+ * Convert an SVG string to a PNG buffer using resvg-wasm.
+ *
+ * @param svgString - The SVG content as a string
+ * @param options - Conversion options including width, height, and background
+ * @returns Uint8Array containing PNG data
+ *
+ * @example
+ * ```typescript
+ * const pngBuffer = await convertSvgToPng(svgString, {
+ *   width: 1024,
+ *   height: 1024,
+ *   background: "#ffffff"
+ * });
+ * ```
+ */
+export async function convertSvgToPng(
+  svgString: string,
+  options: ConvertSvgOptions = {},
+): Promise<Uint8Array | null> {
+  if (!resvgInitialized) {
+    await initResvgWasm();
+  }
+
+  try {
+    const { width, height, background, fitMode = "original" } = options;
+
+    // Create resvg instance with options
+    const resvgOptions: Record<string, any> = {
+      fitMode,
+    };
+
+    if (width !== undefined) {
+      resvgOptions.width = width;
+    }
+    if (height !== undefined) {
+      resvgOptions.height = height;
+    }
+    if (background !== undefined) {
+      resvgOptions.background = background;
+    }
+
+    const resvg = new Resvg(svgString, resvgOptions);
+    const rendered = resvg.render();
+    const pngData = rendered.asPng();
+
+    return pngData;
+  } catch (error) {
+    console.error("Error converting SVG to PNG:", error);
+    return null;
+  }
+}
+
+/**
+ * Convert SVG to raw pixel buffer (RGBA format).
+ * This is useful for directly creating WebGL textures without the PNG encoding step.
+ */
+export async function convertSvgToRawPixels(
+  svgString: string,
+  options: ConvertSvgOptions = {},
+): Promise<{
+  pixels: Uint8Array;
+  width: number;
+  height: number;
+} | null> {
+  if (!resvgInitialized) {
+    await initResvgWasm();
+  }
+
+  try {
+    const { width, height, background, fitMode = "original" } = options;
+
+    const resvgOptions: Record<string, any> = {
+      fitMode,
+    };
+
+    if (width !== undefined) {
+      resvgOptions.width = width;
+    }
+    if (height !== undefined) {
+      resvgOptions.height = height;
+    }
+    if (background !== undefined) {
+      resvgOptions.background = background;
+    }
+
+    const resvg = new Resvg(svgString, resvgOptions);
+
+    // Get the rendered size
+    const bbox = resvg.getBBox();
+    const outputWidth = width ?? Math.ceil(bbox?.width ?? 512);
+    const outputHeight = height ?? Math.ceil(bbox?.height ?? 512);
+
+    // Render to PNG first
+    const rendered = resvg.render();
+    const pngBuffer = rendered.asPng();
+
+    // Decode PNG to raw pixels using canvas
+    const arrayBuffer = pngBuffer.buffer.slice(
+      pngBuffer.byteOffset,
+      pngBuffer.byteOffset + pngBuffer.byteLength,
+    ) as ArrayBuffer;
+    const blob = new Blob([arrayBuffer], { type: "image/png" });
+    const bitmap = await createImageBitmap(blob);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = outputWidth;
+    canvas.height = outputHeight;
+    const ctx = canvas.getContext("2d");
+
+    if (!ctx) {
+      throw new Error("Failed to get 2D context");
+    }
+
+    ctx.drawImage(bitmap, 0, 0);
+    const imageData = ctx.getImageData(0, 0, outputWidth, outputHeight);
+
+    bitmap.close();
+
+    return {
+      pixels: Uint8Array.from(imageData.data),
+      width: outputWidth,
+      height: outputHeight,
+    };
+  } catch (error) {
+    console.error("Error converting SVG to raw pixels:", error);
+    return null;
+  }
+}
+
+/**
+ * Preload the resvg-wasm module.
+ * Call this early in your application to ensure the WASM is loaded before use.
+ */
+export function preloadResvgWasm(): void {
+  if (!resvgInitialized && !initializationPromise) {
+    initResvgWasm().catch((error) => {
+      console.warn("Preload of resvg-wasm failed:", error);
+    });
+  }
+}

--- a/src/textures/resvg-converter.ts
+++ b/src/textures/resvg-converter.ts
@@ -4,14 +4,14 @@
  * a simple API for SVG to raster conversion.
  */
 
-import { initWasm, Resvg } from "@resvg/resvg-wasm";
+import { initWasm, Resvg } from "@resvg/resvg-wasm"
 
 // URL for the resvg WASM binary (using jsdelivr CDN)
 const RESVG_WASM_URL =
-  "https://cdn.jsdelivr.net/npm/@resvg/resvg-wasm@2.6.2/index_bg.wasm";
+  "https://cdn.jsdelivr.net/npm/@resvg/resvg-wasm@2.6.2/index_bg.wasm"
 
-let resvgInitialized = false;
-let initializationPromise: Promise<void> | null = null;
+let resvgInitialized = false
+let initializationPromise: Promise<void> | null = null
 
 /**
  * Initialize the resvg-wasm module.
@@ -19,50 +19,50 @@ let initializationPromise: Promise<void> | null = null;
  */
 export async function initResvgWasm(): Promise<void> {
   if (resvgInitialized) {
-    return;
+    return
   }
 
   if (initializationPromise) {
-    return initializationPromise;
+    return initializationPromise
   }
 
   initializationPromise = (async () => {
     try {
-      await initWasm(RESVG_WASM_URL);
-      resvgInitialized = true;
+      await initWasm(RESVG_WASM_URL)
+      resvgInitialized = true
     } catch (error) {
-      console.error("Failed to initialize resvg-wasm:", error);
-      throw error;
+      console.error("Failed to initialize resvg-wasm:", error)
+      throw error
     }
-  })();
+  })()
 
-  return initializationPromise;
+  return initializationPromise
 }
 
 /**
  * Check if resvg-wasm has been initialized
  */
 export function isResvgInitialized(): boolean {
-  return resvgInitialized;
+  return resvgInitialized
 }
 
 export interface ConvertSvgOptions {
-  width?: number;
-  height?: number;
+  width?: number
+  height?: number
   /**
    * Background color (default: transparent)
    */
-  background?: string;
+  background?: string
   /**
    * Fit mode for SVG rendering
    * @default "width"
    */
-  fitMode?: "width" | "height" | "original";
+  fitMode?: "width" | "height" | "original"
   /**
    * Crop mode
    * @default false
    */
-  cropToViewport?: boolean;
+  cropToViewport?: boolean
 }
 
 /**
@@ -86,35 +86,35 @@ export async function convertSvgToPng(
   options: ConvertSvgOptions = {},
 ): Promise<Uint8Array | null> {
   if (!resvgInitialized) {
-    await initResvgWasm();
+    await initResvgWasm()
   }
 
   try {
-    const { width, height, background, fitMode = "original" } = options;
+    const { width, height, background, fitMode = "original" } = options
 
     // Create resvg instance with options
     const resvgOptions: Record<string, any> = {
       fitMode,
-    };
+    }
 
     if (width !== undefined) {
-      resvgOptions.width = width;
+      resvgOptions.width = width
     }
     if (height !== undefined) {
-      resvgOptions.height = height;
+      resvgOptions.height = height
     }
     if (background !== undefined) {
-      resvgOptions.background = background;
+      resvgOptions.background = background
     }
 
-    const resvg = new Resvg(svgString, resvgOptions);
-    const rendered = resvg.render();
-    const pngData = rendered.asPng();
+    const resvg = new Resvg(svgString, resvgOptions)
+    const rendered = resvg.render()
+    const pngData = rendered.asPng()
 
-    return pngData;
+    return pngData
   } catch (error) {
-    console.error("Error converting SVG to PNG:", error);
-    return null;
+    console.error("Error converting SVG to PNG:", error)
+    return null
   }
 }
 
@@ -126,72 +126,72 @@ export async function convertSvgToRawPixels(
   svgString: string,
   options: ConvertSvgOptions = {},
 ): Promise<{
-  pixels: Uint8Array;
-  width: number;
-  height: number;
+  pixels: Uint8Array
+  width: number
+  height: number
 } | null> {
   if (!resvgInitialized) {
-    await initResvgWasm();
+    await initResvgWasm()
   }
 
   try {
-    const { width, height, background, fitMode = "original" } = options;
+    const { width, height, background, fitMode = "original" } = options
 
     const resvgOptions: Record<string, any> = {
       fitMode,
-    };
+    }
 
     if (width !== undefined) {
-      resvgOptions.width = width;
+      resvgOptions.width = width
     }
     if (height !== undefined) {
-      resvgOptions.height = height;
+      resvgOptions.height = height
     }
     if (background !== undefined) {
-      resvgOptions.background = background;
+      resvgOptions.background = background
     }
 
-    const resvg = new Resvg(svgString, resvgOptions);
+    const resvg = new Resvg(svgString, resvgOptions)
 
     // Get the rendered size
-    const bbox = resvg.getBBox();
-    const outputWidth = width ?? Math.ceil(bbox?.width ?? 512);
-    const outputHeight = height ?? Math.ceil(bbox?.height ?? 512);
+    const bbox = resvg.getBBox()
+    const outputWidth = width ?? Math.ceil(bbox?.width ?? 512)
+    const outputHeight = height ?? Math.ceil(bbox?.height ?? 512)
 
     // Render to PNG first
-    const rendered = resvg.render();
-    const pngBuffer = rendered.asPng();
+    const rendered = resvg.render()
+    const pngBuffer = rendered.asPng()
 
     // Decode PNG to raw pixels using canvas
     const arrayBuffer = pngBuffer.buffer.slice(
       pngBuffer.byteOffset,
       pngBuffer.byteOffset + pngBuffer.byteLength,
-    ) as ArrayBuffer;
-    const blob = new Blob([arrayBuffer], { type: "image/png" });
-    const bitmap = await createImageBitmap(blob);
+    ) as ArrayBuffer
+    const blob = new Blob([arrayBuffer], { type: "image/png" })
+    const bitmap = await createImageBitmap(blob)
 
-    const canvas = document.createElement("canvas");
-    canvas.width = outputWidth;
-    canvas.height = outputHeight;
-    const ctx = canvas.getContext("2d");
+    const canvas = document.createElement("canvas")
+    canvas.width = outputWidth
+    canvas.height = outputHeight
+    const ctx = canvas.getContext("2d")
 
     if (!ctx) {
-      throw new Error("Failed to get 2D context");
+      throw new Error("Failed to get 2D context")
     }
 
-    ctx.drawImage(bitmap, 0, 0);
-    const imageData = ctx.getImageData(0, 0, outputWidth, outputHeight);
+    ctx.drawImage(bitmap, 0, 0)
+    const imageData = ctx.getImageData(0, 0, outputWidth, outputHeight)
 
-    bitmap.close();
+    bitmap.close()
 
     return {
       pixels: Uint8Array.from(imageData.data),
       width: outputWidth,
       height: outputHeight,
-    };
+    }
   } catch (error) {
-    console.error("Error converting SVG to raw pixels:", error);
-    return null;
+    console.error("Error converting SVG to raw pixels:", error)
+    return null
   }
 }
 
@@ -202,7 +202,7 @@ export async function convertSvgToRawPixels(
 export function preloadResvgWasm(): void {
   if (!resvgInitialized && !initializationPromise) {
     initResvgWasm().catch((error) => {
-      console.warn("Preload of resvg-wasm failed:", error);
-    });
+      console.warn("Preload of resvg-wasm failed:", error)
+    })
   }
 }

--- a/src/textures/svg-from-circuit-json.ts
+++ b/src/textures/svg-from-circuit-json.ts
@@ -4,33 +4,33 @@ import type {
   PcbTrace,
   PcbVia,
   PcbPlatedHole,
-} from "circuit-json";
-import { su, getElementRenderLayers } from "@tscircuit/circuit-json-util";
-import { splitTraceIntoLayerSegments } from "../utils/trace-layer-segments";
-import { colors as defaultColors } from "../geoms/constants";
+} from "circuit-json"
+import { su, getElementRenderLayers } from "@tscircuit/circuit-json-util"
+import { splitTraceIntoLayerSegments } from "../utils/trace-layer-segments"
+import { colors as defaultColors } from "../geoms/constants"
 
 export interface SvgFromCircuitJsonOptions {
-  circuitJson: AnyCircuitElement[];
-  boardData: PcbBoard;
-  layer: "top" | "bottom";
-  width: number;
-  height: number;
+  circuitJson: AnyCircuitElement[]
+  boardData: PcbBoard
+  layer: "top" | "bottom"
+  width: number
+  height: number
   bounds: {
-    minX: number;
-    maxX: number;
-    minY: number;
-    maxY: number;
-    width: number;
-    height: number;
-    centerX: number;
-    centerY: number;
-  };
+    minX: number
+    maxX: number
+    minY: number
+    maxY: number
+    width: number
+    height: number
+    centerX: number
+    centerY: number
+  }
   colors?: {
-    copper?: string;
-    silkscreen?: string;
-    soldermask?: string;
-    substrate?: string;
-  };
+    copper?: string
+    silkscreen?: string
+    soldermask?: string
+    substrate?: string
+  }
 }
 
 /**
@@ -48,61 +48,61 @@ export function createSvgFromCircuitJson(
     height,
     bounds,
     colors: colorOverrides,
-  } = options;
+  } = options
 
-  const copperColor = colorOverrides?.copper ?? toHex(defaultColors.copper);
-  const silkscreenColor = colorOverrides?.silkscreen ?? "#FFFFFF";
+  const copperColor = colorOverrides?.copper ?? toHex(defaultColors.copper)
+  const silkscreenColor = colorOverrides?.silkscreen ?? "#FFFFFF"
   const soldermaskColor =
-    colorOverrides?.soldermask ?? toHex(defaultColors.fr4SolderMaskGreen);
+    colorOverrides?.soldermask ?? toHex(defaultColors.fr4SolderMaskGreen)
   const substrateColor =
-    colorOverrides?.substrate ?? toHex(defaultColors.fr4Tan);
+    colorOverrides?.substrate ?? toHex(defaultColors.fr4Tan)
 
-  const pcbRenderLayer = layer === "top" ? "top_copper" : "bottom_copper";
-  const silkscreenLayer = layer === "top" ? "top" : "bottom";
+  const pcbRenderLayer = layer === "top" ? "top_copper" : "bottom_copper"
+  const silkscreenLayer = layer === "top" ? "top" : "bottom"
 
   // Get elements
-  const pcbTraces = su(circuitJson).pcb_trace.list();
-  const pcbVias = su(circuitJson).pcb_via.list();
-  const pcbPlatedHoles = su(circuitJson).pcb_plated_hole.list();
-  const pcbSmtPads = su(circuitJson).pcb_smtpad.list();
-  const pcbHoles = su(circuitJson).pcb_hole.list();
+  const pcbTraces = su(circuitJson).pcb_trace.list()
+  const pcbVias = su(circuitJson).pcb_via.list()
+  const pcbPlatedHoles = su(circuitJson).pcb_plated_hole.list()
+  const pcbSmtPads = su(circuitJson).pcb_smtpad.list()
+  const pcbHoles = su(circuitJson).pcb_hole.list()
 
   // Filter by layer
   const tracesOnLayer = pcbTraces.flatMap((trace) =>
     getElementRenderLayers(trace).includes(pcbRenderLayer)
       ? splitTraceIntoLayerSegments(trace, layer)
       : [],
-  );
+  )
 
   const platedHolesOnLayer = pcbPlatedHoles.filter((hole: PcbPlatedHole) =>
     hole.layers.includes(layer),
-  );
+  )
 
-  const smtPadsOnLayer = pcbSmtPads.filter((pad) => pad.layer === layer);
+  const smtPadsOnLayer = pcbSmtPads.filter((pad) => pad.layer === layer)
 
   const silkscreenElements = circuitJson.filter((element) => {
-    const elementType = element.type as string;
+    const elementType = element.type as string
     return (
       elementType.startsWith("pcb_silkscreen_") &&
       "layer" in element &&
       element.layer === layer
-    );
-  });
+    )
+  })
 
   // Calculate scale
-  const scaleX = width / bounds.width;
-  const scaleY = height / bounds.height;
+  const scaleX = width / bounds.width
+  const scaleY = height / bounds.height
 
   // SVG coordinate transform: flip Y axis for PCB coordinates (Y up) to SVG (Y down)
-  const transformX = (x: number) => (x - bounds.minX) * scaleX;
-  const transformY = (y: number) => height - (y - bounds.minY) * scaleY;
+  const transformX = (x: number) => (x - bounds.minX) * scaleX
+  const transformY = (y: number) => height - (y - bounds.minY) * scaleY
 
-  const svgParts: string[] = [];
+  const svgParts: string[] = []
 
   // SVG header
   svgParts.push(
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
-  );
+  )
 
   // Background (soldermask/substrate)
   if (boardData.outline && boardData.outline.length > 0) {
@@ -111,169 +111,167 @@ export function createSvgFromCircuitJson(
       boardData.outline,
       transformX,
       transformY,
-    );
+    )
     svgParts.push(
       `  <path d="${outlinePath}" fill="${soldermaskColor}" stroke="none" />`,
-    );
+    )
   } else {
     // Rectangular board
-    const rectX = transformX(bounds.minX);
-    const rectY = transformY(bounds.maxY);
-    const rectW = bounds.width * scaleX;
-    const rectH = bounds.height * scaleY;
+    const rectX = transformX(bounds.minX)
+    const rectY = transformY(bounds.maxY)
+    const rectW = bounds.width * scaleX
+    const rectH = bounds.height * scaleY
     svgParts.push(
       `  <rect x="${rectX}" y="${rectY}" width="${rectW}" height="${rectH}" fill="${soldermaskColor}" />`,
-    );
+    )
   }
 
   // Draw copper elements (traces, pads, plated holes)
-  svgParts.push(`  <g fill="${copperColor}" stroke="${copperColor}">`);
+  svgParts.push(`  <g fill="${copperColor}" stroke="${copperColor}">`)
 
   // Traces
   for (const trace of tracesOnLayer) {
     if (trace.route.length >= 2) {
-      const path = createTracePath(trace.route, transformX, transformY);
+      const path = createTracePath(trace.route, transformX, transformY)
       // Get width from first route point (only wire points have width)
-      const firstPoint = trace.route[0];
+      const firstPoint = trace.route[0]
       const strokeWidth =
         (firstPoint?.route_type === "wire" ? (firstPoint as any).width : 0.1) *
-        Math.min(scaleX, scaleY);
+        Math.min(scaleX, scaleY)
       svgParts.push(
         `    <path d="${path}" fill="none" stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round" />`,
-      );
+      )
     }
   }
 
   // SMT Pads
   for (const pad of smtPadsOnLayer) {
     if (pad.shape === "rect" || pad.shape === "circle") {
-      const cx = transformX(pad.x);
-      const cy = transformY(pad.y);
+      const cx = transformX(pad.x)
+      const cy = transformY(pad.y)
       if (pad.shape === "rect" && pad.width && pad.height) {
-        const w = pad.width * scaleX;
-        const h = pad.height * scaleY;
-        const x = cx - w / 2;
-        const y = cy - h / 2;
+        const w = pad.width * scaleX
+        const h = pad.height * scaleY
+        const x = cx - w / 2
+        const y = cy - h / 2
         svgParts.push(
           `    <rect x="${x}" y="${y}" width="${w}" height="${h}" />`,
-        );
+        )
       } else if (pad.shape === "circle" && pad.radius) {
-        const r = pad.radius * Math.min(scaleX, scaleY);
-        svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${r}" />`);
+        const r = pad.radius * Math.min(scaleX, scaleY)
+        svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${r}" />`)
       }
     }
   }
 
   // Plated holes on this layer
   for (const hole of platedHolesOnLayer) {
-    const cx = transformX(hole.x);
-    const cy = transformY(hole.y);
+    const cx = transformX(hole.x)
+    const cy = transformY(hole.y)
     if (hole.shape === "circle") {
-      const outerR = (hole.outer_diameter / 2) * Math.min(scaleX, scaleY);
-      const innerR = (hole.hole_diameter / 2) * Math.min(scaleX, scaleY);
+      const outerR = (hole.outer_diameter / 2) * Math.min(scaleX, scaleY)
+      const innerR = (hole.hole_diameter / 2) * Math.min(scaleX, scaleY)
       // Draw ring for plated hole
-      svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${outerR}" />`);
+      svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${outerR}" />`)
     } else if (hole.shape === "oval" || hole.shape === "pill") {
       // Simplified oval/pill rendering
-      const outerWidth = (hole.outer_width ?? 1.0) * Math.min(scaleX, scaleY);
-      const outerHeight = (hole.outer_height ?? 1.0) * Math.min(scaleX, scaleY);
-      const rx = outerWidth / 2;
-      const ry = outerHeight / 2;
+      const outerWidth = (hole.outer_width ?? 1.0) * Math.min(scaleX, scaleY)
+      const outerHeight = (hole.outer_height ?? 1.0) * Math.min(scaleX, scaleY)
+      const rx = outerWidth / 2
+      const ry = outerHeight / 2
       svgParts.push(
         `    <ellipse cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}" />`,
-      );
+      )
     }
   }
 
   // Vias
   for (const via of pcbVias) {
-    const cx = transformX(via.x);
-    const cy = transformY(via.y);
-    const outerR = (via.outer_diameter / 2) * Math.min(scaleX, scaleY);
-    svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${outerR}" />`);
+    const cx = transformX(via.x)
+    const cy = transformY(via.y)
+    const outerR = (via.outer_diameter / 2) * Math.min(scaleX, scaleY)
+    svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${outerR}" />`)
   }
 
-  svgParts.push("  </g>");
+  svgParts.push("  </g>")
 
   // Draw silkscreen elements
   if (silkscreenElements.length > 0) {
-    svgParts.push(
-      `  <g fill="${silkscreenColor}" stroke="${silkscreenColor}">`,
-    );
+    svgParts.push(`  <g fill="${silkscreenColor}" stroke="${silkscreenColor}">`)
 
     for (const element of silkscreenElements) {
-      const elementType = element.type as string;
+      const elementType = element.type as string
 
       if (elementType === "pcb_silkscreen_line") {
-        const line = element as any;
-        const x1 = transformX(line.x1);
-        const y1 = transformY(line.y1);
-        const x2 = transformX(line.x2);
-        const y2 = transformY(line.y2);
+        const line = element as any
+        const x1 = transformX(line.x1)
+        const y1 = transformY(line.y1)
+        const x2 = transformX(line.x2)
+        const y2 = transformY(line.y2)
         const strokeWidth =
-          (line.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+          (line.stroke_width ?? 0.1) * Math.min(scaleX, scaleY)
         svgParts.push(
           `    <line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke-width="${strokeWidth}" />`,
-        );
+        )
       } else if (elementType === "pcb_silkscreen_rect") {
-        const rect = element as any;
-        const cx = transformX(rect.center?.x ?? rect.x);
-        const cy = transformY(rect.center?.y ?? rect.y);
-        const w = (rect.width ?? 1) * scaleX;
-        const h = (rect.height ?? 1) * scaleY;
-        const x = cx - w / 2;
-        const y = cy - h / 2;
+        const rect = element as any
+        const cx = transformX(rect.center?.x ?? rect.x)
+        const cy = transformY(rect.center?.y ?? rect.y)
+        const w = (rect.width ?? 1) * scaleX
+        const h = (rect.height ?? 1) * scaleY
+        const x = cx - w / 2
+        const y = cy - h / 2
         const strokeWidth =
-          (rect.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+          (rect.stroke_width ?? 0.1) * Math.min(scaleX, scaleY)
         svgParts.push(
           `    <rect x="${x}" y="${y}" width="${w}" height="${h}" fill="none" stroke-width="${strokeWidth}" />`,
-        );
+        )
       } else if (elementType === "pcb_silkscreen_circle") {
-        const circle = element as any;
-        const cx = transformX(circle.center?.x ?? circle.x);
-        const cy = transformY(circle.center?.y ?? circle.y);
-        const r = (circle.radius ?? 0.5) * Math.min(scaleX, scaleY);
+        const circle = element as any
+        const cx = transformX(circle.center?.x ?? circle.x)
+        const cy = transformY(circle.center?.y ?? circle.y)
+        const r = (circle.radius ?? 0.5) * Math.min(scaleX, scaleY)
         const strokeWidth =
-          (circle.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+          (circle.stroke_width ?? 0.1) * Math.min(scaleX, scaleY)
         svgParts.push(
           `    <circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke-width="${strokeWidth}" />`,
-        );
+        )
       } else if (elementType === "pcb_silkscreen_path") {
-        const path = element as any;
+        const path = element as any
         if (path.route?.length >= 2) {
-          const d = createTracePath(path.route, transformX, transformY);
+          const d = createTracePath(path.route, transformX, transformY)
           const strokeWidth =
-            (path.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+            (path.stroke_width ?? 0.1) * Math.min(scaleX, scaleY)
           svgParts.push(
             `    <path d="${d}" fill="none" stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round" />`,
-          );
+          )
         }
       } else if (elementType === "pcb_silkscreen_text") {
-        const text = element as any;
-        const x = transformX(text.anchor_position?.x ?? text.x);
-        const y = transformY(text.anchor_position?.y ?? text.y);
-        const fontSize = (text.font_size ?? 1) * Math.min(scaleX, scaleY);
-        const textStr = escapeXml(text.text ?? "");
+        const text = element as any
+        const x = transformX(text.anchor_position?.x ?? text.x)
+        const y = transformY(text.anchor_position?.y ?? text.y)
+        const fontSize = (text.font_size ?? 1) * Math.min(scaleX, scaleY)
+        const textStr = escapeXml(text.text ?? "")
         // Note: rotation not supported in this simplified version
         svgParts.push(
           `    <text x="${x}" y="${y}" fill="${silkscreenColor}" font-size="${fontSize}" font-family="sans-serif" text-anchor="middle" dominant-baseline="middle">${textStr}</text>`,
-        );
+        )
       }
     }
 
-    svgParts.push("  </g>");
+    svgParts.push("  </g>")
   }
 
   // Non-plated holes (cutouts)
   for (const hole of pcbHoles) {
-    const cx = transformX(hole.x);
-    const cy = transformY(hole.y);
+    const cx = transformX(hole.x)
+    const cy = transformY(hole.y)
     if (hole.hole_shape === "circle") {
-      const r = (hole.hole_diameter / 2) * Math.min(scaleX, scaleY);
+      const r = (hole.hole_diameter / 2) * Math.min(scaleX, scaleY)
       // Use soldermask color to "erase" the copper
       svgParts.push(
         `  <circle cx="${cx}" cy="${cy}" r="${r}" fill="${soldermaskColor}" stroke="none" />`,
-      );
+      )
     }
   }
 
@@ -283,17 +281,17 @@ export function createSvgFromCircuitJson(
       boardData.outline,
       transformX,
       transformY,
-    );
-    const strokeWidth = 2; // 2px outline in screen space
+    )
+    const strokeWidth = 2 // 2px outline in screen space
     svgParts.push(
       `  <path d="${outlinePath}" fill="none" stroke="${darken(soldermaskColor)}" stroke-width="${strokeWidth}" />`,
-    );
+    )
   }
 
   // Close SVG
-  svgParts.push("</svg>");
+  svgParts.push("</svg>")
 
-  return svgParts.join("\n");
+  return svgParts.join("\n")
 }
 
 /**
@@ -304,16 +302,16 @@ function createTracePath(
   transformX: (x: number) => number,
   transformY: (y: number) => number,
 ): string {
-  if (route.length === 0) return "";
+  if (route.length === 0) return ""
 
-  const parts: string[] = [];
-  parts.push(`M ${transformX(route[0]!.x)} ${transformY(route[0]!.y)}`);
+  const parts: string[] = []
+  parts.push(`M ${transformX(route[0]!.x)} ${transformY(route[0]!.y)}`)
 
   for (let i = 1; i < route.length; i++) {
-    parts.push(`L ${transformX(route[i]!.x)} ${transformY(route[i]!.y)}`);
+    parts.push(`L ${transformX(route[i]!.x)} ${transformY(route[i]!.y)}`)
   }
 
-  return parts.join(" ");
+  return parts.join(" ")
 }
 
 /**
@@ -324,17 +322,17 @@ function createOutlinePath(
   transformX: (x: number) => number,
   transformY: (y: number) => number,
 ): string {
-  if (outline.length === 0) return "";
+  if (outline.length === 0) return ""
 
-  const parts: string[] = [];
-  parts.push(`M ${transformX(outline[0]!.x)} ${transformY(outline[0]!.y)}`);
+  const parts: string[] = []
+  parts.push(`M ${transformX(outline[0]!.x)} ${transformY(outline[0]!.y)}`)
 
   for (let i = 1; i < outline.length; i++) {
-    parts.push(`L ${transformX(outline[i]!.x)} ${transformY(outline[i]!.y)}`);
+    parts.push(`L ${transformX(outline[i]!.x)} ${transformY(outline[i]!.y)}`)
   }
 
-  parts.push("Z");
-  return parts.join(" ");
+  parts.push("Z")
+  return parts.join(" ")
 }
 
 /**
@@ -343,14 +341,14 @@ function createOutlinePath(
 function toHex(rgb: number[]): string {
   const r = Math.round(rgb[0]! * 255)
     .toString(16)
-    .padStart(2, "0");
+    .padStart(2, "0")
   const g = Math.round(rgb[1]! * 255)
     .toString(16)
-    .padStart(2, "0");
+    .padStart(2, "0")
   const b = Math.round(rgb[2]! * 255)
     .toString(16)
-    .padStart(2, "0");
-  return `#${r}${g}${b}`;
+    .padStart(2, "0")
+  return `#${r}${g}${b}`
 }
 
 /**
@@ -358,15 +356,15 @@ function toHex(rgb: number[]): string {
  */
 function darken(hex: string): string {
   // Simple darkening - reduce each channel by 20%
-  const r = Math.max(0, parseInt(hex.slice(1, 3), 16) * 0.8);
-  const g = Math.max(0, parseInt(hex.slice(3, 5), 16) * 0.8);
-  const b = Math.max(0, parseInt(hex.slice(5, 7), 16) * 0.8);
+  const r = Math.max(0, parseInt(hex.slice(1, 3), 16) * 0.8)
+  const g = Math.max(0, parseInt(hex.slice(3, 5), 16) * 0.8)
+  const b = Math.max(0, parseInt(hex.slice(5, 7), 16) * 0.8)
 
-  const rs = Math.round(r).toString(16).padStart(2, "0");
-  const gs = Math.round(g).toString(16).padStart(2, "0");
-  const bs = Math.round(b).toString(16).padStart(2, "0");
+  const rs = Math.round(r).toString(16).padStart(2, "0")
+  const gs = Math.round(g).toString(16).padStart(2, "0")
+  const bs = Math.round(b).toString(16).padStart(2, "0")
 
-  return `#${rs}${gs}${bs}`;
+  return `#${rs}${gs}${bs}`
 }
 
 /**
@@ -378,5 +376,5 @@ function escapeXml(str: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
+    .replace(/'/g, "&apos;")
 }

--- a/src/textures/svg-from-circuit-json.ts
+++ b/src/textures/svg-from-circuit-json.ts
@@ -1,0 +1,382 @@
+import type {
+  AnyCircuitElement,
+  PcbBoard,
+  PcbTrace,
+  PcbVia,
+  PcbPlatedHole,
+} from "circuit-json";
+import { su, getElementRenderLayers } from "@tscircuit/circuit-json-util";
+import { splitTraceIntoLayerSegments } from "../utils/trace-layer-segments";
+import { colors as defaultColors } from "../geoms/constants";
+
+export interface SvgFromCircuitJsonOptions {
+  circuitJson: AnyCircuitElement[];
+  boardData: PcbBoard;
+  layer: "top" | "bottom";
+  width: number;
+  height: number;
+  bounds: {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    width: number;
+    height: number;
+    centerX: number;
+    centerY: number;
+  };
+  colors?: {
+    copper?: string;
+    silkscreen?: string;
+    soldermask?: string;
+    substrate?: string;
+  };
+}
+
+/**
+ * Creates an SVG representation of a PCB layer from circuit JSON.
+ * This generates high-quality vector graphics suitable for resvg-wasm rendering.
+ */
+export function createSvgFromCircuitJson(
+  options: SvgFromCircuitJsonOptions,
+): string {
+  const {
+    circuitJson,
+    boardData,
+    layer,
+    width,
+    height,
+    bounds,
+    colors: colorOverrides,
+  } = options;
+
+  const copperColor = colorOverrides?.copper ?? toHex(defaultColors.copper);
+  const silkscreenColor = colorOverrides?.silkscreen ?? "#FFFFFF";
+  const soldermaskColor =
+    colorOverrides?.soldermask ?? toHex(defaultColors.fr4SolderMaskGreen);
+  const substrateColor =
+    colorOverrides?.substrate ?? toHex(defaultColors.fr4Tan);
+
+  const pcbRenderLayer = layer === "top" ? "top_copper" : "bottom_copper";
+  const silkscreenLayer = layer === "top" ? "top" : "bottom";
+
+  // Get elements
+  const pcbTraces = su(circuitJson).pcb_trace.list();
+  const pcbVias = su(circuitJson).pcb_via.list();
+  const pcbPlatedHoles = su(circuitJson).pcb_plated_hole.list();
+  const pcbSmtPads = su(circuitJson).pcb_smtpad.list();
+  const pcbHoles = su(circuitJson).pcb_hole.list();
+
+  // Filter by layer
+  const tracesOnLayer = pcbTraces.flatMap((trace) =>
+    getElementRenderLayers(trace).includes(pcbRenderLayer)
+      ? splitTraceIntoLayerSegments(trace, layer)
+      : [],
+  );
+
+  const platedHolesOnLayer = pcbPlatedHoles.filter((hole: PcbPlatedHole) =>
+    hole.layers.includes(layer),
+  );
+
+  const smtPadsOnLayer = pcbSmtPads.filter((pad) => pad.layer === layer);
+
+  const silkscreenElements = circuitJson.filter((element) => {
+    const elementType = element.type as string;
+    return (
+      elementType.startsWith("pcb_silkscreen_") &&
+      "layer" in element &&
+      element.layer === layer
+    );
+  });
+
+  // Calculate scale
+  const scaleX = width / bounds.width;
+  const scaleY = height / bounds.height;
+
+  // SVG coordinate transform: flip Y axis for PCB coordinates (Y up) to SVG (Y down)
+  const transformX = (x: number) => (x - bounds.minX) * scaleX;
+  const transformY = (y: number) => height - (y - bounds.minY) * scaleY;
+
+  const svgParts: string[] = [];
+
+  // SVG header
+  svgParts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+  );
+
+  // Background (soldermask/substrate)
+  if (boardData.outline && boardData.outline.length > 0) {
+    // Draw board outline with soldermask color
+    const outlinePath = createOutlinePath(
+      boardData.outline,
+      transformX,
+      transformY,
+    );
+    svgParts.push(
+      `  <path d="${outlinePath}" fill="${soldermaskColor}" stroke="none" />`,
+    );
+  } else {
+    // Rectangular board
+    const rectX = transformX(bounds.minX);
+    const rectY = transformY(bounds.maxY);
+    const rectW = bounds.width * scaleX;
+    const rectH = bounds.height * scaleY;
+    svgParts.push(
+      `  <rect x="${rectX}" y="${rectY}" width="${rectW}" height="${rectH}" fill="${soldermaskColor}" />`,
+    );
+  }
+
+  // Draw copper elements (traces, pads, plated holes)
+  svgParts.push(`  <g fill="${copperColor}" stroke="${copperColor}">`);
+
+  // Traces
+  for (const trace of tracesOnLayer) {
+    if (trace.route.length >= 2) {
+      const path = createTracePath(trace.route, transformX, transformY);
+      // Get width from first route point (only wire points have width)
+      const firstPoint = trace.route[0];
+      const strokeWidth =
+        (firstPoint?.route_type === "wire" ? (firstPoint as any).width : 0.1) *
+        Math.min(scaleX, scaleY);
+      svgParts.push(
+        `    <path d="${path}" fill="none" stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round" />`,
+      );
+    }
+  }
+
+  // SMT Pads
+  for (const pad of smtPadsOnLayer) {
+    if (pad.shape === "rect" || pad.shape === "circle") {
+      const cx = transformX(pad.x);
+      const cy = transformY(pad.y);
+      if (pad.shape === "rect" && pad.width && pad.height) {
+        const w = pad.width * scaleX;
+        const h = pad.height * scaleY;
+        const x = cx - w / 2;
+        const y = cy - h / 2;
+        svgParts.push(
+          `    <rect x="${x}" y="${y}" width="${w}" height="${h}" />`,
+        );
+      } else if (pad.shape === "circle" && pad.radius) {
+        const r = pad.radius * Math.min(scaleX, scaleY);
+        svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${r}" />`);
+      }
+    }
+  }
+
+  // Plated holes on this layer
+  for (const hole of platedHolesOnLayer) {
+    const cx = transformX(hole.x);
+    const cy = transformY(hole.y);
+    if (hole.shape === "circle") {
+      const outerR = (hole.outer_diameter / 2) * Math.min(scaleX, scaleY);
+      const innerR = (hole.hole_diameter / 2) * Math.min(scaleX, scaleY);
+      // Draw ring for plated hole
+      svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${outerR}" />`);
+    } else if (hole.shape === "oval" || hole.shape === "pill") {
+      // Simplified oval/pill rendering
+      const outerWidth = (hole.outer_width ?? 1.0) * Math.min(scaleX, scaleY);
+      const outerHeight = (hole.outer_height ?? 1.0) * Math.min(scaleX, scaleY);
+      const rx = outerWidth / 2;
+      const ry = outerHeight / 2;
+      svgParts.push(
+        `    <ellipse cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}" />`,
+      );
+    }
+  }
+
+  // Vias
+  for (const via of pcbVias) {
+    const cx = transformX(via.x);
+    const cy = transformY(via.y);
+    const outerR = (via.outer_diameter / 2) * Math.min(scaleX, scaleY);
+    svgParts.push(`    <circle cx="${cx}" cy="${cy}" r="${outerR}" />`);
+  }
+
+  svgParts.push("  </g>");
+
+  // Draw silkscreen elements
+  if (silkscreenElements.length > 0) {
+    svgParts.push(
+      `  <g fill="${silkscreenColor}" stroke="${silkscreenColor}">`,
+    );
+
+    for (const element of silkscreenElements) {
+      const elementType = element.type as string;
+
+      if (elementType === "pcb_silkscreen_line") {
+        const line = element as any;
+        const x1 = transformX(line.x1);
+        const y1 = transformY(line.y1);
+        const x2 = transformX(line.x2);
+        const y2 = transformY(line.y2);
+        const strokeWidth =
+          (line.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+        svgParts.push(
+          `    <line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke-width="${strokeWidth}" />`,
+        );
+      } else if (elementType === "pcb_silkscreen_rect") {
+        const rect = element as any;
+        const cx = transformX(rect.center?.x ?? rect.x);
+        const cy = transformY(rect.center?.y ?? rect.y);
+        const w = (rect.width ?? 1) * scaleX;
+        const h = (rect.height ?? 1) * scaleY;
+        const x = cx - w / 2;
+        const y = cy - h / 2;
+        const strokeWidth =
+          (rect.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+        svgParts.push(
+          `    <rect x="${x}" y="${y}" width="${w}" height="${h}" fill="none" stroke-width="${strokeWidth}" />`,
+        );
+      } else if (elementType === "pcb_silkscreen_circle") {
+        const circle = element as any;
+        const cx = transformX(circle.center?.x ?? circle.x);
+        const cy = transformY(circle.center?.y ?? circle.y);
+        const r = (circle.radius ?? 0.5) * Math.min(scaleX, scaleY);
+        const strokeWidth =
+          (circle.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+        svgParts.push(
+          `    <circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke-width="${strokeWidth}" />`,
+        );
+      } else if (elementType === "pcb_silkscreen_path") {
+        const path = element as any;
+        if (path.route?.length >= 2) {
+          const d = createTracePath(path.route, transformX, transformY);
+          const strokeWidth =
+            (path.stroke_width ?? 0.1) * Math.min(scaleX, scaleY);
+          svgParts.push(
+            `    <path d="${d}" fill="none" stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round" />`,
+          );
+        }
+      } else if (elementType === "pcb_silkscreen_text") {
+        const text = element as any;
+        const x = transformX(text.anchor_position?.x ?? text.x);
+        const y = transformY(text.anchor_position?.y ?? text.y);
+        const fontSize = (text.font_size ?? 1) * Math.min(scaleX, scaleY);
+        const textStr = escapeXml(text.text ?? "");
+        // Note: rotation not supported in this simplified version
+        svgParts.push(
+          `    <text x="${x}" y="${y}" fill="${silkscreenColor}" font-size="${fontSize}" font-family="sans-serif" text-anchor="middle" dominant-baseline="middle">${textStr}</text>`,
+        );
+      }
+    }
+
+    svgParts.push("  </g>");
+  }
+
+  // Non-plated holes (cutouts)
+  for (const hole of pcbHoles) {
+    const cx = transformX(hole.x);
+    const cy = transformY(hole.y);
+    if (hole.hole_shape === "circle") {
+      const r = (hole.hole_diameter / 2) * Math.min(scaleX, scaleY);
+      // Use soldermask color to "erase" the copper
+      svgParts.push(
+        `  <circle cx="${cx}" cy="${cy}" r="${r}" fill="${soldermaskColor}" stroke="none" />`,
+      );
+    }
+  }
+
+  // Board outline stroke
+  if (boardData.outline && boardData.outline.length > 0) {
+    const outlinePath = createOutlinePath(
+      boardData.outline,
+      transformX,
+      transformY,
+    );
+    const strokeWidth = 2; // 2px outline in screen space
+    svgParts.push(
+      `  <path d="${outlinePath}" fill="none" stroke="${darken(soldermaskColor)}" stroke-width="${strokeWidth}" />`,
+    );
+  }
+
+  // Close SVG
+  svgParts.push("</svg>");
+
+  return svgParts.join("\n");
+}
+
+/**
+ * Create an SVG path from a trace route
+ */
+function createTracePath(
+  route: Array<{ x: number; y: number }>,
+  transformX: (x: number) => number,
+  transformY: (y: number) => number,
+): string {
+  if (route.length === 0) return "";
+
+  const parts: string[] = [];
+  parts.push(`M ${transformX(route[0]!.x)} ${transformY(route[0]!.y)}`);
+
+  for (let i = 1; i < route.length; i++) {
+    parts.push(`L ${transformX(route[i]!.x)} ${transformY(route[i]!.y)}`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Create an SVG path from board outline
+ */
+function createOutlinePath(
+  outline: Array<{ x: number; y: number }>,
+  transformX: (x: number) => number,
+  transformY: (y: number) => number,
+): string {
+  if (outline.length === 0) return "";
+
+  const parts: string[] = [];
+  parts.push(`M ${transformX(outline[0]!.x)} ${transformY(outline[0]!.y)}`);
+
+  for (let i = 1; i < outline.length; i++) {
+    parts.push(`L ${transformX(outline[i]!.x)} ${transformY(outline[i]!.y)}`);
+  }
+
+  parts.push("Z");
+  return parts.join(" ");
+}
+
+/**
+ * Convert RGB array to hex color string
+ */
+function toHex(rgb: number[]): string {
+  const r = Math.round(rgb[0]! * 255)
+    .toString(16)
+    .padStart(2, "0");
+  const g = Math.round(rgb[1]! * 255)
+    .toString(16)
+    .padStart(2, "0");
+  const b = Math.round(rgb[2]! * 255)
+    .toString(16)
+    .padStart(2, "0");
+  return `#${r}${g}${b}`;
+}
+
+/**
+ * Darken a hex color slightly for outlines
+ */
+function darken(hex: string): string {
+  // Simple darkening - reduce each channel by 20%
+  const r = Math.max(0, parseInt(hex.slice(1, 3), 16) * 0.8);
+  const g = Math.max(0, parseInt(hex.slice(3, 5), 16) * 0.8);
+  const b = Math.max(0, parseInt(hex.slice(5, 7), 16) * 0.8);
+
+  const rs = Math.round(r).toString(16).padStart(2, "0");
+  const gs = Math.round(g).toString(16).padStart(2, "0");
+  const bs = Math.round(b).toString(16).padStart(2, "0");
+
+  return `#${rs}${gs}${bs}`;
+}
+
+/**
+ * Escape special XML characters
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/src/three-components/SvgBoardTextures.tsx
+++ b/src/three-components/SvgBoardTextures.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useMemo } from "react"
+import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import * as THREE from "three"
+import { useLayerVisibility } from "../contexts/LayerVisibilityContext"
+import { useThree } from "../react-three/ThreeContext"
+import { useSvgBoardTextures, usePreloadResvgWasm } from "../hooks/useSvgBoardTextures"
+import { calculateOutlineBounds } from "../utils/outline-bounds"
+import { FAUX_BOARD_OPACITY } from "../geoms/constants"
+
+interface SvgBoardTexturesProps {
+  circuitJson: AnyCircuitElement[]
+  boardData: PcbBoard | null
+  pcbThickness: number
+  isFaux?: boolean
+}
+
+/**
+ * Component that renders high-quality SVG-based textures on the PCB board faces.
+ *
+ * This component uses resvg-wasm to generate raster textures from SVG representations
+ * of the PCB artwork. This provides better quality than canvas-based rendering,
+ * especially for text and fine details.
+ *
+ * The textures are only rendered when `svgTexturesEnabled` is true in the
+ * LayerVisibilityContext.
+ */
+export function SvgBoardTextures({
+  circuitJson,
+  boardData,
+  pcbThickness,
+  isFaux = false,
+}: SvgBoardTexturesProps) {
+  const { rootObject } = useThree()
+  const { visibility } = useLayerVisibility()
+
+  // Preload resvg-wasm on mount
+  usePreloadResvgWasm()
+
+  // Generate SVG textures
+  const { topTexture, bottomTexture, isLoading, error } = useSvgBoardTextures({
+    circuitJson,
+    boardData,
+    visibility,
+  })
+
+  // Check if SVG textures are enabled
+  const svgTexturesEnabled = visibility.svgTexturesEnabled ?? false
+
+  // Create meshes when textures are ready
+  useEffect(() => {
+    if (!rootObject || !boardData || !svgTexturesEnabled) return
+
+    const meshes: THREE.Mesh[] = []
+
+    const disposeTextureMaterial = (material: THREE.Material) => {
+      const textureProps = [
+        "map",
+        "alphaMap",
+        "aoMap",
+        "bumpMap",
+        "displacementMap",
+        "emissiveMap",
+        "lightMap",
+        "metalnessMap",
+        "normalMap",
+        "roughnessMap",
+        "specularMap",
+      ] as const
+      const typedMaterial = material as THREE.Material &
+        Record<(typeof textureProps)[number], THREE.Texture | null | undefined>
+
+      for (const prop of textureProps) {
+        const texture = typedMaterial[prop]
+        if (texture && texture instanceof THREE.Texture) {
+          texture.dispose()
+          typedMaterial[prop] = null
+        }
+      }
+
+      material.dispose()
+    }
+
+    const createTexturePlane = (
+      texture: THREE.DataTexture | null,
+      zOffset: number,
+      isBottomLayer: boolean,
+      name: string,
+    ): THREE.Mesh | null => {
+      if (!texture) return null
+
+      const boardOutlineBounds = calculateOutlineBounds(boardData)
+      const planeGeom = new THREE.PlaneGeometry(
+        boardOutlineBounds.width,
+        boardOutlineBounds.height,
+      )
+
+      const material = new THREE.MeshBasicMaterial({
+        map: texture,
+        transparent: true,
+        alphaTest: 0.08,
+        side: THREE.FrontSide,
+        depthWrite: true,
+        polygonOffset: true,
+        polygonOffsetFactor: -4,
+        polygonOffsetUnits: -4,
+        opacity: isFaux ? FAUX_BOARD_OPACITY : 1.0,
+      })
+
+      const mesh = new THREE.Mesh(planeGeom, material)
+      mesh.position.set(
+        boardOutlineBounds.centerX,
+        boardOutlineBounds.centerY,
+        zOffset,
+      )
+
+      if (isBottomLayer) {
+        mesh.rotation.set(Math.PI, 0, 0)
+      }
+
+      mesh.name = name
+      mesh.renderOrder = 1
+      mesh.frustumCulled = false
+
+      return mesh
+    }
+
+    // Small offset to place textures just above board surface
+    const SURFACE_OFFSET = 0.005
+
+    // Create top texture mesh
+    const topBoardMesh = createTexturePlane(
+      topTexture,
+      pcbThickness / 2 + SURFACE_OFFSET,
+      false,
+      "svg-top-board-texture",
+    )
+
+    if (topBoardMesh) {
+      meshes.push(topBoardMesh)
+      rootObject.add(topBoardMesh)
+    }
+
+    // Create bottom texture mesh
+    const bottomBoardMesh = createTexturePlane(
+      bottomTexture,
+      -pcbThickness / 2 - SURFACE_OFFSET,
+      true,
+      "svg-bottom-board-texture",
+    )
+
+    if (bottomBoardMesh) {
+      meshes.push(bottomBoardMesh)
+      rootObject.add(bottomBoardMesh)
+    }
+
+    // Cleanup function
+    return () => {
+      meshes.forEach((mesh) => {
+        if (mesh.parent === rootObject) {
+          rootObject.remove(mesh)
+        }
+        mesh.geometry.dispose()
+        if (Array.isArray(mesh.material)) {
+          mesh.material.forEach((material) => disposeTextureMaterial(material))
+        } else if (mesh.material instanceof THREE.Material) {
+          disposeTextureMaterial(mesh.material)
+        }
+      })
+    }
+  }, [
+    rootObject,
+    boardData,
+    pcbThickness,
+    isFaux,
+    topTexture,
+    bottomTexture,
+    svgTexturesEnabled,
+  ])
+
+  // Log errors
+  useEffect(() => {
+    if (error) {
+      console.error("SVG texture generation error:", error)
+    }
+  }, [error])
+
+  // This component doesn't render any React elements
+  return null
+}
+
+/**
+ * Props for the SvgBoardTexturesDebug component
+ */
+interface SvgBoardTexturesDebugProps extends SvgBoardTexturesProps {
+  /**
+   * Optional callback when texture generation status changes
+   */
+  onStatusChange?: (status: {
+    isLoading: boolean
+    error: string | null
+    hasTopTexture: boolean
+    hasBottomTexture: boolean
+  }) => void
+}
+
+/**
+ * Debug version of SvgBoardTextures that reports status.
+ * Useful for development and testing.
+ */
+export function SvgBoardTexturesDebug({
+  onStatusChange,
+  ...props
+}: SvgBoardTexturesDebugProps) {
+  const { visibility } = useLayerVisibility()
+  const { topTexture, bottomTexture, isLoading, error } = useSvgBoardTextures({
+    circuitJson: props.circuitJson,
+    boardData: props.boardData,
+    visibility,
+  })
+
+  useEffect(() => {
+    onStatusChange?.({
+      isLoading,
+      error,
+      hasTopTexture: !!topTexture,
+      hasBottomTexture: !!bottomTexture,
+    })
+  }, [isLoading, error, topTexture, bottomTexture, onStatusChange])
+
+  return <SvgBoardTextures {...props} />
+}

--- a/src/three-components/SvgBoardTextures.tsx
+++ b/src/three-components/SvgBoardTextures.tsx
@@ -3,7 +3,10 @@ import type { AnyCircuitElement, PcbBoard } from "circuit-json"
 import * as THREE from "three"
 import { useLayerVisibility } from "../contexts/LayerVisibilityContext"
 import { useThree } from "../react-three/ThreeContext"
-import { useSvgBoardTextures, usePreloadResvgWasm } from "../hooks/useSvgBoardTextures"
+import {
+  useSvgBoardTextures,
+  usePreloadResvgWasm,
+} from "../hooks/useSvgBoardTextures"
 import { calculateOutlineBounds } from "../utils/outline-bounds"
 import { FAUX_BOARD_OPACITY } from "../geoms/constants"
 

--- a/stories/SvgBoardTextures.stories.tsx
+++ b/stories/SvgBoardTextures.stories.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { CadViewer } from "src/CadViewer";
-import type { AnyCircuitElement } from "circuit-json";
+import { useState } from "react"
+import { CadViewer } from "src/CadViewer"
+import type { AnyCircuitElement } from "circuit-json"
 
 const createTestCircuit = (): AnyCircuitElement[] => {
   return [
@@ -116,23 +116,23 @@ const createTestCircuit = (): AnyCircuitElement[] => {
       hole_diameter: 0.3,
       layers: ["top", "bottom"],
     },
-  ];
-};
+  ]
+}
 
 export const SvgTexturesDisabled = () => {
-  const circuitJson = createTestCircuit();
+  const circuitJson = createTestCircuit()
   return (
     <div style={{ width: "100%", height: "500px" }}>
       <CadViewer circuitJson={circuitJson} />
     </div>
-  );
-};
+  )
+}
 
-SvgTexturesDisabled.storyName = "SVG Textures (Disabled - Default)";
+SvgTexturesDisabled.storyName = "SVG Textures (Disabled - Default)"
 
 export const SvgTexturesEnabled = () => {
-  const circuitJson = createTestCircuit();
-  const [status, setStatus] = useState<string>("Loading...");
+  const circuitJson = createTestCircuit()
+  const [status, setStatus] = useState<string>("Loading...")
 
   return (
     <div style={{ width: "100%", height: "500px", position: "relative" }}>
@@ -159,13 +159,13 @@ export const SvgTexturesEnabled = () => {
       </div>
       <CadViewer circuitJson={circuitJson} />
     </div>
-  );
-};
+  )
+}
 
-SvgTexturesEnabled.storyName = "SVG Textures (Enabled)";
+SvgTexturesEnabled.storyName = "SVG Textures (Enabled)"
 
 export const SvgTexturesHighRes = () => {
-  const circuitJson = createTestCircuit();
+  const circuitJson = createTestCircuit()
 
   return (
     <div style={{ width: "100%", height: "500px", position: "relative" }}>
@@ -191,12 +191,12 @@ export const SvgTexturesHighRes = () => {
       </div>
       <CadViewer circuitJson={circuitJson} />
     </div>
-  );
-};
+  )
+}
 
-SvgTexturesHighRes.storyName = "SVG Textures (High Resolution)";
+SvgTexturesHighRes.storyName = "SVG Textures (High Resolution)"
 
 export default {
   title: "SVG Board Textures",
   component: SvgTexturesDisabled,
-};
+}

--- a/stories/SvgBoardTextures.stories.tsx
+++ b/stories/SvgBoardTextures.stories.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { CadViewer } from "src/CadViewer";
+import type { AnyCircuitElement } from "circuit-json";
+
+const createTestCircuit = (): AnyCircuitElement[] => {
+  return [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_1",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      thickness: 1.6,
+      num_layers: 2,
+      material: "fr4",
+    },
+    // Top copper traces
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_1",
+      route: [
+        { x: -3, y: -3, route_type: "wire", width: 0.2, layer: "top" },
+        { x: -1, y: -3, route_type: "wire", width: 0.2, layer: "top" },
+        { x: -1, y: -1, route_type: "wire", width: 0.2, layer: "top" },
+        { x: 1, y: -1, route_type: "wire", width: 0.2, layer: "top" },
+      ],
+    },
+    // SMT Pads - top
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad_1",
+      pcb_component_id: "comp_1",
+      x: -2,
+      y: -2,
+      layer: "top",
+      shape: "rect",
+      width: 1.5,
+      height: 0.8,
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad_2",
+      pcb_component_id: "comp_1",
+      x: 2,
+      y: -2,
+      layer: "top",
+      shape: "circle",
+      radius: 0.6,
+    },
+    // SMT Pads - bottom
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad_3",
+      pcb_component_id: "comp_2",
+      x: -2,
+      y: 2,
+      layer: "bottom",
+      shape: "rect",
+      width: 1.5,
+      height: 0.8,
+    },
+    // Silkscreen - top
+    {
+      type: "pcb_silkscreen_text",
+      pcb_silkscreen_text_id: "text_1",
+      pcb_component_id: "comp_1",
+      text: "R1",
+      layer: "top",
+      anchor_position: { x: 0, y: 0 },
+      anchor_alignment: "center",
+      font_size: 1,
+      font: "tscircuit2024",
+    },
+    {
+      type: "pcb_silkscreen_line",
+      pcb_silkscreen_line_id: "line_1",
+      pcb_component_id: "comp_1",
+      stroke_width: 0.1,
+      x1: -2.5,
+      y1: 0,
+      x2: 2.5,
+      y2: 0,
+      layer: "top",
+    },
+    // Silkscreen - bottom
+    {
+      type: "pcb_silkscreen_text",
+      pcb_silkscreen_text_id: "text_2",
+      pcb_component_id: "comp_2",
+      text: "C1",
+      layer: "bottom",
+      anchor_position: { x: 0, y: 2 },
+      anchor_alignment: "center",
+      font_size: 1,
+      font: "tscircuit2024",
+    },
+    // Plated hole (through-hole)
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "hole_1",
+      pcb_component_id: "comp_3",
+      x: 3,
+      y: 3,
+      layers: ["top", "bottom"],
+      shape: "circle",
+      hole_diameter: 0.8,
+      outer_diameter: 1.2,
+    },
+    // Via
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_1",
+      x: 0,
+      y: 0,
+      outer_diameter: 0.6,
+      hole_diameter: 0.3,
+      layers: ["top", "bottom"],
+    },
+  ];
+};
+
+export const SvgTexturesDisabled = () => {
+  const circuitJson = createTestCircuit();
+  return (
+    <div style={{ width: "100%", height: "500px" }}>
+      <CadViewer circuitJson={circuitJson} />
+    </div>
+  );
+};
+
+SvgTexturesDisabled.storyName = "SVG Textures (Disabled - Default)";
+
+export const SvgTexturesEnabled = () => {
+  const circuitJson = createTestCircuit();
+  const [status, setStatus] = useState<string>("Loading...");
+
+  return (
+    <div style={{ width: "100%", height: "500px", position: "relative" }}>
+      <div
+        style={{
+          position: "absolute",
+          top: 10,
+          left: 10,
+          background: "rgba(0,0,0,0.7)",
+          color: "white",
+          padding: "8px 12px",
+          borderRadius: 4,
+          fontSize: 12,
+          zIndex: 100,
+        }}
+      >
+        <div style={{ fontWeight: "bold", marginBottom: 4 }}>
+          SVG Textures: Enabled
+        </div>
+        <div>Status: {status}</div>
+        <div style={{ marginTop: 8, fontSize: 10, opacity: 0.8 }}>
+          Higher quality rendering using resvg-wasm
+        </div>
+      </div>
+      <CadViewer circuitJson={circuitJson} />
+    </div>
+  );
+};
+
+SvgTexturesEnabled.storyName = "SVG Textures (Enabled)";
+
+export const SvgTexturesHighRes = () => {
+  const circuitJson = createTestCircuit();
+
+  return (
+    <div style={{ width: "100%", height: "500px", position: "relative" }}>
+      <div
+        style={{
+          position: "absolute",
+          top: 10,
+          left: 10,
+          background: "rgba(0,0,0,0.7)",
+          color: "white",
+          padding: "8px 12px",
+          borderRadius: 4,
+          fontSize: 12,
+          zIndex: 100,
+        }}
+      >
+        <div style={{ fontWeight: "bold", marginBottom: 4 }}>
+          SVG Textures: High Resolution (300 PPI)
+        </div>
+        <div style={{ fontSize: 10, opacity: 0.8 }}>
+          Sharp details at close zoom
+        </div>
+      </div>
+      <CadViewer circuitJson={circuitJson} />
+    </div>
+  );
+};
+
+SvgTexturesHighRes.storyName = "SVG Textures (High Resolution)";
+
+export default {
+  title: "SVG Board Textures",
+  component: SvgTexturesDisabled,
+};


### PR DESCRIPTION
This PR implements issue #534 — SVG Board Textures for PCB meshes in the 3D viewer.

## Summary
- Generates SVG from circuit JSON including traces, pads, silkscreen, vias
- Converts SVG → PNG using resvg-wasm
- Creates Three.js DataTexture and applies to PCB box faces
- Integrates into viewer with a toggle in Appearance menu (experimental)

## New Dependencies
- resvg/resvg-wasm

## New Files Created
| File | Purpose |
|------|--------|
| src/textures/resvg-converter.ts | resvg-wasm initialization & SVG→PNG conversion |
| src/textures/svg-from-circuit-json.ts | Generates SVG markup from circuit JSON |
| src/textures/create-svg-based-texture.ts | High-level API to create Three.js DataTexture from SVG |
| src/hooks/useSvgBoardTextures.ts | React hook managing async texture generation |
| src/three-components/SvgBoardTextures.tsx | Mesh planes with SVG textures on PCB faces |
| stories/SvgBoardTextures.stories.tsx | Storybook demo |

## Modified Files
- src/contexts/LayerVisibilityContext.tsx — added svgTexturesEnabled, svgTextureResolution, svgTextureTop, svgTextureBottom
- src/components/AppearanceMenu.tsx — added UI toggle with experimental badge
- src/textures/index.ts — exported texture utilities
- src/hooks/index.ts — exported useSvgBoardTextures hook
- src/index.tsx — exported main component & utilities
- src/CadViewerManifold.tsx — integrated SvgBoardTextures
- src/CadViewerJscad.tsx — integrated SvgBoardTextures

## How to Use
1. Right-click in the 3D viewer
2. Go to Appearance → SVG Board Textures (toggle on/off)
3. Feature is disabled by default (marked as "experimental")

/claim #534