### PR TITLE
fix: add module-level cache to load3DModel to prevent duplicate loading

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,7 +4,21 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+/**
+ * Module-level cache for loaded 3D models.
+ * Stores in-flight promises to deduplicate concurrent requests for the same URL,
+ * and stores resolved objects for instant retrieval on subsequent requests.
+ */
+const modelCache = new Map<string, Promise<THREE.Object3D | null>>()
+
+/**
+ * Clear the model cache (useful for testing or when memory pressure is high).
+ */
+export function clearModelCache(): void {
+  modelCache.clear()
+}
+
+async function loadModelUncached(url: string): Promise<THREE.Object3D | null> {
   if (url.endsWith(".stl")) {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
@@ -33,4 +47,31 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
 
   console.error("Unsupported file format or failed to load 3D model.")
   return null
+}
+
+/**
+ * Load a 3D model from the given URL, using a module-level cache to avoid
+ * duplicate network requests and redundant parsing for the same model URL.
+ *
+ * Concurrent calls for the same URL share a single in-flight request.
+ * Subsequent calls after the first resolution return a cloned copy of the
+ * cached object so each consumer gets an independent Three.js scene graph.
+ */
+export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+  const cached = modelCache.get(url)
+  if (cached !== undefined) {
+    const result = await cached
+    return result ? (result.clone() as THREE.Object3D) : null
+  }
+
+  const promise = loadModelUncached(url)
+  modelCache.set(url, promise)
+
+  try {
+    return await promise
+  } catch (error) {
+    // Remove failed entries so they can be retried on the next call
+    modelCache.delete(url)
+    throw error
+  }
 }

--- a/tests/load-model-cache.test.ts
+++ b/tests/load-model-cache.test.ts
@@ -1,0 +1,18 @@
+import { expect, test, beforeEach, mock } from "bun:test"
+import { clearModelCache } from "../src/utils/load-model"
+
+// Reset cache between tests
+beforeEach(() => {
+  clearModelCache()
+})
+
+test("clearModelCache is exported and callable", () => {
+  // Should not throw
+  clearModelCache()
+})
+
+test("load3DModel cache module exports are present", async () => {
+  const module = await import("../src/utils/load-model")
+  expect(typeof module.load3DModel).toBe("function")
+  expect(typeof module.clearModelCache).toBe("function")
+})


### PR DESCRIPTION
Adds module-level cache to the 3D model loader to prevent the same model from being fetched/parsed multiple times.