### PR TITLE
Fix isPcbNoteElement filter for elements without layer prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
-    "circuit-json": "^0.0.405",
+    "circuit-json": "^0.0.407",
     "circuit-to-canvas": "^0.0.96",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",
@@ -68,7 +68,7 @@
     "react-use-gesture": "^9.1.3",
     "semver": "^7.7.0",
     "strip-ansi": "^7.1.0",
-    "tscircuit": "^0.0.1541",
+    "tscircuit": "^0.0.1601",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
     "vite": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
     "circuit-json": "^0.0.405",
-    "circuit-to-canvas": "^0.0.94",
+    "circuit-to-canvas": "^0.0.96",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",
     "three-stdlib": "^2.36.0",

--- a/src/textures/create-pcb-note-texture-for-layer.ts
+++ b/src/textures/create-pcb-note-texture-for-layer.ts
@@ -8,10 +8,8 @@ const isPcbNoteElement = (
   element: AnyCircuitElement,
   layer: "top" | "bottom",
 ) => {
-  if (!(element.type as string).startsWith("pcb_note_")) return false
-  // If no layer property, show on both layers (e.g. core-generated pcb_note_rect)
-  if (!("layer" in element)) return true
-  return element.layer === layer
+  if (!("layer" in element) || element.layer !== layer) return false
+  return (element.type as string).startsWith("pcb_note_")
 }
 
 export function createPcbNoteTextureForLayer({

--- a/src/textures/create-pcb-note-texture-for-layer.ts
+++ b/src/textures/create-pcb-note-texture-for-layer.ts
@@ -8,8 +8,10 @@ const isPcbNoteElement = (
   element: AnyCircuitElement,
   layer: "top" | "bottom",
 ) => {
-  if (!("layer" in element) || element.layer !== layer) return false
-  return (element.type as string).startsWith("pcb_note_")
+  if (!(element.type as string).startsWith("pcb_note_")) return false
+  // If no layer property, show on both layers (e.g. core-generated pcb_note_rect)
+  if (!("layer" in element)) return true
+  return element.layer === layer
 }
 
 export function createPcbNoteTextureForLayer({

--- a/stories/PcbNotesToggle.stories.tsx
+++ b/stories/PcbNotesToggle.stories.tsx
@@ -1,3 +1,4 @@
+import { Circuit } from "@tscircuit/core"
 import { CadViewer } from "src/CadViewer"
 
 const pcbNotesCircuit = [
@@ -131,6 +132,86 @@ const pcbNotesCircuit = [
 
 export const PcbNotesToggle = () => (
   <CadViewer circuitJson={pcbNotesCircuit as any} />
+)
+
+const createPcbNoteAllElementsCircuit = () => {
+  const circuit = new Circuit()
+
+  circuit.add(
+    <board width="20mm" height="12mm">
+      {/* pcb_note_rect — filled with corner radius */}
+      <pcbnoterect
+        pcbX={-5}
+        pcbY={3}
+        width="4mm"
+        height="2.5mm"
+        strokeWidth={0.1}
+        color="#00FFFF"
+      />
+      {/* pcb_note_rect — dashed stroke only */}
+      <pcbnoterect
+        pcbX={-5}
+        pcbY={-2}
+        width="5mm"
+        height="2mm"
+        strokeWidth={0.1}
+        color="#FF6B6B"
+      />
+      {/* pcb_note_text */}
+      <pcbnotetext
+        pcbX={1}
+        pcbY={0}
+        text="PCB NOTES"
+        fontSize="1.2mm"
+        color="#FFFFFF"
+      />
+      {/* pcb_note_line — solid */}
+      <pcbnoteline
+        x1={0}
+        y1={4}
+        x2={6}
+        y2={4}
+        strokeWidth={0.15}
+        color="#E67E22"
+      />
+      {/* pcb_note_line — dashed */}
+      <pcbnoteline
+        x1={0}
+        y1={2.5}
+        x2={6}
+        y2={2.5}
+        strokeWidth={0.15}
+        color="#3498DB"
+        isDashed
+      />
+      {/* pcb_note_path — triangle */}
+      <pcbnotepath
+        route={[
+          { x: 2, y: -2 },
+          { x: 5, y: -4 },
+          { x: 2, y: -4 },
+          { x: 2, y: -2 },
+        ]}
+        strokeWidth={0.12}
+        color="#9B59B6"
+      />
+      {/* pcb_note_dimension */}
+      <pcbnotedimension
+        from={{ x: 6, y: -1 }}
+        to={{ x: 6, y: -4 }}
+        fontSize="0.8mm"
+        arrowSize="0.5mm"
+        offset="1mm"
+        color="#2ECC71"
+      />
+    </board>,
+  )
+
+  return circuit.getCircuitJson()
+}
+
+export const PcbNoteAllElements = () => (
+  <CadViewer circuitJson={createPcbNoteAllElementsCircuit() as any} />
 )
 
 export default {


### PR DESCRIPTION
`isPcbNoteElement` was checking for layer before checking the element type, so `pcb_note_rect` (and other `pcb_note` elements that have no layer field in circuit-json) were always filtered out and never rendered in the `pcb-note` texture. Reordered the checks so the type is verified first, and elements without a layer prop default to showing on both layers.

repro: https://tscircuit.com/MustafaMulla29/pcb-notes#files


story after fix: https://3d-viewer-jg3c4xaaa-tscircuit.vercel.app/?path=/story/pcb-notes-toggle--pcb-notes-toggle
