### PR TITLE
Fix OBJ loader cache key and material cloning

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react"
-import type { Object3D } from "three"
-import { MTLLoader, OBJLoader } from "three-stdlib"
+import { useEffect, useState } from "react"
 import { loadVrml } from "src/utils/vrml"
+import type { Material, Object3D } from "three"
+import { MTLLoader, OBJLoader } from "three-stdlib"
 
 // Define the type for our cache
 interface CacheItem {
@@ -20,6 +20,46 @@ if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
   window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
 }
 
+export function getModelLoaderCacheKey(url: string): string {
+  const hashIndex = url.indexOf("#")
+  const urlWithoutHash = hashIndex === -1 ? url : url.slice(0, hashIndex)
+  const hash = hashIndex === -1 ? "" : url.slice(hashIndex)
+  const queryIndex = urlWithoutHash.indexOf("?")
+
+  if (queryIndex === -1) {
+    return url
+  }
+
+  const path = urlWithoutHash.slice(0, queryIndex)
+  const query = urlWithoutHash.slice(queryIndex + 1)
+  const searchParams = new URLSearchParams(query)
+  searchParams.delete("cachebust_origin")
+
+  const cleanQuery = searchParams.toString()
+  return `${path}${cleanQuery ? `?${cleanQuery}` : ""}${hash}`
+}
+
+function cloneMaterial(material: Material | Material[]): Material | Material[] {
+  return Array.isArray(material)
+    ? material.map((materialItem) => materialItem.clone())
+    : material.clone()
+}
+
+export function cloneObject3DForModelInstance(model: Object3D): Object3D {
+  const clone = model.clone(true)
+
+  clone.traverse((child) => {
+    const childWithMaterial = child as Object3D & {
+      material?: Material | Material[]
+    }
+    if (!childWithMaterial.material) return
+
+    childWithMaterial.material = cloneMaterial(childWithMaterial.material)
+  })
+
+  return clone
+}
+
 export function useGlobalObjLoader(
   url: string | null,
 ): Object3D | null | Error {
@@ -28,7 +68,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = getModelLoaderCacheKey(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
@@ -82,13 +122,14 @@ export function useGlobalObjLoader(
       if (cache.has(cleanUrl)) {
         const cacheItem = cache.get(cleanUrl)!
         if (cacheItem.result) {
-          // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
+          return Promise.resolve(
+            cloneObject3DForModelInstance(cacheItem.result),
+          )
         }
         // If we're still loading, return the existing promise
         return cacheItem.promise.then((result) => {
           if (result instanceof Error) return result
-          return result.clone()
+          return cloneObject3DForModelInstance(result)
         })
       }
       // If it's not in the cache, create a new promise and cache it

--- a/tests/use-global-obj-loader.test.ts
+++ b/tests/use-global-obj-loader.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { BoxGeometry, Group, Mesh, MeshBasicMaterial } from "three"
+import {
+  cloneObject3DForModelInstance,
+  getModelLoaderCacheKey,
+} from "../src/hooks/use-global-obj-loader"
+
+test("normalizes cachebust_origin without dropping meaningful query params", () => {
+  expect(getModelLoaderCacheKey("/models/chip.obj?cachebust_origin=abc")).toBe(
+    "/models/chip.obj",
+  )
+  expect(
+    getModelLoaderCacheKey(
+      "/models/chip.obj?variant=small&cachebust_origin=abc",
+    ),
+  ).toBe("/models/chip.obj?variant=small")
+  expect(getModelLoaderCacheKey("models/chip.obj?cachebust_origin=abc")).toBe(
+    "models/chip.obj",
+  )
+  expect(
+    getModelLoaderCacheKey(
+      "https://cdn.example.com/chip.wrl?cachebust_origin=abc&variant=small#mesh",
+    ),
+  ).toBe("https://cdn.example.com/chip.wrl?variant=small#mesh")
+})
+
+test("clones cached Object3D instances with independent materials", () => {
+  const sourceMaterial = new MeshBasicMaterial({
+    opacity: 1,
+    transparent: false,
+  })
+  const sourceMesh = new Mesh(new BoxGeometry(1, 1, 1), sourceMaterial)
+  const source = new Group()
+  source.add(sourceMesh)
+
+  const clone = cloneObject3DForModelInstance(source)
+  const clonedMesh = clone.children[0] as Mesh
+  const clonedMaterial = clonedMesh.material as MeshBasicMaterial
+
+  expect(clonedMaterial).not.toBe(sourceMaterial)
+
+  clonedMaterial.transparent = true
+  clonedMaterial.opacity = 0.4
+
+  expect(sourceMaterial.transparent).toBe(false)
+  expect(sourceMaterial.opacity).toBe(1)
+})


### PR DESCRIPTION
/claim #93

## Summary
- normalize `cachebust_origin` out of `useGlobalObjLoader` cache keys regardless of query parameter position while preserving meaningful query params and hashes
- clone cached model materials per returned Object3D instance so hover/translucency mutations do not leak between repeated model instances
- add regression coverage for cache-key normalization and material isolation

## Verification
- `bunx biome check src/hooks/use-global-obj-loader.ts tests/use-global-obj-loader.test.ts --write`
- `bun test tests/use-global-obj-loader.test.ts`
- `bun run build`
- `bun run test:node-bundle`

Note: `bun test` still has unrelated existing failures in `tests/preprocess-circuit-json.test.ts` and `tests/outline-bounds.test.ts` around board z offsets/SVG soldermask color expectations; the new targeted regression test passes.
