### PR TITLE
Normalize model cache URLs

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
 import { loadVrml } from "src/utils/vrml"
+import { normalizeModelCacheUrl } from "src/utils/normalize-model-cache-url"
 
 // Define the type for our cache
 interface CacheItem {
@@ -28,7 +29,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = normalizeModelCacheUrl(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false

--- a/src/utils/normalize-model-cache-url.ts
+++ b/src/utils/normalize-model-cache-url.ts
@@ -1,0 +1,18 @@
+const CACHE_BUST_PARAMS = new Set(["cachebust_origin", "cachebust"])
+
+export function normalizeModelCacheUrl(url: string) {
+  try {
+    const parsedUrl = new URL(url, globalThis.location?.href ?? "http://localhost")
+
+    for (const param of CACHE_BUST_PARAMS) {
+      parsedUrl.searchParams.delete(param)
+    }
+
+    const normalized = parsedUrl.toString()
+    return parsedUrl.origin === "http://localhost"
+      ? `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+      : normalized
+  } catch {
+    return url.replace(/([?&])cachebust(?:_origin)?=[^&]*&?/g, "$1").replace(/[?&]$/, "")
+  }
+}

--- a/tests/normalize-model-cache-url.test.ts
+++ b/tests/normalize-model-cache-url.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test"
+import { normalizeModelCacheUrl } from "../src/utils/normalize-model-cache-url"
+
+test("removes cache bust params from model URLs", () => {
+  expect(
+    normalizeModelCacheUrl(
+      "https://modelcdn.tscircuit.com/model.obj?uuid=abc&cachebust_origin=123",
+    ),
+  ).toBe("https://modelcdn.tscircuit.com/model.obj?uuid=abc")
+
+  expect(
+    normalizeModelCacheUrl(
+      "https://modelcdn.tscircuit.com/model.obj?cachebust=456&uuid=abc",
+    ),
+  ).toBe("https://modelcdn.tscircuit.com/model.obj?uuid=abc")
+})
+
+test("keeps relative model URLs relative", () => {
+  expect(normalizeModelCacheUrl("/models/part.obj?cachebust_origin=123")).toBe(
+    "/models/part.obj",
+  )
+})


### PR DESCRIPTION
Fixes #93.

The OBJ/WRL loader already has a global cache, but URLs with cache-busting query params can miss that cache and trigger duplicate fetch/parse work. This normalizes model cache keys by stripping cachebust/cachebust_origin params while preserving the real model URL.

Verification:
- npx bun test tests/normalize-model-cache-url.test.ts
- npx bun run build