### PR TITLE
Cache utility-loaded 3D models

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,81 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
+type CachedModel = {
+  promise: Promise<THREE.Object3D | null>
+  result: THREE.Object3D | null
+}
+
+const modelCache = new Map<string, CachedModel>()
+
+export const getModelExtensionFromUrl = (url: string): string => {
+  try {
+    const parsedUrl = new URL(url, "https://model.local")
+    return parsedUrl.pathname.split(".").pop()?.toLowerCase() ?? ""
+  } catch {
+    return url.split(/[?#]/)[0]?.split(".").pop()?.toLowerCase() ?? ""
+  }
+}
+
+export const getModelCacheKey = (url: string): string => {
+  try {
+    const parsedUrl = new URL(url, "https://model.local")
+    parsedUrl.searchParams.delete("cachebust_origin")
+    return parsedUrl.href.replace("https://model.local/", "")
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&#]*&?/g, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
+export const cloneModelForUse = (model: THREE.Object3D): THREE.Object3D => {
+  const clone = model.clone(true)
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    child.geometry = child.geometry.clone()
+    if (Array.isArray(child.material)) {
+      child.material = child.material.map((material) => material.clone())
+    } else if (child.material) {
+      child.material = child.material.clone()
+    }
+  })
+  return clone
+}
+
+export const clearModelCacheForTests = () => {
+  modelCache.clear()
+}
+
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+  const cacheKey = getModelCacheKey(url)
+  const cached = modelCache.get(cacheKey)
+  if (cached?.result) return cloneModelForUse(cached.result)
+  if (cached) {
+    const model = await cached.promise
+    return model ? cloneModelForUse(model) : null
+  }
+
+  const promise = load3DModelUncached(url)
+  modelCache.set(cacheKey, { promise, result: null })
+
+  try {
+    const model = await promise
+    modelCache.set(cacheKey, { promise, result: model })
+    return model ? cloneModelForUse(model) : null
+  } catch (error) {
+    modelCache.delete(cacheKey)
+    throw error
+  }
+}
+
+async function load3DModelUncached(
+  url: string,
+): Promise<THREE.Object3D | null> {
+  const extension = getModelExtensionFromUrl(url)
+
+  if (extension === "stl") {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,16 +89,16 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (extension === "obj") {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (extension === "wrl") {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  if (extension === "gltf" || extension === "glb") {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene

--- a/tests/load-model.test.ts
+++ b/tests/load-model.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  cloneModelForUse,
+  getModelCacheKey,
+  getModelExtensionFromUrl,
+} from "src/utils/load-model"
+
+test("detects model extensions from URLs with query strings and hashes", () => {
+  expect(
+    getModelExtensionFromUrl(
+      "https://modelcdn.tscircuit.com/packages/model.glb?cachebust_origin=abc#viewer",
+    ),
+  ).toBe("glb")
+  expect(getModelExtensionFromUrl("/models/part.obj?version=1")).toBe("obj")
+  expect(getModelExtensionFromUrl("part.stl#section")).toBe("stl")
+})
+
+test("normalizes cachebust_origin without dropping meaningful query params", () => {
+  expect(
+    getModelCacheKey(
+      "https://modelcdn.tscircuit.com/download?uuid=123&cachebust_origin=abc&pn=C1",
+    ),
+  ).toBe("https://modelcdn.tscircuit.com/download?uuid=123&pn=C1")
+  expect(getModelCacheKey("/models/part.glb?cachebust_origin=abc")).toBe(
+    "models/part.glb",
+  )
+})
+
+test("clones model geometry and materials for independent instances", () => {
+  const material = new THREE.MeshStandardMaterial({ color: 0xff0000 })
+  const geometry = new THREE.BoxGeometry(1, 1, 1)
+  const mesh = new THREE.Mesh(geometry, material)
+  const group = new THREE.Group()
+  group.add(mesh)
+
+  const clone = cloneModelForUse(group)
+  const clonedMesh = clone.children[0] as THREE.Mesh
+
+  expect(clone).not.toBe(group)
+  expect(clonedMesh.geometry).not.toBe(geometry)
+  expect(clonedMesh.material).not.toBe(material)
+})


### PR DESCRIPTION
Fixes #93

/claim #93

## Summary
- add normalized model extension detection for URLs with query strings or hashes in `load3DModel`
- cache in-flight and completed utility-loaded models by URL, ignoring only `cachebust_origin`
- return cloned model instances with cloned geometry/materials so repeated model usage does not share mutable render state
- add focused tests for extension detection, cache-key normalization, and clone isolation

## Test plan
- bun test tests/load-model.test.ts
- bun run format:check src/utils/load-model.ts tests/load-model.test.ts
- bun run build

AI-assisted with Codex; I reviewed the diff and kept the change scoped to the remaining `load3DModel` utility path.