### PR TITLE
Cache load3DModel results

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,68 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
+const modelCache = new Map<string, Promise<THREE.Object3D | null>>()
+
+export function getModelCacheKey(url: string): string {
+  try {
+    const parsedUrl = new URL(url, "https://tscircuit.local")
+    parsedUrl.searchParams.delete("cachebust_origin")
+
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return parsedUrl.toString()
+    }
+
+    return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&]*&?/, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
+export function getModelExtension(url: string): string {
+  try {
+    return (
+      new URL(url, "https://tscircuit.local").pathname
+        .split(".")
+        .pop()
+        ?.toLowerCase() ?? ""
+    )
+  } catch {
+    return url.split("?")[0]?.split(".").pop()?.toLowerCase() ?? ""
+  }
+}
+
+export function cloneLoadedModel(model: THREE.Object3D): THREE.Object3D {
+  const clone = model.clone(true)
+  clone.traverse((object) => {
+    if (!("material" in object)) return
+    const mesh = object as THREE.Mesh
+    if (Array.isArray(mesh.material)) {
+      mesh.material = mesh.material.map((material) => material.clone())
+    } else if (mesh.material) {
+      mesh.material = mesh.material.clone()
+    }
+  })
+  return clone
+}
+
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+  const cacheKey = getModelCacheKey(url)
+  if (!modelCache.has(cacheKey)) {
+    modelCache.set(cacheKey, load3DModelUncached(url))
+  }
+
+  const cachedModel = await modelCache.get(cacheKey)!
+  return cachedModel ? cloneLoadedModel(cachedModel) : null
+}
+
+async function load3DModelUncached(
+  url: string,
+): Promise<THREE.Object3D | null> {
+  const extension = getModelExtension(url)
+
+  if (extension === "stl") {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,16 +76,16 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (extension === "obj") {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (extension === "wrl") {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  if (extension === "gltf" || extension === "glb") {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene

--- a/tests/load-model.test.ts
+++ b/tests/load-model.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  cloneLoadedModel,
+  getModelCacheKey,
+  getModelExtension,
+} from "../src/utils/load-model"
+
+test("getModelCacheKey removes only cachebust_origin", () => {
+  expect(
+    getModelCacheKey(
+      "https://modelcdn.tscircuit.com/model.obj?uuid=abc&cachebust_origin=&pn=C1",
+    ),
+  ).toBe("https://modelcdn.tscircuit.com/model.obj?uuid=abc&pn=C1")
+
+  expect(getModelCacheKey("/models/chip.glb?cachebust_origin=123")).toBe(
+    "/models/chip.glb",
+  )
+})
+
+test("getModelExtension ignores query strings", () => {
+  expect(
+    getModelExtension("https://example.com/model.obj?cachebust_origin="),
+  ).toBe("obj")
+  expect(getModelExtension("/models/chip.glb?version=1")).toBe("glb")
+})
+
+test("cloneLoadedModel clones materials so cached instances can be styled independently", () => {
+  const material = new THREE.MeshStandardMaterial({ color: 0x00ff00 })
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material)
+
+  const cloned = cloneLoadedModel(mesh) as THREE.Mesh
+
+  expect(cloned).not.toBe(mesh)
+  expect(cloned.geometry).toBe(mesh.geometry)
+  expect(cloned.material).not.toBe(mesh.material)
+})


### PR DESCRIPTION
Adds a shared cache to load3DModel for #93.

Details:
- Caches loaded model promises by normalized URL.
- Removes cachebust_origin from cache keys while preserving meaningful query params.
- Detects model extension from the URL pathname so query strings do not break .obj/.glb/.gltf/.stl/.wrl detection.
- Returns cloned Object3D instances and clones materials so per-instance hover/translucency styling does not mutate the cached source object.

Verification:
- PATH=/private/tmp/bun-runtime/bun-darwin-aarch64:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/phil/.codex/tmp/arg0/codex-arg0SMEyBJ:/Users/phil/google-cloud-sdk/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Applications/Codex.app/Contents/Resources /private/tmp/bun-runtime/bun-darwin-aarch64/bun test tests/load-model.test.ts
- PATH=/private/tmp/bun-runtime/bun-darwin-aarch64:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/phil/.codex/tmp/arg0/codex-arg0SMEyBJ:/Users/phil/google-cloud-sdk/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Applications/Codex.app/Contents/Resources /private/tmp/bun-runtime/bun-darwin-aarch64/bun x biome check src/utils/load-model.ts tests/load-model.test.ts
- PATH=/private/tmp/bun-runtime/bun-darwin-aarch64:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/phil/.codex/tmp/arg0/codex-arg0SMEyBJ:/Users/phil/google-cloud-sdk/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Applications/Codex.app/Contents/Resources /private/tmp/bun-runtime/bun-darwin-aarch64/bun x tsc --noEmit

/claim #93