### PR TITLE
Detect model extensions before query strings

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,16 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
+export const getModelFileExtension = (url: string) => {
+  const pathWithoutQuery = url.split(/[?#]/)[0]?.toLowerCase() ?? ""
+  const match = pathWithoutQuery.match(/\.([a-z0-9]+)$/)
+  return match?.[1] ?? ""
+}
+
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+  const extension = getModelFileExtension(url)
+
+  if (extension === "stl") {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,16 +24,16 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (extension === "obj") {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (extension === "wrl") {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  if (extension === "gltf" || extension === "glb") {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene

--- a/tests/load-model-url-extension.test.ts
+++ b/tests/load-model-url-extension.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { getModelFileExtension } from "../src/utils/load-model"
+
+test("gets model file extension from URLs with query strings", () => {
+  expect(
+    getModelFileExtension(
+      "https://cdn.example.com/models/chip.glb?cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+    ),
+  ).toBe("glb")
+  expect(getModelFileExtension("/models/enclosure.obj?version=2#mesh")).toBe(
+    "obj",
+  )
+  expect(getModelFileExtension("/models/part.STL?cachebust_origin=")).toBe(
+    "stl",
+  )
+  expect(getModelFileExtension("/models/legacy.wrl#view")).toBe("wrl")
+})
+
+test("returns an empty extension for unsupported or extensionless model URLs", () => {
+  expect(getModelFileExtension("/models/download?uuid=abc123")).toBe("")
+  expect(getModelFileExtension("/models/readme.txt?download=1")).toBe("txt")
+})


### PR DESCRIPTION
## Summary

/claim #93

- adds `getModelFileExtension` so `load3DModel` detects file type from the URL path before query/hash suffixes
- preserves the original URL passed to STL/OBJ/WRL/GLTF loaders
- fixes valid URLs like `model.glb?cachebust_origin=...` being treated as unsupported
- adds regression coverage for `.glb`, `.obj`, `.stl`, and `.wrl` URLs with query/hash suffixes

## Verification

- `npx --yes bun@latest test tests/load-model-url-extension.test.ts`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest x biome check src/utils/load-model.ts tests/load-model-url-extension.test.ts`
- `npx --yes bun@latest run build`
- `git diff --check`

## Full test note

- `npx --yes bun@latest test` has 3 existing unrelated failures on current main: two `tests/preprocess-circuit-json.test.ts` z-offset assertions expect `0.8`/`1.8` while current output is `0.7`/`1.7`, and `tests/outline-bounds.test.ts` expects `rgb(39,89,56)` while current SVG contains nearby soldermask colors.

AI-assisted with Codex; I reviewed the diff and ran the checks above before opening this PR.