### PR TITLE
Remove legacy pad geometry cleanup

### DIFF
--- a/src/BoardGeomBuilder.ts
+++ b/src/BoardGeomBuilder.ts
@@ -45,7 +45,6 @@ const BOARD_CLIP_XY_OUTSET = 0.05
 
 type BuilderState =
   | "initializing"
-  | "processing_copper_pours"
   | "processing_plated_holes"
   | "processing_holes"
   | "processing_cutouts"
@@ -55,8 +54,6 @@ type BuilderState =
 
 const buildStateOrder: BuilderState[] = [
   "initializing",
-  "processing_copper_pours",
-
   "processing_plated_holes",
   "processing_holes",
   "processing_cutouts",
@@ -76,7 +73,6 @@ export class BoardGeomBuilder {
   private boardGeom: Geom3 | null = null
   private platedHoleGeoms: Geom3[] = []
   private viaGeoms: Geom3[] = [] // Combined with platedHoleGeoms
-  private copperPourGeoms: Geom3[] = []
   private boardClipGeom: Geom3 | null = null
 
   private state: BuilderState = "initializing"
@@ -162,7 +158,7 @@ export class BoardGeomBuilder {
         center: [this.board.center.x, this.board.center.y, 0],
       })
     }
-    this.state = "processing_copper_pours"
+    this.state = "processing_plated_holes"
     this.currentIndex = 0
   }
 
@@ -197,12 +193,6 @@ export class BoardGeomBuilder {
           } else {
             this.goToNextState()
           }
-          break
-
-        case "processing_copper_pours":
-          // Copper pours are rendered as textures in the JSCAD viewer.
-          // SMT pads are also rendered as textures.
-          this.goToNextState()
           break
 
         case "processing_vias":
@@ -709,7 +699,6 @@ export class BoardGeomBuilder {
       this.boardGeom,
       ...this.platedHoleGeoms,
       ...this.viaGeoms,
-      ...this.copperPourGeoms,
     ]
 
     if (this.onCompleteCallback) {

--- a/src/utils/pad-geoms.ts
+++ b/src/utils/pad-geoms.ts
@@ -1,6 +1,4 @@
-import {
-  clampRectBorderRadius,
-} from "./rect-border-radius"
+import { clampRectBorderRadius } from "./rect-border-radius"
 
 const RECT_PAD_SEGMENTS = 64
 

--- a/src/utils/pad-geoms.ts
+++ b/src/utils/pad-geoms.ts
@@ -1,7 +1,5 @@
-import type { PcbSmtPad } from "circuit-json"
 import {
   clampRectBorderRadius,
-  extractRectBorderRadius,
 } from "./rect-border-radius"
 
 const RECT_PAD_SEGMENTS = 64
@@ -57,44 +55,4 @@ export function createRoundedRectPrism({
   })
 
   return Manifold.union(shapes)
-}
-
-export function createPadManifoldOp({
-  Manifold,
-  pad,
-  padBaseThickness,
-}: {
-  Manifold: any
-  pad: PcbSmtPad
-  padBaseThickness: number
-}) {
-  if (pad.shape === "rect") {
-    const rectBorderRadius = extractRectBorderRadius(pad)
-    return createRoundedRectPrism({
-      Manifold,
-      width: pad.width,
-      height: pad.height,
-      thickness: padBaseThickness,
-      borderRadius: rectBorderRadius,
-    })
-  } else if (pad.shape === "rotated_rect") {
-    const rectBorderRadius = extractRectBorderRadius(pad)
-    let padOp = createRoundedRectPrism({
-      Manifold,
-      width: pad.width,
-      height: pad.height,
-      thickness: padBaseThickness,
-      borderRadius: rectBorderRadius,
-    })
-
-    const rotation = pad.ccw_rotation ?? 0
-    if (rotation) {
-      padOp = padOp.rotate([0, 0, rotation])
-    }
-
-    return padOp
-  } else if (pad.shape === "circle" && pad.radius) {
-    return Manifold.cylinder(padBaseThickness, pad.radius, -1, 32, true)
-  }
-  return null
 }


### PR DESCRIPTION
## Summary
- remove the unused SMT pad manifold helper now that pads render via textures
- remove the no-op legacy copper-pour state and unused geometry accumulator from `BoardGeomBuilder`
- keep the shared rounded-rect prism helper because it is still used by hole and cutout geometry

## Why
Pads and copper pours no longer render as 3D board geometry in this path, so these leftover helpers and state-machine steps were dead code.

## Validation
- `npm run build`