### PR TITLE
Cache shared glTF model loads

### DIFF
--- a/src/hooks/use-global-gltf-loader.ts
+++ b/src/hooks/use-global-gltf-loader.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react"
+import * as THREE from "three"
+import { GLTFLoader } from "three-stdlib"
+
+type GltfCacheItem = {
+  promise: Promise<THREE.Group | Error>
+  result: THREE.Group | Error | null
+}
+
+declare global {
+  var TSCIRCUIT_GLTF_LOADER_CACHE: Map<string, GltfCacheItem> | undefined
+}
+
+function getGltfLoaderCache(): Map<string, GltfCacheItem> {
+  if (!globalThis.TSCIRCUIT_GLTF_LOADER_CACHE) {
+    globalThis.TSCIRCUIT_GLTF_LOADER_CACHE = new Map<string, GltfCacheItem>()
+  }
+  return globalThis.TSCIRCUIT_GLTF_LOADER_CACHE
+}
+
+function cloneLoadedGltf(result: THREE.Group | Error): THREE.Group | Error {
+  if (result instanceof Error) {
+    return result
+  }
+  return result.clone(true)
+}
+
+export function useGlobalGltfLoader(
+  gltfUrl: string | null,
+): THREE.Group | null | Error {
+  const [model, setModel] = useState<THREE.Group | null | Error>(null)
+
+  useEffect(() => {
+    if (!gltfUrl) return
+
+    let isActive = true
+    const cache = getGltfLoaderCache()
+    const cleanUrl = gltfUrl.replace(/&cachebust_origin=$/, "")
+
+    const loadUrl = () => {
+      const cached = cache.get(cleanUrl)
+      if (cached) {
+        if (cached.result) {
+          return Promise.resolve(cloneLoadedGltf(cached.result))
+        }
+        return cached.promise.then(cloneLoadedGltf)
+      }
+
+      const loader = new GLTFLoader()
+      const promise = loader
+        .loadAsync(cleanUrl)
+        .then((gltf) => {
+          cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result: gltf.scene })
+          return gltf.scene
+        })
+        .catch((error) => {
+          const err =
+            error instanceof Error
+              ? error
+              : new Error(`Failed to load glTF model from ${cleanUrl}`)
+          cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result: err })
+          return err
+        })
+
+      cache.set(cleanUrl, { promise, result: null })
+      return promise.then(cloneLoadedGltf)
+    }
+
+    void loadUrl().then((result) => {
+      if (!isActive) return
+      setModel(result)
+    })
+
+    return () => {
+      isActive = false
+    }
+  }, [gltfUrl])
+
+  return model
+}

--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from "react"
+import { useEffect } from "react"
 import * as THREE from "three"
-import { GLTFLoader } from "three-stdlib"
 import { useThree } from "src/react-three/ThreeContext"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
+import { useGlobalGltfLoader } from "src/hooks/use-global-gltf-loader"
 
 const DEFAULT_ENV_MAP_INTENSITY = 1.25
 
@@ -39,10 +39,9 @@ export function GltfModel({
   isTranslucent?: boolean
 }) {
   const { renderer } = useThree()
-  const [model, setModel] = useState<THREE.Group | null>(null)
-  const [loadError, setLoadError] = useState<Error | null>(null)
+  const model = useGlobalGltfLoader(gltfUrl)
   const { boardTransformGroup } = useCadModelTransformGraph({
-    model,
+    model: model instanceof Error ? null : model,
     position,
     rotation,
     modelOffset,
@@ -54,54 +53,30 @@ export function GltfModel({
   })
 
   useEffect(() => {
-    if (!gltfUrl) return
-    const loader = new GLTFLoader()
-    let isMounted = true
-    loader.load(
-      gltfUrl,
-      (gltf) => {
-        if (!isMounted) return
-        const scene = gltf.scene
+    if (!model || model instanceof Error) return
 
-        scene.traverse((child) => {
-          if (child instanceof THREE.Mesh && child.material) {
-            const setMaterialTransparency = (mat: THREE.Material) => {
-              mat.transparent = isTranslucent
-              mat.opacity = isTranslucent ? 0.5 : 1
-              mat.depthWrite = !isTranslucent
-              mat.needsUpdate = true
-            }
+    model.traverse((child) => {
+      if (child instanceof THREE.Mesh && child.material) {
+        const setMaterialTransparency = (mat: THREE.Material) => {
+          mat.transparent = isTranslucent
+          mat.opacity = isTranslucent ? 0.5 : 1
+          mat.depthWrite = !isTranslucent
+          mat.needsUpdate = true
+        }
 
-            if (Array.isArray(child.material)) {
-              child.material.forEach(setMaterialTransparency)
-            } else {
-              setMaterialTransparency(child.material)
-            }
+        if (Array.isArray(child.material)) {
+          child.material.forEach(setMaterialTransparency)
+        } else {
+          setMaterialTransparency(child.material)
+        }
 
-            child.renderOrder = isTranslucent ? 2 : 1
-          }
-        })
-
-        setModel(scene)
-      },
-      undefined,
-      (error) => {
-        if (!isMounted) return
-        console.error(`An error happened loading ${gltfUrl}`, error)
-        const err =
-          error instanceof Error
-            ? error
-            : new Error(`Failed to load glTF model from ${gltfUrl}`)
-        setLoadError(err)
-      },
-    )
-    return () => {
-      isMounted = false
-    }
-  }, [gltfUrl, isTranslucent])
+        child.renderOrder = isTranslucent ? 2 : 1
+      }
+    })
+  }, [model, isTranslucent])
 
   useEffect(() => {
-    if (!model || !renderer) return
+    if (!model || model instanceof Error || !renderer) return
 
     const environmentMap = getDefaultEnvironmentMap(renderer)
     if (!environmentMap) return
@@ -154,7 +129,7 @@ export function GltfModel({
   }, [model, renderer])
 
   useEffect(() => {
-    if (!model) return
+    if (!model || model instanceof Error) return
     model.traverse((child) => {
       if (
         child instanceof THREE.Mesh &&
@@ -170,8 +145,9 @@ export function GltfModel({
     })
   }, [isHovered, model])
 
-  if (loadError) {
-    throw loadError
+  if (model instanceof Error) {
+    console.error(`An error happened loading ${gltfUrl}`, model)
+    throw model
   }
 
   if (!model) return null


### PR DESCRIPTION
/claim #93

## Summary
- Adds a shared glTF/GLB loader cache so repeated components using the same model URL reuse the same in-flight/completed load.
- Clones the cached glTF scene for each component so transforms/material updates do not share the same Object3D instance.
- Keeps existing transparency, environment map, and hover highlighting behavior in GltfModel.

## Validation
- npm install --legacy-peer-deps
- npm run build
- npm run test:node-bundle
- biome format src/hooks/use-global-gltf-loader.ts src/three-components/GltfModel.tsx
- git diff --check