### PR TITLE
feat: fix orthographic camera frustum to match perspective view scale

### DIFF
--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -38,6 +38,7 @@ const CadViewerInner = (props: any) => {
   const cameraControllerRef = useRef<CameraController | null>(null)
   const [cameraControllerReadyVersion, setCameraControllerReadyVersion] =
     useState(0)
+  const lastAppliedControllerVersionRef = useRef(cameraControllerReadyVersion)
   const externalCameraControllerReady = props.onCameraControllerReady as
     | ((controller: CameraController | null) => void)
     | undefined
@@ -89,14 +90,26 @@ const CadViewerInner = (props: any) => {
   const handleCameraPresetSelect = useCallback(
     (preset: CameraPreset) => {
       setCameraPreset(preset)
+      if (preset !== "Custom") {
+        lastAppliedControllerVersionRef.current = cameraControllerReadyVersion
+        cameraControllerRef.current?.animateToPreset(preset)
+      }
       closeMenu()
     },
-    [closeMenu],
+    [cameraControllerReadyVersion, closeMenu],
   )
 
   useEffect(() => {
     if (!cameraControllerRef.current) return
     if (cameraPreset === "Custom") return
+
+    if (
+      lastAppliedControllerVersionRef.current === cameraControllerReadyVersion
+    ) {
+      return
+    }
+
+    lastAppliedControllerVersionRef.current = cameraControllerReadyVersion
     cameraControllerRef.current.animateToPreset(cameraPreset)
   }, [cameraPreset, cameraControllerReadyVersion])
 

--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -26,6 +26,13 @@ const CadViewerInner = (props: any) => {
     return stored === "true"
   })
   const [cameraPreset, setCameraPreset] = useState<CameraPreset>("Custom")
+  const [shouldUseOrthographicCamera, setShouldUseOrthographicCamera] =
+    useState(() => {
+      const stored = window.localStorage.getItem(
+        "cadViewerUseOrthographicCamera",
+      )
+      return stored === "true"
+    })
   const { visibility, toggleLayer } = useLayerVisibility()
 
   const cameraControllerRef = useRef<CameraController | null>(null)
@@ -54,6 +61,10 @@ const CadViewerInner = (props: any) => {
   const toggleAutoRotate = useCallback(() => {
     setAutoRotate((prev) => !prev)
     setAutoRotateUserToggled(true)
+  }, [])
+
+  const toggleOrthographicCamera = useCallback(() => {
+    setShouldUseOrthographicCamera((prev) => !prev)
   }, [])
 
   const downloadGltf = useGlobalDownloadGltf()
@@ -105,6 +116,13 @@ const CadViewerInner = (props: any) => {
     )
   }, [autoRotateUserToggled])
 
+  useEffect(() => {
+    window.localStorage.setItem(
+      "cadViewerUseOrthographicCamera",
+      String(shouldUseOrthographicCamera),
+    )
+  }, [shouldUseOrthographicCamera])
+
   const viewerKey = props.circuitJson
     ? JSON.stringify(props.circuitJson)
     : undefined
@@ -131,6 +149,7 @@ const CadViewerInner = (props: any) => {
           autoRotateDisabled={props.autoRotateDisabled || !autoRotate}
           onUserInteraction={handleUserInteraction}
           onCameraControllerReady={handleCameraControllerReady}
+          shouldUseOrthographicCamera={shouldUseOrthographicCamera}
         />
       ) : (
         <CadViewerManifold
@@ -138,6 +157,7 @@ const CadViewerInner = (props: any) => {
           autoRotateDisabled={props.autoRotateDisabled || !autoRotate}
           onUserInteraction={handleUserInteraction}
           onCameraControllerReady={handleCameraControllerReady}
+          shouldUseOrthographicCamera={shouldUseOrthographicCamera}
         />
       )}
       <div
@@ -163,6 +183,7 @@ const CadViewerInner = (props: any) => {
           engine={engine}
           cameraPreset={cameraPreset}
           autoRotate={autoRotate}
+          shouldUseOrthographicCamera={shouldUseOrthographicCamera}
           onEngineSwitch={(newEngine) => {
             setEngine(newEngine)
             closeMenu()
@@ -170,6 +191,10 @@ const CadViewerInner = (props: any) => {
           onCameraPresetSelect={handleCameraPresetSelect}
           onAutoRotateToggle={() => {
             toggleAutoRotate()
+            closeMenu()
+          }}
+          onOrthographicToggle={() => {
+            toggleOrthographicCamera()
             closeMenu()
           }}
           onDownloadGltf={() => {

--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -36,6 +36,8 @@ const CadViewerInner = (props: any) => {
   const { visibility, toggleLayer } = useLayerVisibility()
 
   const cameraControllerRef = useRef<CameraController | null>(null)
+  const [cameraControllerReadyVersion, setCameraControllerReadyVersion] =
+    useState(0)
   const externalCameraControllerReady = props.onCameraControllerReady as
     | ((controller: CameraController | null) => void)
     | undefined
@@ -77,22 +79,26 @@ const CadViewerInner = (props: any) => {
     (controller: CameraController | null) => {
       cameraControllerRef.current = controller
       externalCameraControllerReady?.(controller)
-      if (controller && cameraPreset !== "Custom") {
-        controller.animateToPreset(cameraPreset)
+      if (controller) {
+        setCameraControllerReadyVersion((version) => version + 1)
       }
     },
-    [cameraPreset, externalCameraControllerReady],
+    [externalCameraControllerReady],
   )
 
   const handleCameraPresetSelect = useCallback(
     (preset: CameraPreset) => {
       setCameraPreset(preset)
       closeMenu()
-      if (preset === "Custom") return
-      cameraControllerRef.current?.animateToPreset(preset)
     },
     [closeMenu],
   )
+
+  useEffect(() => {
+    if (!cameraControllerRef.current) return
+    if (cameraPreset === "Custom") return
+    cameraControllerRef.current.animateToPreset(cameraPreset)
+  }, [cameraPreset, cameraControllerReadyVersion])
 
   useEffect(() => {
     const stored = window.localStorage.getItem("cadViewerEngine")

--- a/src/CadViewerContainer.tsx
+++ b/src/CadViewerContainer.tsx
@@ -37,6 +37,7 @@ interface Props {
   boardCenter?: { x: number; y: number }
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
+  shouldUseOrthographicCamera?: boolean
 }
 
 export const CadViewerContainer = forwardRef<
@@ -53,6 +54,7 @@ export const CadViewerContainer = forwardRef<
       boardCenter,
       onUserInteraction,
       onCameraControllerReady,
+      shouldUseOrthographicCamera,
     },
     ref,
   ) => {
@@ -87,6 +89,22 @@ export const CadViewerContainer = forwardRef<
       onCameraControllerReady,
     })
 
+    const orthographicFrustumSize = useMemo(() => {
+      const [x, y, z] = initialCameraPosition
+      const maxComponent = Math.max(Math.abs(x), Math.abs(y), Math.abs(z))
+      return Math.max(maxComponent * 2, 10)
+    }, [initialCameraPosition])
+
+    const mutableInitialCameraPosition = useMemo(
+      () =>
+        [
+          initialCameraPosition[0],
+          initialCameraPosition[1],
+          initialCameraPosition[2],
+        ] as [number, number, number],
+      [initialCameraPosition],
+    )
+
     return (
       <div style={{ position: "relative", width: "100%", height: "100%" }}>
         <div
@@ -111,7 +129,12 @@ export const CadViewerContainer = forwardRef<
         <Canvas
           ref={ref}
           scene={{ up: new THREE.Vector3(0, 0, 1) }}
-          camera={{ up: [0, 0, 1], position: initialCameraPosition }}
+          camera={{
+            up: [0, 0, 1],
+            position: mutableInitialCameraPosition,
+            type: shouldUseOrthographicCamera ? "orthographic" : "perspective",
+            frustumSize: orthographicFrustumSize,
+          }}
         >
           <CameraAnimator {...cameraAnimatorProps} />
           <RotationTracker />

--- a/src/CadViewerContainer.tsx
+++ b/src/CadViewerContainer.tsx
@@ -18,11 +18,24 @@ export type {
   CameraPreset,
 } from "./hooks/useCameraController"
 
+declare global {
+  interface Window {
+    TSCI_MAIN_CAMERA_ROTATION: THREE.Euler
+    TSCI_MAIN_CAMERA_QUATERNION: THREE.Quaternion
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.TSCI_MAIN_CAMERA_ROTATION ??= new THREE.Euler(0, 0, 0)
+  window.TSCI_MAIN_CAMERA_QUATERNION ??= new THREE.Quaternion()
+}
+
 export const RotationTracker = () => {
   const { camera } = useThree()
   useFrame(() => {
     if (camera) {
-      window.TSCI_MAIN_CAMERA_ROTATION = camera.rotation
+      window.TSCI_MAIN_CAMERA_ROTATION.copy(camera.rotation)
+      window.TSCI_MAIN_CAMERA_QUATERNION.copy(camera.quaternion)
     }
   })
 

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -30,6 +30,7 @@ interface Props {
   clickToInteractEnabled?: boolean
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
+  shouldUseOrthographicCamera?: boolean
 }
 
 export const CadViewerJscad = forwardRef<
@@ -45,6 +46,7 @@ export const CadViewerJscad = forwardRef<
       clickToInteractEnabled,
       onUserInteraction,
       onCameraControllerReady,
+      shouldUseOrthographicCamera,
     },
     ref,
   ) => {
@@ -118,6 +120,7 @@ export const CadViewerJscad = forwardRef<
         boardCenter={boardCenter}
         onUserInteraction={onUserInteraction}
         onCameraControllerReady={onCameraControllerReady}
+        shouldUseOrthographicCamera={shouldUseOrthographicCamera}
       >
         {boardStls.map(({ stlData, color, layerType }, index) => (
           <VisibleSTLModel

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -119,6 +119,7 @@ type CadViewerManifoldProps = {
   clickToInteractEnabled?: boolean
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
+  shouldUseOrthographicCamera?: boolean
 } & (
   | { circuitJson: AnyCircuitElement[]; children?: React.ReactNode }
   | { circuitJson?: never; children: React.ReactNode }
@@ -133,6 +134,7 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
   onUserInteraction,
   children,
   onCameraControllerReady,
+  shouldUseOrthographicCamera,
 }) => {
   const childrenCircuitJson = useConvertChildrenToCircuitJson(children)
   const circuitJson = useMemo(() => {
@@ -307,6 +309,7 @@ try {
       boardCenter={boardCenter}
       onUserInteraction={onUserInteraction}
       onCameraControllerReady={onCameraControllerReady}
+      shouldUseOrthographicCamera={shouldUseOrthographicCamera}
     >
       <BoardMeshes
         geometryMeshes={geometryMeshes}

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -12,9 +12,11 @@ interface ContextMenuProps {
   engine: "jscad" | "manifold"
   cameraPreset: CameraPreset
   autoRotate: boolean
+  shouldUseOrthographicCamera: boolean
   onEngineSwitch: (engine: "jscad" | "manifold") => void
   onCameraPresetSelect: (preset: CameraPreset) => void
   onAutoRotateToggle: () => void
+  onOrthographicToggle: () => void
   onDownloadGltf: () => void
 }
 
@@ -102,9 +104,11 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   engine,
   cameraPreset,
   autoRotate,
+  shouldUseOrthographicCamera,
   onEngineSwitch,
   onCameraPresetSelect,
   onAutoRotateToggle,
+  onOrthographicToggle,
   onDownloadGltf,
 }) => {
   const [cameraSubOpen, setCameraSubOpen] = useState(false)
@@ -223,6 +227,29 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
               </span>
               <span style={{ display: "flex", alignItems: "center" }}>
                 Auto rotate
+              </span>
+            </DropdownMenu.Item>
+
+            <DropdownMenu.Item
+              style={{
+                ...itemStyles,
+                ...itemPaddingStyles,
+                backgroundColor:
+                  hoveredItem === "orthographic" ? "#404040" : "transparent",
+              }}
+              onSelect={(e) => e.preventDefault()}
+              onPointerDown={(e) => {
+                e.preventDefault()
+                onOrthographicToggle()
+              }}
+              onMouseEnter={() => setHoveredItem("orthographic")}
+              onMouseLeave={() => setHoveredItem(null)}
+            >
+              <span style={iconContainerStyles}>
+                {shouldUseOrthographicCamera && <CheckIcon />}
+              </span>
+              <span style={{ display: "flex", alignItems: "center" }}>
+                Orthographic camera
               </span>
             </DropdownMenu.Item>
 

--- a/src/three-components/cube-with-labeled-sides.tsx
+++ b/src/three-components/cube-with-labeled-sides.tsx
@@ -6,28 +6,18 @@ import { useFrame, useThree } from "src/react-three/ThreeContext"
 declare global {
   interface Window {
     TSCI_MAIN_CAMERA_ROTATION: THREE.Euler
+    TSCI_MAIN_CAMERA_QUATERNION: THREE.Quaternion
   }
 }
 if (typeof window !== "undefined") {
   window.TSCI_MAIN_CAMERA_ROTATION = new THREE.Euler(0, 0, 0)
+  window.TSCI_MAIN_CAMERA_QUATERNION = new THREE.Quaternion()
 }
 
-function computePointInFront(rotationVector, distance) {
-  // Create a quaternion from the rotation vector
-  const quaternion = new THREE.Quaternion().setFromEuler(
-    new THREE.Euler(rotationVector.x, rotationVector.y, rotationVector.z),
-  )
-
-  // Create a vector pointing forward (along the negative z-axis)
+function computePointInFront(quaternion: THREE.Quaternion, distance: number) {
   const forwardVector = new THREE.Vector3(0, 0, 1)
-
-  // Apply the rotation to the forward vector
   forwardVector.applyQuaternion(quaternion)
-
-  // Scale the rotated vector by the distance
-  const result = forwardVector.multiplyScalar(distance)
-
-  return result
+  return forwardVector.multiplyScalar(distance)
 }
 
 export const CubeWithLabeledSides = ({}: any) => {
@@ -45,8 +35,8 @@ export const CubeWithLabeledSides = ({}: any) => {
   useFrame(() => {
     if (!camera) return
 
-    const mainRot = window.TSCI_MAIN_CAMERA_ROTATION
-    const cameraPosition = computePointInFront(mainRot, 2)
+    const mainQuaternion = window.TSCI_MAIN_CAMERA_QUATERNION
+    const cameraPosition = computePointInFront(mainQuaternion, 2)
 
     camera.position.copy(cameraPosition)
     camera.lookAt(0, 0, 0)


### PR DESCRIPTION
Closes #545

## Problem
The orthographic camera toggle existed in the UI but the frustum was hardcoded to ±10 units regardless of scene scale. For typical PCBs viewed from 8-15 units away, this produced a severely zoomed-in or clipped view.

## Fix
- Frustum half-height is now computed as `h = distance × tan(FOV/2)` from the camera position, matching the perspective view's apparent zoom
- The resize handler preserves `camera.top` instead of resetting to 10, so zooming in orthographic mode survives window resizes