### PR TITLE
Hide fabrication note text in 3D board rendering

### DIFF
--- a/src/textures/create-fabrication-note-texture-for-layer.ts
+++ b/src/textures/create-fabrication-note-texture-for-layer.ts
@@ -9,7 +9,12 @@ const isFabricationNoteElement = (
   layer: "top" | "bottom",
 ) => {
   if (!("layer" in element) || element.layer !== layer) return false
-  return (element.type as string).startsWith("pcb_fabrication_note_")
+  const elementType = element.type as string
+
+  return (
+    elementType.startsWith("pcb_fabrication_note_") &&
+    elementType !== "pcb_fabrication_note_text"
+  )
 }
 
 export function createFabricationNoteTextureForLayer({


### PR DESCRIPTION
Before
https://tscircuit-3d-viewer.vercel.app/?path=/story/kicadresistor--kicad-resistor
<img width="672" height="495" alt="Screenshot from 2026-04-26 01-07-06" src="https://github.com/user-attachments/assets/8e06264d-a693-487b-aa68-7767853e10e0" />


After
https://3d-viewer-k2ln87yxs-tscircuit.vercel.app/?path=/story/kicadresistor--kicad-resistor
<img width="681" height="534" alt="Screenshot from 2026-04-26 01-07-55" src="https://github.com/user-attachments/assets/f14419cc-e789-4b0f-b509-7c73279d1fa2" />
