### PR TITLE
Support STL CAD models in the shared loader

### DIFF
--- a/src/AnyCadComponent.tsx
+++ b/src/AnyCadComponent.tsx
@@ -13,6 +13,7 @@ import { GltfModel } from "./three-components/GltfModel"
 import { JscadModel } from "./three-components/JscadModel"
 import { MixedStlModel } from "./three-components/MixedStlModel"
 import { StepModel } from "./three-components/StepModel"
+import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
 import {
   getCadLoaderTransformConfig,
   getCadLoaderTransformMatrix,
@@ -25,7 +26,6 @@ import {
 } from "./utils/get-cad-model-type"
 import { resolveModelUrl } from "./utils/resolve-model-url"
 import { tuple } from "./utils/tuple"
-import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
 
 const ModelLoadErrorReporter = ({
   error,
@@ -122,7 +122,7 @@ export const AnyCadComponent = ({
   const gltfModelType: CadModelType = cad_component.model_glb_url
     ? "glb"
     : "gltf"
-  const meshModelType: CadModelType = cad_component.model_wrl_url
+  const meshModelType = cad_component.model_wrl_url
     ? "wrl"
     : cad_component.model_stl_url
       ? "stl"
@@ -172,6 +172,7 @@ export const AnyCadComponent = ({
         <MixedStlModel
           key={`${cad_component.cad_component_id}-mixed-${url}`}
           url={url}
+          modelType={meshModelType}
           position={adjustedPosition}
           rotation={rotationOffset}
           modelOffset={modelTransform.modelPosition}

--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,7 +1,98 @@
-import { useState, useEffect } from "react"
-import type { Object3D } from "three"
-import { MTLLoader, OBJLoader } from "three-stdlib"
+import { useEffect, useState } from "react"
 import { loadVrml } from "src/utils/vrml"
+import type { Object3D } from "three"
+import * as THREE from "three"
+import { MTLLoader, OBJLoader, STLLoader } from "three-stdlib"
+
+export type GlobalObjLoaderModelType = "obj" | "wrl" | "stl"
+
+export function getModelLoaderType(
+  url: string,
+  modelType?: GlobalObjLoaderModelType,
+): GlobalObjLoaderModelType {
+  if (modelType) return modelType
+
+  const pathname = url.split("#")[0]!.split("?")[0]!.toLowerCase()
+  if (pathname.endsWith(".wrl")) return "wrl"
+  if (pathname.endsWith(".stl")) return "stl"
+  return "obj"
+}
+
+export function getModelLoaderCacheKey(
+  url: string,
+  modelType?: GlobalObjLoaderModelType,
+): string {
+  const [urlWithoutHash, hash] = url.split("#", 2)
+  const [pathname, query] = urlWithoutHash!.split("?", 2)
+  const resolvedModelType = getModelLoaderType(url, modelType)
+
+  if (!query) return `${resolvedModelType}:${url}`
+
+  const searchParams = new URLSearchParams(query)
+  searchParams.delete("cachebust_origin")
+  const normalizedQuery = searchParams.toString()
+  const normalizedUrl = `${pathname}${normalizedQuery ? `?${normalizedQuery}` : ""}${hash ? `#${hash}` : ""}`
+
+  return `${resolvedModelType}:${normalizedUrl}`
+}
+
+export async function loadModelForGlobalObjLoader(
+  url: string,
+  modelType: GlobalObjLoaderModelType,
+): Promise<Object3D | Error> {
+  try {
+    if (modelType === "wrl") {
+      return await loadVrml(url)
+    }
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch "${url}": ${response.status} ${response.statusText}`,
+      )
+    }
+
+    if (modelType === "stl") {
+      const geometry = new STLLoader().parse(await response.arrayBuffer())
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x888888,
+        metalness: 0.5,
+        roughness: 0.5,
+      })
+      return new THREE.Mesh(geometry, material)
+    }
+
+    const text = await response.text()
+    const mtlContentArr = text.match(/newmtl[\s\S]*?endmtl/g)
+
+    const objLoader = new OBJLoader()
+
+    if (mtlContentArr?.length) {
+      const mtlContent = mtlContentArr.join("\n").replace(/d 0\./g, "d 1.")
+      const objContent = text
+        .replace(/newmtl[\s\S]*?endmtl/g, "")
+        .replace(/^mtllib.*/gm, "")
+
+      const mtlLoader = new MTLLoader()
+      mtlLoader.setMaterialOptions({
+        invertTrProperty: true,
+      })
+      const materials = mtlLoader.parse(
+        mtlContent.replace(
+          /Kd\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/g,
+          "Kd $2 $2 $2",
+        ),
+        "embedded.mtl",
+      )
+      objLoader.setMaterials(materials)
+      return objLoader.parse(objContent)
+    }
+
+    return objLoader.parse(text.replace(/^mtllib.*/gm, ""))
+  } catch (error) {
+    return error as Error
+  }
+}
 
 // Define the type for our cache
 interface CacheItem {
@@ -22,65 +113,23 @@ if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
 
 export function useGlobalObjLoader(
   url: string | null,
+  modelType?: GlobalObjLoaderModelType,
 ): Object3D | null | Error {
   const [obj, setObj] = useState<Object3D | null | Error>(null)
 
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const modelUrl = url
+    const loaderModelType = getModelLoaderType(modelUrl, modelType)
+    const cacheKey = getModelLoaderCacheKey(modelUrl, loaderModelType)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
-    async function loadAndParseObj() {
-      try {
-        if (cleanUrl.endsWith(".wrl")) {
-          return await loadVrml(cleanUrl)
-        }
-
-        const response = await fetch(cleanUrl)
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
-          )
-        }
-        const text = await response.text()
-
-        const mtlContentArr = text.match(/newmtl[\s\S]*?endmtl/g)
-
-        const objLoader = new OBJLoader()
-
-        if (mtlContentArr?.length) {
-          const mtlContent = mtlContentArr.join("\n").replace(/d 0\./g, "d 1.")
-          const objContent = text
-            .replace(/newmtl[\s\S]*?endmtl/g, "")
-            .replace(/^mtllib.*/gm, "")
-
-          const mtlLoader = new MTLLoader()
-          mtlLoader.setMaterialOptions({
-            invertTrProperty: true,
-          })
-          const materials = mtlLoader.parse(
-            mtlContent.replace(
-              /Kd\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/g,
-              "Kd $2 $2 $2",
-            ),
-            "embedded.mtl",
-          )
-          objLoader.setMaterials(materials)
-          return objLoader.parse(objContent)
-        }
-
-        return objLoader.parse(text.replace(/^mtllib.*/gm, ""))
-      } catch (error) {
-        return error as Error
-      }
-    }
-
     function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
+      if (cache.has(cacheKey)) {
+        const cacheItem = cache.get(cacheKey)!
         if (cacheItem.result) {
           // If we have a result, clone it
           return Promise.resolve(cacheItem.result.clone())
@@ -92,15 +141,18 @@ export function useGlobalObjLoader(
         })
       }
       // If it's not in the cache, create a new promise and cache it
-      const promise = loadAndParseObj().then((result) => {
+      const promise = loadModelForGlobalObjLoader(
+        modelUrl,
+        loaderModelType,
+      ).then((result) => {
         if (result instanceof Error) {
           // If the result is an Error, return it
           return result
         }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+        cache.set(cacheKey, { ...cache.get(cacheKey)!, result })
         return result
       })
-      cache.set(cleanUrl, { promise, result: null })
+      cache.set(cacheKey, { promise, result: null })
       return promise
     }
 
@@ -116,7 +168,7 @@ export function useGlobalObjLoader(
     return () => {
       hasUrlChanged = true
     }
-  }, [url])
+  }, [url, modelType])
 
   return obj
 }

--- a/src/three-components/MixedStlModel.tsx
+++ b/src/three-components/MixedStlModel.tsx
@@ -1,9 +1,12 @@
-import ContainerWithTooltip from "src/ContainerWithTooltip"
-import { useGlobalObjLoader } from "src/hooks/use-global-obj-loader"
-import type { Euler, Vector3 } from "three"
 import { useMemo } from "react"
-import * as THREE from "three"
+import ContainerWithTooltip from "src/ContainerWithTooltip"
+import {
+  type GlobalObjLoaderModelType,
+  useGlobalObjLoader,
+} from "src/hooks/use-global-obj-loader"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import type { Euler, Vector3 } from "three"
+import * as THREE from "three"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 export function MixedStlModel({
@@ -20,8 +23,10 @@ export function MixedStlModel({
   isHovered,
   scale,
   isTranslucent = false,
+  modelType,
 }: {
   url: string
+  modelType?: GlobalObjLoaderModelType
   position?: Vector3 | [number, number, number]
   rotation?: Euler | [number, number, number]
   modelOffset?: [number, number, number]
@@ -35,7 +40,7 @@ export function MixedStlModel({
   scale?: number
   isTranslucent?: boolean
 }) {
-  const obj = useGlobalObjLoader(url)
+  const obj = useGlobalObjLoader(url, modelType)
   const model = useMemo(() => {
     if (obj && !(obj instanceof Error)) {
       obj.traverse((child) => {

--- a/tests/global-model-loader.test.ts
+++ b/tests/global-model-loader.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  getModelLoaderCacheKey,
+  getModelLoaderType,
+  loadModelForGlobalObjLoader,
+} from "../src/hooks/use-global-obj-loader"
+
+const triangleStl = `solid triangle
+facet normal 0 0 1
+  outer loop
+    vertex 0 0 0
+    vertex 1 0 0
+    vertex 0 1 0
+  endloop
+endfacet
+endsolid triangle`
+
+test("normalizes only cachebust_origin in shared model cache keys", () => {
+  expect(
+    getModelLoaderCacheKey(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&cachebust_origin=editor&pn=C123#mesh",
+      "obj",
+    ),
+  ).toBe(
+    "obj:https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123#mesh",
+  )
+})
+
+test("uses explicit STL type for extensionless model URLs", () => {
+  const url =
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123&cachebust_origin=editor"
+
+  expect(getModelLoaderType(url, "stl")).toBe("stl")
+  expect(getModelLoaderCacheKey(url, "stl")).toBe(
+    "stl:https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123",
+  )
+})
+
+test("loads STL models through the shared model loader", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () =>
+    new Response(triangleStl, {
+      status: 200,
+      statusText: "OK",
+    })
+
+  try {
+    const model = await loadModelForGlobalObjLoader(
+      "https://example.com/model.stl?cachebust_origin=editor",
+      "stl",
+    )
+
+    expect(model).toBeInstanceOf(THREE.Mesh)
+    const position = (model as THREE.Mesh).geometry.attributes.position
+    expect(position).toBeDefined()
+    expect(position!.count).toBe(3)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})


### PR DESCRIPTION
## Summary
- pass the CAD mesh model type into `MixedStlModel` so extensionless CDN URLs can still use the right loader
- add an STL path to the existing shared model loader instead of parsing `model_stl_url` responses as OBJ text
- keep cache keys stable by stripping only `cachebust_origin` and namespacing by loader type
- add regression coverage for extensionless STL URLs, cache-key normalization, and STL parsing

Fixes a remaining model-loading gap for #93.

/claim #93

## Verification
- `bun test tests/global-model-loader.test.ts`
- `bun x biome check src/AnyCadComponent.tsx src/hooks/use-global-obj-loader.ts src/three-components/MixedStlModel.tsx tests/global-model-loader.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun run test:node-bundle`
- `git diff --check`

## Full test note
- `bun test` has 3 existing unrelated failures on current main expectations: two `tests/preprocess-circuit-json.test.ts` z-offset assertions expect 0.8/1.8 while current output is 0.7/1.7, and `tests/outline-bounds.test.ts` expects `rgb(39,89,56)` while current output contains nearby soldermask colors. The new focused STL loader test passes.

