### PR TITLE
[codex] update circuit-to-canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
     "circuit-json": "^0.0.407",
-    "circuit-to-canvas": "^0.0.97",
+    "circuit-to-canvas": "^0.0.100",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",
     "three-stdlib": "^2.36.0",


### PR DESCRIPTION
## Summary
- update `circuit-to-canvas` from `^0.0.97` to `^0.0.100`
- keep the repo change scoped to the dependency bump only

## Why
This brings the viewer onto the newer `circuit-to-canvas` release while preserving the existing package layout and install tooling.

## Impact
Consumers of `@tscircuit/3d-viewer` will pick up the newer `circuit-to-canvas` behavior and fixes after release, with no source changes required in this repo beyond the dependency version.

### Fixed bottom

<img width="1313" height="632" alt="image" src="https://github.com/user-attachments/assets/49a11e89-3c63-42b3-95aa-1e8c623f3b24" />

## Validation
- `bun add circuit-to-canvas@^0.0.100`
- `bun run build`
