### PR TITLE
chore: bump circuit-to-canvas to 0.0.97

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
     "circuit-json": "^0.0.407",
-    "circuit-to-canvas": "^0.0.96",
+    "circuit-to-canvas": "^0.0.97",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",
     "three-stdlib": "^2.36.0",


### PR DESCRIPTION
## Summary
- bump `circuit-to-canvas` from `^0.0.96` to `^0.0.97` in `package.json`

### Before
<img width="809" height="594" alt="image" src="https://github.com/user-attachments/assets/240a3fb5-83f8-4963-8315-d4ffdf467767" />

### After
<img width="539" height="405" alt="image" src="https://github.com/user-attachments/assets/a9ec09ee-d461-4159-afe9-8dd2a090c96d" />

## Testing
- not run (dependency version bump only)