### PR TITLE
Normalize cache-busted OBJ loader URLs

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import { normalizeLoaderUrl } from "src/utils/normalize-loader-url"
+import { loadVrml } from "src/utils/vrml"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
-import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
 interface CacheItem {
@@ -28,7 +29,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = normalizeLoaderUrl(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false

--- a/src/utils/normalize-loader-url.ts
+++ b/src/utils/normalize-loader-url.ts
@@ -1,0 +1,12 @@
+export function normalizeLoaderUrl(url: string) {
+  const [withoutHash, hash = ""] = url.split("#")
+  const [path, query = ""] = withoutHash.split("?")
+
+  const searchParams = new URLSearchParams(query)
+  searchParams.delete("cachebust_origin")
+
+  const normalizedQuery = searchParams.toString()
+  const normalizedUrl = normalizedQuery ? `${path}?${normalizedQuery}` : path
+
+  return hash ? `${normalizedUrl}#${hash}` : normalizedUrl
+}

--- a/tests/normalize-loader-url.test.ts
+++ b/tests/normalize-loader-url.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { normalizeLoaderUrl } from "../src/utils/normalize-loader-url"
+
+test("removes cachebust_origin from the query string", () => {
+  expect(
+    normalizeLoaderUrl(
+      "https://cdn.example.com/models/chip.obj?cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    ),
+  ).toBe("https://cdn.example.com/models/chip.obj")
+})
+
+test("preserves other query params and hash fragments", () => {
+  expect(
+    normalizeLoaderUrl(
+      "/models/chip.obj?foo=1&cachebust_origin=https%3A%2F%2Ftscircuit.com#part",
+    ),
+  ).toBe("/models/chip.obj?foo=1#part")
+})


### PR DESCRIPTION
/claim #93

Normalize loader URLs before they hit the global OBJ cache so `cachebust_origin` does not create duplicate cache entries. This keeps other query params and hash fragments intact and adds a regression test for the URL canonicalization helper.