### PR TITLE
Exclude PCB notes from generated textures by setting `showPcbNotes: false`

### DIFF
--- a/src/textures/copper-text/copper-text-drawing.ts
+++ b/src/textures/copper-text/copper-text-drawing.ts
@@ -52,6 +52,7 @@ export const drawCopperTextLayer = ({
   setDrawerBounds(drawer, bounds)
   drawer.drawElements(elements, {
     layers: [renderLayer],
+    showPcbNotes: false,
   })
 
   const knockoutTexts = elements.filter(
@@ -89,6 +90,7 @@ export const drawCopperTextLayer = ({
     })),
     {
       layers: [renderLayer],
+      showPcbNotes: false,
     },
   )
 

--- a/src/textures/create-copper-pour-texture-for-layer.ts
+++ b/src/textures/create-copper-pour-texture-for-layer.ts
@@ -119,6 +119,7 @@ export function createCopperPourTextureForLayer({
       drawSoldermask: false,
       drawSoldermaskTop: false,
       drawSoldermaskBottom: false,
+      showPcbNotes: false,
     })
     for (let i = 1; i < COPPER_POUR_OPACITY_COMPENSATION_PASSES; i += 1) {
       drawer.drawElements(pours, {
@@ -126,6 +127,7 @@ export function createCopperPourTextureForLayer({
         drawSoldermask: false,
         drawSoldermaskTop: false,
         drawSoldermaskBottom: false,
+        showPcbNotes: false,
       })
     }
   }

--- a/src/textures/fabrication-note/fabrication-note-drawing.ts
+++ b/src/textures/fabrication-note/fabrication-note-drawing.ts
@@ -118,5 +118,6 @@ export const drawFabricationNoteLayer = ({
   setDrawerBounds(drawer, bounds)
   drawer.drawElements(normalizedElements, {
     layers: [renderLayer],
+    showPcbNotes: false,
   })
 }

--- a/src/textures/silkscreen/silkscreen-drawing.ts
+++ b/src/textures/silkscreen/silkscreen-drawing.ts
@@ -80,5 +80,6 @@ export const drawSilkscreenLayer = ({
   setDrawerBounds(drawer, bounds)
   drawer.drawElements(elements, {
     layers: [renderLayer],
+    showPcbNotes: false,
   })
 }

--- a/src/textures/soldermask/soldermask-drawing.ts
+++ b/src/textures/soldermask/soldermask-drawing.ts
@@ -112,6 +112,7 @@ export const drawSoldermaskLayer = ({
     drawSoldermask: true,
     drawSoldermaskTop: layer === "top",
     drawSoldermaskBottom: layer === "bottom",
+    showPcbNotes: false,
   })
 
   const uncoveredPours = elements.filter(
@@ -139,7 +140,10 @@ export const drawSoldermaskLayer = ({
       },
     })
     setDrawerBounds(cutoutDrawer, bounds)
-    cutoutDrawer.drawElements(uncoveredPours, { layers: [copperRenderLayer] })
+    cutoutDrawer.drawElements(uncoveredPours, {
+      layers: [copperRenderLayer],
+      showPcbNotes: false,
+    })
     ctx.restore()
   }
 }

--- a/src/textures/through-hole/through-hole-drawing.ts
+++ b/src/textures/through-hole/through-hole-drawing.ts
@@ -65,5 +65,6 @@ export const drawThroughHoleLayer = ({
   setDrawerBounds(drawer, bounds)
   drawer.drawElements(elements, {
     layers: [renderLayer],
+    showPcbNotes: false,
   })
 }

--- a/src/utils/pad-texture.ts
+++ b/src/utils/pad-texture.ts
@@ -87,6 +87,7 @@ export function createPadTextureForLayer({
     drawSoldermask: false,
     drawSoldermaskTop: false,
     drawSoldermaskBottom: false,
+    showPcbNotes: false,
   })
 
   const texture = new THREE.CanvasTexture(canvas)

--- a/src/utils/trace-texture.ts
+++ b/src/utils/trace-texture.ts
@@ -101,6 +101,7 @@ export function createTraceTextureForLayer({
     drawSoldermask: false,
     drawSoldermaskTop: false,
     drawSoldermaskBottom: false,
+    showPcbNotes: false,
   })
   const texture = new THREE.CanvasTexture(canvas)
   texture.generateMipmaps = true


### PR DESCRIPTION
### Motivation
- Prevent PCB fabrication/annotation notes from being included in generated layer textures and render masks so textures reflect only the intended graphical elements.

### Description
- Pass `showPcbNotes: false` to `drawer.drawElements` in multiple texture and layer drawing modules so PCB notes are not rendered into textures.
- Files changed include `copper-text-drawing.ts`, `create-copper-pour-texture-for-layer.ts`, `fabrication-note-drawing.ts`, `silkscreen-drawing.ts`, `soldermask-drawing.ts`, `through-hole-drawing.ts`, `pad-texture.ts`, and `trace-texture.ts` to consistently suppress PCB notes during texture generation.
- Include the flag for both primary draws and repeated/compensation draws and for the knockout/mask draw paths to ensure complete exclusion.

### Testing
- Ran the project automated test suite with `yarn test` and the full production build with `yarn build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4396e53ec832e8215f0826f51c18a)