### PR TITLE
Improve 3D model cache

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,24 +1,8 @@
 import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
+import { loadCachedModel } from "src/utils/model-cache"
 import { loadVrml } from "src/utils/vrml"
-
-// Define the type for our cache
-interface CacheItem {
-  promise: Promise<any>
-  result: Object3D | null
-}
-
-declare global {
-  interface Window {
-    TSCIRCUIT_OBJ_LOADER_CACHE: Map<string, CacheItem>
-  }
-}
-
-// Ensure the global cache exists
-if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
-  window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
-}
 
 export function useGlobalObjLoader(
   url: string | null,
@@ -28,89 +12,59 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
-
-    const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
-    async function loadAndParseObj() {
-      try {
-        if (cleanUrl.endsWith(".wrl")) {
-          return await loadVrml(cleanUrl)
-        }
-
-        const response = await fetch(cleanUrl)
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
-          )
-        }
-        const text = await response.text()
-
-        const mtlContentArr = text.match(/newmtl[\s\S]*?endmtl/g)
-
-        const objLoader = new OBJLoader()
-
-        if (mtlContentArr?.length) {
-          const mtlContent = mtlContentArr.join("\n").replace(/d 0\./g, "d 1.")
-          const objContent = text
-            .replace(/newmtl[\s\S]*?endmtl/g, "")
-            .replace(/^mtllib.*/gm, "")
-
-          const mtlLoader = new MTLLoader()
-          mtlLoader.setMaterialOptions({
-            invertTrProperty: true,
-          })
-          const materials = mtlLoader.parse(
-            mtlContent.replace(
-              /Kd\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/g,
-              "Kd $2 $2 $2",
-            ),
-            "embedded.mtl",
-          )
-          objLoader.setMaterials(materials)
-          return objLoader.parse(objContent)
-        }
-
-        return objLoader.parse(text.replace(/^mtllib.*/gm, ""))
-      } catch (error) {
-        return error as Error
+    async function loadAndParseObj(cleanUrl: string): Promise<Object3D> {
+      if (cleanUrl.endsWith(".wrl")) {
+        return await loadVrml(cleanUrl)
       }
-    }
 
-    function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
-        if (cacheItem.result) {
-          // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
-        }
-        // If we're still loading, return the existing promise
-        return cacheItem.promise.then((result) => {
-          if (result instanceof Error) return result
-          return result.clone()
+      const response = await fetch(cleanUrl)
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
+        )
+      }
+      const text = await response.text()
+
+      const mtlContentArr = text.match(/newmtl[\s\S]*?endmtl/g)
+
+      const objLoader = new OBJLoader()
+
+      if (mtlContentArr?.length) {
+        const mtlContent = mtlContentArr.join("\n").replace(/d 0\./g, "d 1.")
+        const objContent = text
+          .replace(/newmtl[\s\S]*?endmtl/g, "")
+          .replace(/^mtllib.*/gm, "")
+
+        const mtlLoader = new MTLLoader()
+        mtlLoader.setMaterialOptions({
+          invertTrProperty: true,
         })
+        const materials = mtlLoader.parse(
+          mtlContent.replace(
+            /Kd\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/g,
+            "Kd $2 $2 $2",
+          ),
+          "embedded.mtl",
+        )
+        objLoader.setMaterials(materials)
+        return objLoader.parse(objContent)
       }
-      // If it's not in the cache, create a new promise and cache it
-      const promise = loadAndParseObj().then((result) => {
-        if (result instanceof Error) {
-          // If the result is an Error, return it
-          return result
-        }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
-        return result
-      })
-      cache.set(cleanUrl, { promise, result: null })
-      return promise
+
+      return objLoader.parse(text.replace(/^mtllib.*/gm, ""))
     }
 
-    loadUrl()
+    loadCachedModel(url, loadAndParseObj)
       .then((result) => {
         if (hasUrlChanged) return
         setObj(result)
       })
       .catch((error) => {
         console.error(error)
+        if (!hasUrlChanged) {
+          setObj(error instanceof Error ? error : new Error(String(error)))
+        }
       })
 
     return () => {

--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -5,6 +5,7 @@ import { useThree } from "src/react-three/ThreeContext"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import { loadCachedModel } from "src/utils/model-cache"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 const DEFAULT_ENV_MAP_INTENSITY = 1.25
@@ -57,11 +58,12 @@ export function GltfModel({
     if (!gltfUrl) return
     const loader = new GLTFLoader()
     let isMounted = true
-    loader.load(
-      gltfUrl,
-      (gltf) => {
+    void loadCachedModel(gltfUrl, async (normalizedUrl) => {
+      const gltf = await loader.loadAsync(normalizedUrl)
+      return gltf.scene
+    })
+      .then((scene) => {
         if (!isMounted) return
-        const scene = gltf.scene
 
         scene.traverse((child) => {
           if (child instanceof THREE.Mesh && child.material) {
@@ -82,10 +84,9 @@ export function GltfModel({
           }
         })
 
-        setModel(scene)
-      },
-      undefined,
-      (error) => {
+        setModel(scene as THREE.Group)
+      })
+      .catch((error) => {
         if (!isMounted) return
         console.error(`An error happened loading ${gltfUrl}`, error)
         const err =
@@ -93,8 +94,7 @@ export function GltfModel({
             ? error
             : new Error(`Failed to load glTF model from ${gltfUrl}`)
         setLoadError(err)
-      },
-    )
+      })
     return () => {
       isMounted = false
     }

--- a/src/utils/model-cache.ts
+++ b/src/utils/model-cache.ts
@@ -1,0 +1,88 @@
+import * as THREE from "three"
+
+type ModelCacheItem = {
+  promise: Promise<THREE.Object3D>
+  result?: THREE.Object3D
+}
+
+const MODEL_CACHE_KEY = "__TSCIRCUIT_3D_VIEWER_MODEL_CACHE__"
+const MODEL_CACHE_BASE_URL = "https://model-cache.local"
+
+type GlobalModelCacheScope = typeof globalThis & {
+  [MODEL_CACHE_KEY]?: Map<string, ModelCacheItem>
+}
+
+export function normalizeModelCacheUrl(url: string): string {
+  try {
+    const parsed = new URL(url, MODEL_CACHE_BASE_URL)
+    parsed.searchParams.delete("cachebust_origin")
+
+    if (parsed.origin === MODEL_CACHE_BASE_URL) {
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`
+    }
+
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+function getModelCache(): Map<string, ModelCacheItem> {
+  const scope = globalThis as GlobalModelCacheScope
+  if (!scope[MODEL_CACHE_KEY]) {
+    scope[MODEL_CACHE_KEY] = new Map()
+  }
+  return scope[MODEL_CACHE_KEY]
+}
+
+function cloneMaterial(material: THREE.Material): THREE.Material {
+  return material.clone()
+}
+
+export function cloneObject3D(source: THREE.Object3D): THREE.Object3D {
+  const cloned = source.clone(true)
+
+  cloned.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.material) return
+
+    child.material = Array.isArray(child.material)
+      ? child.material.map(cloneMaterial)
+      : cloneMaterial(child.material)
+  })
+
+  return cloned
+}
+
+export async function loadCachedModel(
+  url: string,
+  loadModel: (normalizedUrl: string) => Promise<THREE.Object3D>,
+): Promise<THREE.Object3D> {
+  const normalizedUrl = normalizeModelCacheUrl(url)
+  const cache = getModelCache()
+  const cached = cache.get(normalizedUrl)
+
+  if (cached?.result) {
+    return cloneObject3D(cached.result)
+  }
+
+  if (cached) {
+    const result = await cached.promise
+    return cloneObject3D(result)
+  }
+
+  const promise = loadModel(normalizedUrl).then(
+    (result) => {
+      cache.set(normalizedUrl, { promise: Promise.resolve(result), result })
+      return result
+    },
+    (error) => {
+      cache.delete(normalizedUrl)
+      throw error
+    },
+  )
+
+  cache.set(normalizedUrl, { promise })
+
+  const result = await promise
+  return cloneObject3D(result)
+}

--- a/tests/model-cache.test.ts
+++ b/tests/model-cache.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  loadCachedModel,
+  normalizeModelCacheUrl,
+} from "../src/utils/model-cache"
+
+test("normalizes model URLs by removing cachebust_origin", () => {
+  expect(
+    normalizeModelCacheUrl(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&cachebust_origin=http%3A%2F%2Flocalhost%3A3020&pn=C123",
+    ),
+  ).toBe(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123",
+  )
+
+  expect(
+    normalizeModelCacheUrl(
+      "/models/chip.obj?cachebust_origin=http%3A%2F%2Flocalhost%3A3020&v=1#mesh",
+    ),
+  ).toBe("/models/chip.obj?v=1#mesh")
+})
+
+test("loadCachedModel reuses a normalized URL and returns isolated clones", async () => {
+  const source = new THREE.Group()
+  source.add(
+    new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 1),
+      new THREE.MeshStandardMaterial({ color: 0xff0000 }),
+    ),
+  )
+
+  let loadCount = 0
+  const baseUrl = `/models/shared-${Date.now()}.obj`
+
+  const first = await loadCachedModel(
+    `${baseUrl}?cachebust_origin=http%3A%2F%2Flocalhost%3A3020`,
+    async (normalizedUrl) => {
+      loadCount += 1
+      expect(normalizedUrl).toBe(baseUrl)
+      return source
+    },
+  )
+
+  const second = await loadCachedModel(
+    `${baseUrl}?cachebust_origin=http%3A%2F%2Fexample.com`,
+    async () => {
+      loadCount += 1
+      return new THREE.Group()
+    },
+  )
+
+  expect(loadCount).toBe(1)
+  expect(first).not.toBe(source)
+  expect(second).not.toBe(source)
+  expect(first).not.toBe(second)
+
+  const firstMesh = first.children[0] as THREE.Mesh
+  const secondMesh = second.children[0] as THREE.Mesh
+  const firstMaterial = firstMesh.material as THREE.MeshStandardMaterial
+  const secondMaterial = secondMesh.material as THREE.MeshStandardMaterial
+
+  firstMaterial.opacity = 0.25
+
+  expect(firstMaterial).not.toBe(secondMaterial)
+  expect(secondMaterial.opacity).toBe(1)
+})


### PR DESCRIPTION
## Summary

- add a shared model cache that normalizes model URLs by removing `cachebust_origin`
- reuse the cache for OBJ/WRL and GLTF/GLB model loading
- clone cached objects and materials before rendering so hover/transparency mutations stay isolated per instance

## Why

Repeated components can point at the same model URL with different `cachebust_origin` values, which causes duplicate model fetch/parse work and contributes to browser lag. GLTF/GLB models also bypassed the existing OBJ cache entirely.

Fixes #93

/claim #93

## Tests

- `npm exec -- tsc --noEmit`
- `npm run build`
- `npx --yes bun test tests/model-cache.test.ts`
- `npx --yes bun test tests/resolve-model-url.test.ts tests/cad-model-transform.test.ts`