### PR TITLE
Fix bottom copper text auto-mirroring in board textures and add regression tests

### DIFF
--- a/src/textures/create-copper-text-texture-for-layer.ts
+++ b/src/textures/create-copper-text-texture-for-layer.ts
@@ -17,12 +17,14 @@ export function createCopperTextTextureForLayer({
   copperColor?: string
   traceTextureResolution?: number
 }): THREE.CanvasTexture | null {
-  const elements = (circuitJson.filter(
-    (element) =>
-      element.type === "pcb_copper_text" &&
-      "layer" in element &&
-      element.layer === layer,
-  ) as PcbCopperText[]).map((element) =>
+  const elements = (
+    circuitJson.filter(
+      (element) =>
+        element.type === "pcb_copper_text" &&
+        "layer" in element &&
+        element.layer === layer,
+    ) as PcbCopperText[]
+  ).map((element) =>
     layer === "bottom"
       ? { ...element, is_mirrored: element.is_mirrored ?? true }
       : element,

--- a/src/textures/create-copper-text-texture-for-layer.ts
+++ b/src/textures/create-copper-text-texture-for-layer.ts
@@ -1,8 +1,20 @@
-import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import type { AnyCircuitElement, PcbBoard, PcbCopperText } from "circuit-json"
 import * as THREE from "three"
 import { TRACE_TEXTURE_RESOLUTION } from "../geoms/constants"
 import { calculateOutlineBounds } from "../utils/outline-bounds"
 import { drawCopperTextLayer } from "./copper-text/copper-text-drawing"
+
+export function applyDefaultBottomCopperTextMirroring(
+  elements: PcbCopperText[],
+  layer: "top" | "bottom",
+): PcbCopperText[] {
+  if (layer !== "bottom") return elements
+
+  return elements.map((element) => ({
+    ...element,
+    is_mirrored: element.is_mirrored ?? true,
+  }))
+}
 
 export function createCopperTextTextureForLayer({
   layer,
@@ -17,11 +29,14 @@ export function createCopperTextTextureForLayer({
   copperColor?: string
   traceTextureResolution?: number
 }): THREE.CanvasTexture | null {
-  const elements = circuitJson.filter(
-    (element) =>
-      element.type === "pcb_copper_text" &&
-      "layer" in element &&
-      element.layer === layer,
+  const elements = applyDefaultBottomCopperTextMirroring(
+    circuitJson.filter(
+      (element) =>
+        element.type === "pcb_copper_text" &&
+        "layer" in element &&
+        element.layer === layer,
+    ) as PcbCopperText[],
+    layer,
   )
   if (elements.length === 0) return null
 

--- a/src/textures/create-copper-text-texture-for-layer.ts
+++ b/src/textures/create-copper-text-texture-for-layer.ts
@@ -4,18 +4,6 @@ import { TRACE_TEXTURE_RESOLUTION } from "../geoms/constants"
 import { calculateOutlineBounds } from "../utils/outline-bounds"
 import { drawCopperTextLayer } from "./copper-text/copper-text-drawing"
 
-export function applyDefaultBottomCopperTextMirroring(
-  elements: PcbCopperText[],
-  layer: "top" | "bottom",
-): PcbCopperText[] {
-  if (layer !== "bottom") return elements
-
-  return elements.map((element) => ({
-    ...element,
-    is_mirrored: element.is_mirrored ?? true,
-  }))
-}
-
 export function createCopperTextTextureForLayer({
   layer,
   circuitJson,
@@ -29,14 +17,15 @@ export function createCopperTextTextureForLayer({
   copperColor?: string
   traceTextureResolution?: number
 }): THREE.CanvasTexture | null {
-  const elements = applyDefaultBottomCopperTextMirroring(
-    circuitJson.filter(
-      (element) =>
-        element.type === "pcb_copper_text" &&
-        "layer" in element &&
-        element.layer === layer,
-    ) as PcbCopperText[],
-    layer,
+  const elements = (circuitJson.filter(
+    (element) =>
+      element.type === "pcb_copper_text" &&
+      "layer" in element &&
+      element.layer === layer,
+  ) as PcbCopperText[]).map((element) =>
+    layer === "bottom"
+      ? { ...element, is_mirrored: element.is_mirrored ?? true }
+      : element,
   )
   if (elements.length === 0) return null
 


### PR DESCRIPTION
This PR reproduces and fixes a subtle rendering bug where bottom-layer copper text was not automatically mirrored in the 3D viewer unless is_mirrored was explicitly set.

  Changes:

  - Default bottom pcb_copper_text elements to is_mirrored: true during texture generation
  - Preserve explicit overrides such as is_mirrored: false
  - Add focused regression tests covering:
      - bottom copper text auto-mirroring by default
      - explicit bottom non-mirrored text remaining unchanged
      - top copper text behavior staying unchanged

  Why this matters:

  - Fixes incorrect bottom-side text rendering
  - Aligns implementation with the expected bottom-layer mirroring behavior already documented in stories
  
## Before
<img width="770" height="639" alt="image" src="https://github.com/user-attachments/assets/4c7e79b2-095b-4eb5-a72d-c5048470b98d" />


## After
<img width="770" height="639" alt="Screenshot_20260406_212500" src="https://github.com/user-attachments/assets/452eba2b-6906-424f-b776-8b036410f9da" />
