### PR TITLE
Deduplicate OBJ loader cache across cachebust_origin query variants

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -28,8 +28,8 @@ export function useGlobalObjLoader(
 
   useEffect(() => {
     if (!url) return
-
-    const cacheKey = normalizeObjCacheUrl(url)
+    const fetchUrl = url
+    const cacheKey = normalizeObjCacheUrl(fetchUrl)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
@@ -37,13 +37,13 @@ export function useGlobalObjLoader(
     async function loadAndParseObj() {
       try {
         if (cacheKey.endsWith(".wrl")) {
-          return await loadVrml(url)
+          return await loadVrml(fetchUrl)
         }
 
-        const response = await fetch(url)
+        const response = await fetch(fetchUrl)
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch "${url}": ${response.status} ${response.statusText}`,
+            `Failed to fetch "${fetchUrl}": ${response.status} ${response.statusText}`,
           )
         }
         const text = await response.text()

--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -28,8 +28,8 @@ export function useGlobalObjLoader(
 
   useEffect(() => {
     if (!url) return
-    const fetchUrl = url
-    const cacheKey = normalizeObjCacheUrl(fetchUrl)
+    const currentUrl = url
+    const cacheKey = normalizeObjCacheUrl(currentUrl)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
@@ -37,13 +37,13 @@ export function useGlobalObjLoader(
     async function loadAndParseObj() {
       try {
         if (cacheKey.endsWith(".wrl")) {
-          return await loadVrml(fetchUrl)
+          return await loadVrml(currentUrl)
         }
 
-        const response = await fetch(fetchUrl)
+        const response = await fetch(currentUrl)
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch "${fetchUrl}": ${response.status} ${response.statusText}`,
+            `Failed to fetch "${currentUrl}": ${response.status} ${response.statusText}`,
           )
         }
         const text = await response.text()

--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
+import { normalizeObjCacheUrl } from "src/utils/normalize-obj-cache-url"
 import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
@@ -28,21 +29,21 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cacheKey = normalizeObjCacheUrl(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
     async function loadAndParseObj() {
       try {
-        if (cleanUrl.endsWith(".wrl")) {
-          return await loadVrml(cleanUrl)
+        if (cacheKey.endsWith(".wrl")) {
+          return await loadVrml(url)
         }
 
-        const response = await fetch(cleanUrl)
+        const response = await fetch(url)
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
+            `Failed to fetch "${url}": ${response.status} ${response.statusText}`,
           )
         }
         const text = await response.text()
@@ -79,8 +80,8 @@ export function useGlobalObjLoader(
     }
 
     function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
+      if (cache.has(cacheKey)) {
+        const cacheItem = cache.get(cacheKey)!
         if (cacheItem.result) {
           // If we have a result, clone it
           return Promise.resolve(cacheItem.result.clone())
@@ -97,10 +98,10 @@ export function useGlobalObjLoader(
           // If the result is an Error, return it
           return result
         }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+        cache.set(cacheKey, { ...cache.get(cacheKey)!, result })
         return result
       })
-      cache.set(cleanUrl, { promise, result: null })
+      cache.set(cacheKey, { promise, result: null })
       return promise
     }
 

--- a/src/utils/normalize-obj-cache-url.ts
+++ b/src/utils/normalize-obj-cache-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns a stable key for OBJ/WRL model fetch+parse caching.
+ * EasyEDA CDN URLs often differ only by `cachebust_origin=...`, which should not
+ * split the cache (same bytes, redundant loads).
+ */
+export function normalizeObjCacheUrl(url: string): string {
+  const trimmed = url.replace(/&cachebust_origin=$/, "")
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      parsed.searchParams.delete("cachebust_origin")
+      return parsed.toString()
+    }
+  } catch {
+    // non-absolute URL or invalid
+  }
+  return trimmed
+}

--- a/tests/normalize-obj-cache-url.test.ts
+++ b/tests/normalize-obj-cache-url.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { normalizeObjCacheUrl } from "../src/utils/normalize-obj-cache-url"
+
+test("strips cachebust_origin for identical CDN identity", () => {
+  const a =
+    "https://modelcdn.example/easyeda_models/download?uuid=abc&pn=C1&cachebust_origin=https%3A%2F%2Fa.com"
+  const b =
+    "https://modelcdn.example/easyeda_models/download?uuid=abc&pn=C1&cachebust_origin=https%3A%2F%2Fb.com"
+  expect(normalizeObjCacheUrl(a)).toBe(normalizeObjCacheUrl(b))
+})
+
+test("legacy empty cachebust suffix at end of query", () => {
+  const u =
+    "https://modelcdn.example/easyeda_models/download?uuid=abc&cachebust_origin="
+  expect(normalizeObjCacheUrl(u)).toBe(
+    "https://modelcdn.example/easyeda_models/download?uuid=abc",
+  )
+})


### PR DESCRIPTION
Fixes #93

useGlobalObjLoader keyed the in-memory cache by the raw URL. EasyEDA model URLs often include cachebust_origin=..., so identical OBJ files were parsed repeatedly when components only differed by that query parameter.

- Add 
ormalizeObjCacheUrl() to strip cachebust_origin for stable cache keys (still fetch using the original URL).
- Add unit tests for the normalizer.

/claim #93