### PR TITLE
Cache shared 3D model loads

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,33 +4,174 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
-    const loader = new STLLoader()
-    const geometry = await loader.loadAsync(url)
-    const material = new THREE.MeshStandardMaterial({
-      color: 0x888888,
-      metalness: 0.5,
-      roughness: 0.5,
-    })
-    return new THREE.Mesh(geometry, material)
+export type ModelType = "stl" | "obj" | "wrl" | "gltf" | "glb"
+
+type ModelLoaders = {
+  stl: (url: string) => Promise<THREE.BufferGeometry>
+  obj: (url: string) => Promise<THREE.Object3D>
+  wrl: (url: string) => Promise<THREE.Object3D | null>
+  gltf: (url: string) => Promise<THREE.Object3D>
+}
+
+type ModelCacheEntry = {
+  promise: Promise<THREE.Object3D | null>
+  result: THREE.Object3D | null
+}
+
+const loadedModelCache = new Map<string, ModelCacheEntry>()
+
+export function normalizeModelCacheKey(url: string) {
+  try {
+    const parsedUrl = new URL(url, "https://model-cache.local")
+    parsedUrl.searchParams.delete("cachebust_origin")
+    parsedUrl.hash = ""
+    const sortedParams = Array.from(parsedUrl.searchParams.entries()).sort(
+      ([leftKey, leftValue], [rightKey, rightValue]) =>
+        leftKey.localeCompare(rightKey) || leftValue.localeCompare(rightValue),
+    )
+    parsedUrl.search = ""
+    for (const [key, value] of sortedParams) {
+      parsedUrl.searchParams.append(key, value)
+    }
+
+    if (parsedUrl.origin === "https://model-cache.local") {
+      return `${parsedUrl.pathname}${parsedUrl.search}`
+    }
+
+    return parsedUrl.toString()
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&]*&?/g, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
+export function getModelTypeFromUrl(
+  url: string,
+  modelType?: ModelType,
+): ModelType | null {
+  if (modelType) return modelType
+
+  const extension = (() => {
+    try {
+      const parsedUrl = new URL(url, "https://model-type.local")
+      const match = parsedUrl.pathname.toLowerCase().match(/\.([a-z0-9]+)$/)
+      return match?.[1]
+    } catch {
+      return url
+        .toLowerCase()
+        .split("?")[0]
+        ?.match(/\.([a-z0-9]+)$/)?.[1]
+    }
+  })()
+
+  if (
+    extension === "stl" ||
+    extension === "obj" ||
+    extension === "wrl" ||
+    extension === "gltf" ||
+    extension === "glb"
+  ) {
+    return extension
   }
 
-  if (url.endsWith(".obj")) {
+  return null
+}
+
+export function cloneModelInstance(model: THREE.Object3D) {
+  const clone = model.clone(true)
+
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    if (Array.isArray(child.material)) {
+      child.material = child.material.map((material) => material.clone())
+    } else if (child.material) {
+      child.material = child.material.clone()
+    }
+  })
+
+  return clone
+}
+
+export function clearLoadedModelCacheForTests() {
+  loadedModelCache.clear()
+}
+
+const defaultModelLoaders: ModelLoaders = {
+  stl: async (url) => {
+    const loader = new STLLoader()
+    return await loader.loadAsync(url)
+  },
+  obj: async (url) => {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
-  }
-
-  if (url.endsWith(".wrl")) {
-    return await loadVrml(url)
-  }
-
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  },
+  wrl: loadVrml,
+  gltf: async (url) => {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene
+  },
+}
+
+export async function load3DModelWithLoaders(
+  url: string,
+  modelType: ModelType | undefined,
+  loaders: ModelLoaders,
+): Promise<THREE.Object3D | null> {
+  const detectedModelType = getModelTypeFromUrl(url, modelType)
+
+  if (!detectedModelType) {
+    console.error("Unsupported file format or failed to load 3D model.")
+    return null
   }
 
-  console.error("Unsupported file format or failed to load 3D model.")
-  return null
+  const cacheKey = `${detectedModelType}:${normalizeModelCacheKey(url)}`
+  const cached = loadedModelCache.get(cacheKey)
+
+  if (cached) {
+    const cachedModel = cached.result ?? (await cached.promise)
+    return cachedModel ? cloneModelInstance(cachedModel) : null
+  }
+
+  const promise = (async () => {
+    if (detectedModelType === "stl") {
+      const geometry = await loaders.stl(url)
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x888888,
+        metalness: 0.5,
+        roughness: 0.5,
+      })
+      return new THREE.Mesh(geometry, material)
+    }
+
+    if (detectedModelType === "obj") {
+      return await loaders.obj(url)
+    }
+
+    if (detectedModelType === "wrl") {
+      return await loaders.wrl(url)
+    }
+
+    return await loaders.gltf(url)
+  })()
+
+  loadedModelCache.set(cacheKey, { promise, result: null })
+
+  try {
+    const model = await promise
+    loadedModelCache.set(cacheKey, { promise, result: model })
+    return model ? cloneModelInstance(model) : null
+  } catch (error) {
+    loadedModelCache.delete(cacheKey)
+    throw error
+  }
+}
+
+export async function load3DModel(
+  url: string,
+  modelType?: ModelType,
+): Promise<THREE.Object3D | null> {
+  return await load3DModelWithLoaders(url, modelType, defaultModelLoaders)
 }

--- a/src/utils/render-component.tsx
+++ b/src/utils/render-component.tsx
@@ -1,28 +1,42 @@
-import jscad from "@jscad/modeling"
-import type { AnyCircuitElement } from "circuit-json"
+import jscad, * as jscadModeling from "@jscad/modeling"
+import type { CadComponent } from "circuit-json"
 import {
   convertCSGToThreeGeom,
   getJscadModelForFootprint,
 } from "jscad-electronics/vanilla"
 import { executeJscadOperations } from "jscad-planner"
 import * as THREE from "three"
-import * as jscadModeling from "@jscad/modeling"
-import { load3DModel } from "./load-model"
-import type { CadComponent } from "circuit-json"
+import { load3DModel, type ModelType } from "./load-model"
+
+const getComponentModelUrl = (
+  component: CadComponent,
+): { url: string; modelType: ModelType } | null => {
+  if (component.model_obj_url) {
+    return { url: component.model_obj_url, modelType: "obj" }
+  }
+  if (component.model_wrl_url) {
+    return { url: component.model_wrl_url, modelType: "wrl" }
+  }
+  if (component.model_stl_url) {
+    return { url: component.model_stl_url, modelType: "stl" }
+  }
+  if (component.model_glb_url) {
+    return { url: component.model_glb_url, modelType: "glb" }
+  }
+  if (component.model_gltf_url) {
+    return { url: component.model_gltf_url, modelType: "gltf" }
+  }
+  return null
+}
 
 export async function renderComponent(
   component: CadComponent,
   scene: THREE.Scene,
 ) {
   // Handle STL/OBJ models first
-  const url =
-    component.model_obj_url ??
-    component.model_wrl_url ??
-    component.model_stl_url ??
-    component.model_glb_url ??
-    component.model_gltf_url
-  if (url) {
-    const model = await load3DModel(url)
+  const modelUrl = getComponentModelUrl(component)
+  if (modelUrl) {
+    const model = await load3DModel(modelUrl.url, modelUrl.modelType)
     if (model) {
       if (component.position) {
         model.position.set(

--- a/tests/load-model.test.ts
+++ b/tests/load-model.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  clearLoadedModelCacheForTests,
+  getModelTypeFromUrl,
+  load3DModelWithLoaders,
+  normalizeModelCacheKey,
+} from "../src/utils/load-model"
+
+describe("load-model", () => {
+  beforeEach(() => {
+    clearLoadedModelCacheForTests()
+  })
+
+  test("normalizes cachebust_origin out of model cache keys", () => {
+    expect(
+      normalizeModelCacheKey(
+        "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+      ),
+    ).toBe(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?pn=C1&uuid=abc",
+    )
+  })
+
+  test("uses an explicit model type for extensionless CDN URLs", () => {
+    expect(
+      getModelTypeFromUrl(
+        "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1",
+        "obj",
+      ),
+    ).toBe("obj")
+    expect(getModelTypeFromUrl("/models/chip.glb")).toBe("glb")
+  })
+
+  test("deduplicates in-flight loads and returns independent model clones", async () => {
+    let loadCount = 0
+    const geometry = new THREE.BoxGeometry(1, 1, 1)
+    const material = new THREE.MeshStandardMaterial({ color: 0xff0000 })
+    const sourceModel = new THREE.Group()
+    sourceModel.add(new THREE.Mesh(geometry, material))
+
+    const loaders = {
+      stl: async () => new THREE.BufferGeometry(),
+      obj: async () => {
+        loadCount += 1
+        await Promise.resolve()
+        return sourceModel
+      },
+      wrl: async () => null,
+      gltf: async () => new THREE.Group(),
+    }
+
+    const [firstModel, secondModel] = await Promise.all([
+      load3DModelWithLoaders(
+        "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+        "obj",
+        loaders,
+      ),
+      load3DModelWithLoaders(
+        "https://modelcdn.tscircuit.com/easyeda_models/download?pn=C1&uuid=abc&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+        "obj",
+        loaders,
+      ),
+    ])
+
+    expect(loadCount).toBe(1)
+    expect(firstModel).toBeInstanceOf(THREE.Group)
+    expect(secondModel).toBeInstanceOf(THREE.Group)
+    expect(firstModel).not.toBe(secondModel)
+
+    const firstMesh = firstModel!.children[0] as THREE.Mesh
+    const secondMesh = secondModel!.children[0] as THREE.Mesh
+    expect(firstMesh.geometry).toBe(secondMesh.geometry)
+    expect(firstMesh.material).not.toBe(secondMesh.material)
+  })
+})


### PR DESCRIPTION
Fixes #93
/claim #93

## Summary
- add a shared `load3DModel` cache that deduplicates in-flight and completed model loads
- normalize cache keys by stripping `cachebust_origin` while preserving other model query params
- pass the model type from `CadComponent` model URL fields so extensionless CDN URLs still load with the correct loader
- return cloned model instances with independent material objects for per-instance transforms/hover/translucency state
- add focused tests for cache key normalization, type hints, and in-flight deduplication

## Verification
- `npx --yes bun test tests/load-model.test.ts`
- `npx --yes biome check src/utils/load-model.ts src/utils/render-component.tsx tests/load-model.test.ts`
- `npx --yes tsc --noEmit`
- `npx --yes bun run build`
- `git diff --check`

## Local full-suite note
- `npx --yes bun test` currently has 3 unrelated local failures outside this change: `tests/preprocess-circuit-json.test.ts` expects z offsets 0.8/1.8 but receives 0.7/1.7, and `tests/outline-bounds.test.ts` expects `rgb(39,89,56)` while current output contains nearby soldermask colors. The new model-loader coverage passes.