### PR TITLE
Normalize cachebust_origin in OBJ loader cache keys

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
 import { loadVrml } from "src/utils/vrml"
+import { normalizeModelCacheUrl } from "src/utils/normalize-model-cache-url"
 
 // Define the type for our cache
 interface CacheItem {
@@ -28,7 +29,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = normalizeModelCacheUrl(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false

--- a/src/utils/normalize-model-cache-url.ts
+++ b/src/utils/normalize-model-cache-url.ts
@@ -1,0 +1,8 @@
+export const normalizeModelCacheUrl = (url: string): string => {
+  return url
+    .replace(/([?&])cachebust_origin=[^&#]*(&)?/g, (_match, separator, hasMore) =>
+      separator === "?" && hasMore ? "?" : hasMore ? "&" : "",
+    )
+    .replace(/\?&/, "?")
+    .replace(/[?&]$/, "")
+}

--- a/src/utils/normalize-model-cache-url.ts
+++ b/src/utils/normalize-model-cache-url.ts
@@ -1,7 +1,9 @@
 export const normalizeModelCacheUrl = (url: string): string => {
   return url
-    .replace(/([?&])cachebust_origin=[^&#]*(&)?/g, (_match, separator, hasMore) =>
-      separator === "?" && hasMore ? "?" : hasMore ? "&" : "",
+    .replace(
+      /([?&])cachebust_origin=[^&#]*(&)?/g,
+      (_match, separator, hasMore) =>
+        separator === "?" && hasMore ? "?" : hasMore ? "&" : "",
     )
     .replace(/\?&/, "?")
     .replace(/[?&]$/, "")

--- a/tests/normalize-model-cache-url.test.ts
+++ b/tests/normalize-model-cache-url.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { normalizeModelCacheUrl } from "../src/utils/normalize-model-cache-url"
+
+test("removes cachebust_origin when it is the only query param", () => {
+  expect(
+    normalizeModelCacheUrl(
+      "https://cdn.example.com/model.obj?cachebust_origin=abc123",
+    ),
+  ).toBe("https://cdn.example.com/model.obj")
+})
+
+test("removes cachebust_origin while preserving other query params", () => {
+  expect(
+    normalizeModelCacheUrl(
+      "https://cdn.example.com/model.obj?uuid=1&cachebust_origin=abc123&pn=C123",
+    ),
+  ).toBe("https://cdn.example.com/model.obj?uuid=1&pn=C123")
+})
+
+test("removes trailing blank cachebust_origin param", () => {
+  expect(
+    normalizeModelCacheUrl(
+      "https://cdn.example.com/model.obj?uuid=1&pn=C123&cachebust_origin=",
+    ),
+  ).toBe("https://cdn.example.com/model.obj?uuid=1&pn=C123")
+})


### PR DESCRIPTION
## Summary
- add `normalizeModelCacheUrl` helper to strip `cachebust_origin` query params robustly
- use normalized URL as the cache key in `useGlobalObjLoader`
- add focused regression tests for different cachebust query shapes

This addresses duplicate cache entries and repeated model loads caused by cachebust variants of the same model URL.

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #93