### PR TITLE
Ignore local .codex workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yalc.lock
 package-lock.json
 storybook-static
 repomix-output.txt
+.codex/

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ yalc.lock
 package-lock.json
 storybook-static
 repomix-output.txt
-.codex/
+.codex


### PR DESCRIPTION
## Summary
- add `.codex` to `.gitignore`

## Why
The local `.codex` workspace file should not show up as an untracked file in the repository.

## Validation
- `npm run build`