### PR TITLE
Dispose glTF model resources on cleanup

### DIFF
--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -5,6 +5,7 @@ import { useThree } from "src/react-three/ThreeContext"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import { disposeObject3DResources } from "src/utils/dispose-object3d-resources"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 const DEFAULT_ENV_MAP_INTENSITY = 1.25
@@ -57,30 +58,18 @@ export function GltfModel({
     if (!gltfUrl) return
     const loader = new GLTFLoader()
     let isMounted = true
+    let loadedScene: THREE.Group | null = null
+    setModel(null)
+    setLoadError(null)
     loader.load(
       gltfUrl,
       (gltf) => {
-        if (!isMounted) return
+        if (!isMounted) {
+          disposeObject3DResources(gltf.scene)
+          return
+        }
         const scene = gltf.scene
-
-        scene.traverse((child) => {
-          if (child instanceof THREE.Mesh && child.material) {
-            const setMaterialTransparency = (mat: THREE.Material) => {
-              mat.transparent = isTranslucent
-              mat.opacity = isTranslucent ? 0.5 : 1
-              mat.depthWrite = !isTranslucent
-              mat.needsUpdate = true
-            }
-
-            if (Array.isArray(child.material)) {
-              child.material.forEach(setMaterialTransparency)
-            } else {
-              setMaterialTransparency(child.material)
-            }
-
-            child.renderOrder = isTranslucent ? 2 : 1
-          }
-        })
+        loadedScene = scene
 
         setModel(scene)
       },
@@ -97,8 +86,34 @@ export function GltfModel({
     )
     return () => {
       isMounted = false
+      if (loadedScene) {
+        disposeObject3DResources(loadedScene)
+      }
     }
-  }, [gltfUrl, isTranslucent])
+  }, [gltfUrl])
+
+  useEffect(() => {
+    if (!model) return
+
+    model.traverse((child) => {
+      if (!(child instanceof THREE.Mesh) || !child.material) return
+
+      const setMaterialTransparency = (mat: THREE.Material) => {
+        mat.transparent = isTranslucent
+        mat.opacity = isTranslucent ? 0.5 : 1
+        mat.depthWrite = !isTranslucent
+        mat.needsUpdate = true
+      }
+
+      if (Array.isArray(child.material)) {
+        child.material.forEach(setMaterialTransparency)
+      } else {
+        setMaterialTransparency(child.material)
+      }
+
+      child.renderOrder = isTranslucent ? 2 : 1
+    })
+  }, [model, isTranslucent])
 
   useEffect(() => {
     if (!model || !renderer) return

--- a/src/utils/dispose-object3d-resources.ts
+++ b/src/utils/dispose-object3d-resources.ts
@@ -1,0 +1,44 @@
+import * as THREE from "three"
+
+function disposeMaterialTextures(
+  material: THREE.Material,
+  disposedTextures: Set<THREE.Texture>,
+) {
+  for (const [key, value] of Object.entries(material)) {
+    if (key === "envMap") continue
+    if (value && typeof value === "object" && "isTexture" in value) {
+      const texture = value as THREE.Texture
+      if (texture.isTexture && !disposedTextures.has(texture)) {
+        texture.dispose()
+        disposedTextures.add(texture)
+      }
+    }
+  }
+}
+
+export function disposeObject3DResources(object: THREE.Object3D) {
+  const disposedGeometries = new Set<THREE.BufferGeometry>()
+  const disposedMaterials = new Set<THREE.Material>()
+  const disposedTextures = new Set<THREE.Texture>()
+
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    const geometry = child.geometry
+    if (geometry && !disposedGeometries.has(geometry)) {
+      geometry.dispose()
+      disposedGeometries.add(geometry)
+    }
+
+    const materials = Array.isArray(child.material)
+      ? child.material
+      : [child.material]
+
+    for (const material of materials) {
+      if (!material || disposedMaterials.has(material)) continue
+      disposeMaterialTextures(material, disposedTextures)
+      material.dispose()
+      disposedMaterials.add(material)
+    }
+  })
+}

--- a/tests/dispose-object3d-resources.test.ts
+++ b/tests/dispose-object3d-resources.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { disposeObject3DResources } from "../src/utils/dispose-object3d-resources"
+
+test("disposes shared geometries, materials, and textures once", () => {
+  const object = new THREE.Group()
+  const geometry = new THREE.BufferGeometry()
+  const texture = new THREE.Texture()
+  const environmentMap = new THREE.Texture()
+  const material = new THREE.MeshStandardMaterial({ map: texture })
+  material.envMap = environmentMap
+
+  let geometryDisposals = 0
+  let materialDisposals = 0
+  let textureDisposals = 0
+  let environmentMapDisposals = 0
+
+  geometry.dispose = () => {
+    geometryDisposals += 1
+  }
+  material.dispose = () => {
+    materialDisposals += 1
+  }
+  texture.dispose = () => {
+    textureDisposals += 1
+  }
+  environmentMap.dispose = () => {
+    environmentMapDisposals += 1
+  }
+
+  object.add(new THREE.Mesh(geometry, material))
+  object.add(new THREE.Mesh(geometry, material))
+
+  disposeObject3DResources(object)
+
+  expect(geometryDisposals).toBe(1)
+  expect(materialDisposals).toBe(1)
+  expect(textureDisposals).toBe(1)
+  expect(environmentMapDisposals).toBe(0)
+})


### PR DESCRIPTION
/claim #93

## Summary

- Adds a small `disposeObject3DResources` helper for Object3D cleanup.
- Disposes glTF/GLB scene geometries, materials, and material textures when `GltfModel` unmounts, changes URL, or finishes loading after unmount.
- Keeps `envMap` textures alive because those are assigned from the shared renderer environment map.
- Moves translucency updates out of the loader callback so toggling translucency no longer reloads the glTF asset.

## Why

Repeated GLTF/GLB loads were detached from the scene graph but their GPU/browser resources were not explicitly released. In longer sessions or when models are swapped/reloaded, those stale geometries/materials/textures can accumulate and contribute to the laggy-browser behavior described in #93.

## Tests

- `npx biome format src/three-components/GltfModel.tsx src/utils/dispose-object3d-resources.ts tests/dispose-object3d-resources.test.ts`
- `npx tsc --noEmit`
- `npx bun test tests/dispose-object3d-resources.test.ts`
- `npm run build`

Also ran `npx bun test tests`; it currently has unrelated existing failures in:
- `tests/outline-bounds.test.ts` expecting an older soldermask RGB string
- `tests/preprocess-circuit-json.test.ts` expecting z offsets `0.8` / `1.8` while current output is `0.7` / `1.7`

AI-assisted with OpenAI Codex; I reviewed the diff and kept the change scoped.