### PR TITLE
Remove more legacy board geometry code

### DIFF
--- a/src/convert-circuit-json-to-3d-svg.ts
+++ b/src/convert-circuit-json-to-3d-svg.ts
@@ -3,7 +3,7 @@ import { su } from "@tscircuit/circuit-json-util"
 import Debug from "debug"
 import * as THREE from "three"
 import { SVGRenderer } from "three/examples/jsm/renderers/SVGRenderer.js"
-import { createBoardGeomFromCircuitJson } from "./soup-to-3d"
+import { createSimplifiedBoardGeom } from "./soup-to-3d"
 import { createBoardMaterial } from "./utils/create-board-material"
 import { createGeometryFromPolygons } from "./utils/create-geometry-from-polygons"
 import { renderComponent } from "./utils/render-component"
@@ -96,7 +96,7 @@ export async function convertCircuitJsonTo3dSvg(
   const boardData = su(circuitJson).pcb_board.list()[0]
 
   // Add board geometry after components
-  const boardGeom = createBoardGeomFromCircuitJson(circuitJson)
+  const boardGeom = createSimplifiedBoardGeom(circuitJson)
   if (boardGeom) {
     // Use green solder mask color for the board
     const solderMaskColor = colors.fr4SolderMaskGreen

--- a/src/geoms/constants.ts
+++ b/src/geoms/constants.ts
@@ -3,11 +3,6 @@ import type { PcbBoard } from "circuit-json"
 
 export const M = 0.01
 
-export const BOARD_SURFACE_OFFSET = {
-  traces: 0.001,
-  copper: 0.002,
-} as const
-
 export const colors = {
   copper: [0.9, 0.6, 0.2],
   fr4Tan: [0.6, 0.43, 0.28],
@@ -22,19 +17,12 @@ export const colors = {
 // Constants for Manifold processing
 export const MANIFOLD_Z_OFFSET = 0.001 // Small offset to prevent Z-fighting
 export const SMOOTH_CIRCLE_SEGMENTS = 32 // Number of segments for smooth circles
-export const DEFAULT_SMT_PAD_THICKNESS = 0.035 // Typical 1oz copper thickness in mm
 export const TRACE_TEXTURE_RESOLUTION = 150 // pixels per mm for trace texture
 
 export const FAUX_BOARD_OPACITY = 0.6 // Opacity for faux boards (60% transparent)
 export const boardMaterialColors: Record<PcbBoard["material"], RGB> = {
   fr1: colors.fr1Tan,
   fr4: colors.fr4Tan,
-}
-
-// Color for traces (tan/copper when no soldermask)
-export const tracesMaterialColors: Record<PcbBoard["material"], RGB> = {
-  fr1: colors.fr1TracesWithMaskCopper,
-  fr4: colors.fr4TracesWithoutMaskTan,
 }
 
 // Color for the soldermask layer itself (dark green coating)

--- a/src/hooks/useManifoldBoardBuilder.ts
+++ b/src/hooks/useManifoldBoardBuilder.ts
@@ -11,9 +11,7 @@ import * as THREE from "three"
 import {
   boardMaterialColors,
   colors as defaultColors,
-  soldermaskColors,
   TRACE_TEXTURE_RESOLUTION,
-  tracesMaterialColors,
 } from "../geoms/constants"
 import { getLayerTextureResolution } from "../utils/layer-texture-resolution"
 import { createManifoldBoard } from "../utils/manifold/create-manifold-board"

--- a/src/soup-to-3d/index.ts
+++ b/src/soup-to-3d/index.ts
@@ -6,7 +6,6 @@ import { colorize } from "@jscad/modeling/src/colors"
 import {
   colors,
   boardMaterialColors,
-  tracesMaterialColors,
 } from "../geoms/constants"
 import { createBoardGeomWithOutline } from "../geoms/create-board-with-outline"
 
@@ -78,24 +77,4 @@ export const createSimplifiedBoardGeom = (
   const material = boardMaterialColors[materialName] ?? colors.fr4Tan
 
   return [colorize(material, boardGeom)]
-}
-
-/**
- * @deprecated Use BoardGeomBuilder for detailed geometry or createSimplifiedBoardGeom for initial display.
- */
-export const createBoardGeomFromCircuitJson = (
-  circuitJson: AnyCircuitElement[],
-  opts: {
-    simplifiedBoard?: boolean
-  } = {},
-): Geom3[] => {
-  console.warn(
-    "createBoardGeomFromCircuitJson is deprecated. Use BoardGeomBuilder or createSimplifiedBoardGeom.",
-  )
-  if (opts.simplifiedBoard) {
-    return createSimplifiedBoardGeom(circuitJson)
-  }
-  // For non-simplified, we ideally shouldn't reach here in the new flow.
-  // Return simplified as a fallback for now.
-  return createSimplifiedBoardGeom(circuitJson)
 }

--- a/src/soup-to-3d/index.ts
+++ b/src/soup-to-3d/index.ts
@@ -3,10 +3,7 @@ import type { AnyCircuitElement, PcbBoard, PcbPanel } from "circuit-json"
 import { su } from "@tscircuit/circuit-json-util"
 import { cuboid } from "@jscad/modeling/src/primitives"
 import { colorize } from "@jscad/modeling/src/colors"
-import {
-  colors,
-  boardMaterialColors,
-} from "../geoms/constants"
+import { colors, boardMaterialColors } from "../geoms/constants"
 import { createBoardGeomWithOutline } from "../geoms/create-board-with-outline"
 
 /**

--- a/src/utils/manifold/process-plated-holes.ts
+++ b/src/utils/manifold/process-plated-holes.ts
@@ -3,8 +3,6 @@ import type { AnyCircuitElement, PcbPlatedHole } from "circuit-json"
 import type { Manifold, ManifoldToplevel } from "manifold-3d"
 import * as THREE from "three"
 import {
-  BOARD_SURFACE_OFFSET,
-  DEFAULT_SMT_PAD_THICKNESS,
   colors as defaultColors,
   M,
   MANIFOLD_Z_OFFSET,


### PR DESCRIPTION
## Summary
- remove unused board-geometry constants and dangling imports left over from the old raised-copper path
- stop routing the SVG board export through the deprecated board-geometry wrapper
- remove the unused `createBoardGeomFromCircuitJson` export

## Why
The board renderer now relies on texture-based layers for pads and related copper details, so these old helpers and compatibility shims were no longer used.

## Validation
- `npm run build`