### PR TITLE
Optimize repeated OBJ model loading

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,11 +1,15 @@
 import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
+import {
+  cloneObjModelForScene,
+  getObjModelCacheKey,
+} from "src/utils/obj-model-cache"
 import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
 interface CacheItem {
-  promise: Promise<any>
+  promise: Promise<Object3D | Error>
   result: Object3D | null
 }
 
@@ -28,21 +32,22 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const modelUrl = url
+    const cacheKey = getObjModelCacheKey(modelUrl)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
     async function loadAndParseObj() {
       try {
-        if (cleanUrl.endsWith(".wrl")) {
-          return await loadVrml(cleanUrl)
+        if (modelUrl.endsWith(".wrl")) {
+          return await loadVrml(modelUrl)
         }
 
-        const response = await fetch(cleanUrl)
+        const response = await fetch(modelUrl)
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
+            `Failed to fetch "${modelUrl}": ${response.status} ${response.statusText}`,
           )
         }
         const text = await response.text()
@@ -79,16 +84,15 @@ export function useGlobalObjLoader(
     }
 
     function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
+      if (cache.has(cacheKey)) {
+        const cacheItem = cache.get(cacheKey)!
         if (cacheItem.result) {
-          // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
+          return Promise.resolve(cloneObjModelForScene(cacheItem.result))
         }
         // If we're still loading, return the existing promise
         return cacheItem.promise.then((result) => {
           if (result instanceof Error) return result
-          return result.clone()
+          return cloneObjModelForScene(result)
         })
       }
       // If it's not in the cache, create a new promise and cache it
@@ -97,11 +101,14 @@ export function useGlobalObjLoader(
           // If the result is an Error, return it
           return result
         }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+        cache.set(cacheKey, { ...cache.get(cacheKey)!, result })
         return result
       })
-      cache.set(cleanUrl, { promise, result: null })
-      return promise
+      cache.set(cacheKey, { promise, result: null })
+      return promise.then((result) => {
+        if (result instanceof Error) return result
+        return cloneObjModelForScene(result)
+      })
     }
 
     loadUrl()

--- a/src/utils/obj-model-cache.ts
+++ b/src/utils/obj-model-cache.ts
@@ -1,0 +1,44 @@
+import * as THREE from "three"
+
+const CACHEBUST_PARAM = "cachebust_origin"
+
+export function getObjModelCacheKey(modelUrl: string): string {
+  try {
+    const url = new URL(modelUrl, "https://tscircuit.local")
+    url.searchParams.delete(CACHEBUST_PARAM)
+
+    if (!/^[a-z][a-z\d+.-]*:/i.test(modelUrl) || modelUrl.startsWith(".")) {
+      return `${url.pathname}${url.search}${url.hash}`
+    }
+
+    return url.toString()
+  } catch {
+    return modelUrl
+      .replace(new RegExp(`([?&])${CACHEBUST_PARAM}=[^&#]*&?`), "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
+export function cloneObjModelForScene(model: THREE.Object3D): THREE.Object3D {
+  const clone = model.clone(true)
+  const materialCloneCache = new Map<THREE.Material, THREE.Material>()
+
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.material) return
+
+    const cloneMaterial = (material: THREE.Material) => {
+      let clonedMaterial = materialCloneCache.get(material)
+      if (!clonedMaterial) {
+        clonedMaterial = material.clone()
+        materialCloneCache.set(material, clonedMaterial)
+      }
+      return clonedMaterial
+    }
+
+    child.material = Array.isArray(child.material)
+      ? child.material.map(cloneMaterial)
+      : cloneMaterial(child.material)
+  })
+
+  return clone
+}

--- a/tests/obj-model-cache.test.ts
+++ b/tests/obj-model-cache.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  cloneObjModelForScene,
+  getObjModelCacheKey,
+} from "../src/utils/obj-model-cache"
+
+test("normalizes modelcdn cachebust_origin query params", () => {
+  const first = getObjModelCacheKey(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+  )
+  const second = getObjModelCacheKey(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123&cachebust_origin=http%3A%2F%2Flocalhost%3A3020",
+  )
+
+  expect(first).toBe(second)
+  expect(first).toBe(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123",
+  )
+})
+
+test("normalizes empty cachebust_origin query params", () => {
+  expect(
+    getObjModelCacheKey(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123&cachebust_origin=",
+    ),
+  ).toBe(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123",
+  )
+})
+
+test("keeps independent material instances for cloned cached models", () => {
+  const templateMaterial = new THREE.MeshStandardMaterial({ opacity: 1 })
+  const template = new THREE.Group()
+  template.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), templateMaterial))
+
+  const first = cloneObjModelForScene(template)
+  const second = cloneObjModelForScene(template)
+  const firstMesh = first.children[0] as THREE.Mesh
+  const secondMesh = second.children[0] as THREE.Mesh
+  const firstMaterial = firstMesh.material as THREE.Material
+  const secondMaterial = secondMesh.material as THREE.Material
+
+  firstMaterial.opacity = 0.5
+
+  expect(first).not.toBe(template)
+  expect(firstMaterial).not.toBe(templateMaterial)
+  expect(firstMaterial).not.toBe(secondMaterial)
+  expect(secondMaterial.opacity).toBe(1)
+})


### PR DESCRIPTION
/claim #93

## Summary
- normalize OBJ/WRL model cache keys by stripping `cachebust_origin`, so the same model URL from different editor origins shares one cached parse
- always return cloned Object3D instances from the cache, including the first load, so scene attachment and material transparency changes do not mutate the cached template
- clone materials for each model instance to avoid translucent/hover state leaking between repeated components

## Tests
- `npx bun test tests/obj-model-cache.test.ts`
- `npx tsc --noEmit`
- `npm run build`

Full `npx bun test` still has pre-existing failures in `outline-bounds.test.ts` and `preprocess-circuit-json.test.ts` on current dependency install; this PR's focused regression test passes.

AI-assisted with Codex; I reviewed the diff.