### PR TITLE
fix: normalize obj loader cache keys

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -20,6 +20,20 @@ if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
   window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
 }
 
+export function getObjLoaderCacheKey(url: string): string {
+  try {
+    const parsedUrl = new URL(url, window.location.href)
+    parsedUrl.searchParams.delete("cachebust_origin")
+    parsedUrl.hash = ""
+    parsedUrl.searchParams.sort()
+    return parsedUrl.href
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&]*&?/g, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
 export function useGlobalObjLoader(
   url: string | null,
 ): Object3D | null | Error {
@@ -28,21 +42,22 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const modelUrl = url.replace(/&cachebust_origin=$/, "")
+    const cacheKey = getObjLoaderCacheKey(modelUrl)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
     async function loadAndParseObj() {
       try {
-        if (cleanUrl.endsWith(".wrl")) {
-          return await loadVrml(cleanUrl)
+        if (modelUrl.endsWith(".wrl")) {
+          return await loadVrml(modelUrl)
         }
 
-        const response = await fetch(cleanUrl)
+        const response = await fetch(modelUrl)
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
+            `Failed to fetch "${modelUrl}": ${response.status} ${response.statusText}`,
           )
         }
         const text = await response.text()
@@ -78,9 +93,9 @@ export function useGlobalObjLoader(
       }
     }
 
-    function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
+    function loadCachedUrl() {
+      if (cache.has(cacheKey)) {
+        const cacheItem = cache.get(cacheKey)!
         if (cacheItem.result) {
           // If we have a result, clone it
           return Promise.resolve(cacheItem.result.clone())
@@ -97,14 +112,14 @@ export function useGlobalObjLoader(
           // If the result is an Error, return it
           return result
         }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+        cache.set(cacheKey, { ...cache.get(cacheKey)!, result })
         return result
       })
-      cache.set(cleanUrl, { promise, result: null })
+      cache.set(cacheKey, { promise, result: null })
       return promise
     }
 
-    loadUrl()
+    loadCachedUrl()
       .then((result) => {
         if (hasUrlChanged) return
         setObj(result)


### PR DESCRIPTION
Fixes #93
/claim #93

## Summary
- normalize OBJ/WRL loader cache keys by stripping `cachebust_origin`
- sort remaining query params and ignore URL hashes for cache lookup
- keep the original model URL for the actual fetch/load request

## Verification
- `bun run format:check`
- `bun run build`
- `bun run test:node-bundle`
- static assertion that the cache key helper strips `cachebust_origin` while fetch still uses the original model URL
