### PR TITLE
Fix OBJ loader cache key

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -20,6 +20,27 @@ if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
   window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
 }
 
+export function getGlobalObjLoaderCacheKey(url: string): string {
+  try {
+    const baseUrl =
+      typeof window !== "undefined" && window.location?.href
+        ? window.location.href
+        : "https://tscircuit.local"
+    const parsedUrl = new URL(url, baseUrl)
+    parsedUrl.searchParams.delete("cachebust_origin")
+
+    if (/^[a-z][a-z\d+\-.]*:/i.test(url)) {
+      return parsedUrl.toString()
+    }
+
+    return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&]*&?/, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
 export function useGlobalObjLoader(
   url: string | null,
 ): Object3D | null | Error {
@@ -28,21 +49,22 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const modelUrl = url
+    const cacheKey = getGlobalObjLoaderCacheKey(modelUrl)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
     async function loadAndParseObj() {
       try {
-        if (cleanUrl.endsWith(".wrl")) {
-          return await loadVrml(cleanUrl)
+        if (modelUrl.endsWith(".wrl")) {
+          return await loadVrml(modelUrl)
         }
 
-        const response = await fetch(cleanUrl)
+        const response = await fetch(modelUrl)
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
+            `Failed to fetch "${modelUrl}": ${response.status} ${response.statusText}`,
           )
         }
         const text = await response.text()
@@ -79,8 +101,8 @@ export function useGlobalObjLoader(
     }
 
     function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
+      if (cache.has(cacheKey)) {
+        const cacheItem = cache.get(cacheKey)!
         if (cacheItem.result) {
           // If we have a result, clone it
           return Promise.resolve(cacheItem.result.clone())
@@ -97,10 +119,10 @@ export function useGlobalObjLoader(
           // If the result is an Error, return it
           return result
         }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+        cache.set(cacheKey, { ...cache.get(cacheKey)!, result })
         return result
       })
-      cache.set(cleanUrl, { promise, result: null })
+      cache.set(cacheKey, { promise, result: null })
       return promise
     }
 

--- a/tests/use-global-obj-loader.test.ts
+++ b/tests/use-global-obj-loader.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { getGlobalObjLoaderCacheKey } from "../src/hooks/use-global-obj-loader"
+
+test("uses the same OBJ cache key when only cachebust_origin changes", () => {
+  const first = getGlobalObjLoaderCacheKey(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+  )
+  const second = getGlobalObjLoaderCacheKey(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+  )
+
+  expect(first).toBe(second)
+  expect(first).not.toContain("cachebust_origin")
+})
+
+test("keeps meaningful model URL parameters in the OBJ cache key", () => {
+  const first = getGlobalObjLoaderCacheKey(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c886ec2b42464573a88fc1f647577a49&pn=C5184526&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+  )
+  const second = getGlobalObjLoaderCacheKey(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=c00f29e7afb64c29bc388e168980ded2&pn=C400227&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+  )
+
+  expect(first).not.toBe(second)
+  expect(first).toContain("uuid=c886ec2b42464573a88fc1f647577a49")
+  expect(first).toContain("pn=C5184526")
+})
+
+test("normalizes relative OBJ cache keys without making them origin-specific", () => {
+  expect(
+    getGlobalObjLoaderCacheKey(
+      "/easyeda-models/chip.obj?uuid=abc&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    ),
+  ).toBe("/easyeda-models/chip.obj?uuid=abc")
+})


### PR DESCRIPTION
## Summary

- add a stable OBJ loader cache key that ignores only `cachebust_origin`
- keep loading the original model URL so request behavior does not change
- cover cache-key normalization for repeated model URLs with tests

## Testing

- `npx.cmd bun x biome format src/hooks/use-global-obj-loader.ts tests/use-global-obj-loader.test.ts`
- `npx.cmd bun test tests/use-global-obj-loader.test.ts`
- `npx.cmd bun x tsc --noEmit`

Fixes #93
/claim #93
