### PR TITLE
Cache duplicate 3D model loads

### DIFF
--- a/src/three-components/MixedStlModel.tsx
+++ b/src/three-components/MixedStlModel.tsx
@@ -1,10 +1,44 @@
+import { useEffect, useMemo } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { useGlobalObjLoader } from "src/hooks/use-global-obj-loader"
-import type { Euler, Vector3 } from "three"
-import { useMemo } from "react"
-import * as THREE from "three"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import type { Euler, Vector3 } from "three"
+import * as THREE from "three"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
+
+const MIXED_STL_FALLBACK_MODEL_KEY = "__tscircuitMixedStlFallbackModel"
+
+export function createMixedStlFallbackModel() {
+  const fallbackModel = new THREE.Mesh(
+    new THREE.BoxGeometry(0.5, 0.5, 0.5),
+    new THREE.MeshStandardMaterial({
+      transparent: true,
+      color: "red",
+      opacity: 0.25,
+    }),
+  )
+  fallbackModel.userData[MIXED_STL_FALLBACK_MODEL_KEY] = true
+  return fallbackModel
+}
+
+function isMixedStlFallbackModel(model: THREE.Object3D) {
+  return model.userData[MIXED_STL_FALLBACK_MODEL_KEY] === true
+}
+
+export function disposeObject3DResources(object: THREE.Object3D) {
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    child.geometry?.dispose()
+    if (Array.isArray(child.material)) {
+      for (const material of child.material) {
+        material.dispose()
+      }
+    } else {
+      child.material?.dispose()
+    }
+  })
+}
 
 export function MixedStlModel({
   url,
@@ -58,16 +92,17 @@ export function MixedStlModel({
       })
       return obj
     }
-    // Fallback mesh
-    return new THREE.Mesh(
-      new THREE.BoxGeometry(0.5, 0.5, 0.5),
-      new THREE.MeshStandardMaterial({
-        transparent: true,
-        color: "red",
-        opacity: 0.25,
-      }),
-    )
+    return createMixedStlFallbackModel()
   }, [obj, isTranslucent])
+
+  useEffect(() => {
+    if (!isMixedStlFallbackModel(model)) return
+
+    return () => {
+      disposeObject3DResources(model)
+    }
+  }, [model])
+
   const { boardTransformGroup } = useCadModelTransformGraph({
     model,
     position: Array.isArray(position)

--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,91 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
+interface ModelCacheItem {
+  promise: Promise<THREE.Object3D | null>
+  result: THREE.Object3D | null
+}
+
+const modelCache = new Map<string, ModelCacheItem>()
+
+export function getModelCacheKey(url: string): string {
+  try {
+    const parsedUrl = new URL(url, "https://tscircuit.local")
+    parsedUrl.searchParams.delete("cachebust_origin")
+
+    const normalizedPath = `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return `${parsedUrl.origin}${normalizedPath}`
+    }
+
+    return url.startsWith("/") ? normalizedPath : normalizedPath.slice(1)
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&#]*&?/g, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
+function getModelExtension(url: string): string {
+  return getModelCacheKey(url).split("#")[0]!.split("?")[0]!.toLowerCase()
+}
+
+function cloneMaterial(
+  material: THREE.Material | THREE.Material[],
+): THREE.Material | THREE.Material[] {
+  return Array.isArray(material)
+    ? material.map((singleMaterial) => singleMaterial.clone())
+    : material.clone()
+}
+
+function cloneCachedModel(model: THREE.Object3D | null): THREE.Object3D | null {
+  if (!model) return null
+
+  const clonedModel = model.clone(true)
+  clonedModel.traverse((object) => {
+    const mesh = object as THREE.Mesh
+    if (mesh.isMesh && mesh.material) {
+      mesh.material = cloneMaterial(mesh.material)
+    }
+  })
+  return clonedModel
+}
+
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+  const cacheKey = getModelCacheKey(url)
+  const cachedModel = modelCache.get(cacheKey)
+
+  if (cachedModel) {
+    const result = cachedModel.result ?? (await cachedModel.promise)
+    return cloneCachedModel(result)
+  }
+
+  const promise = loadUncached3DModel(url)
+
+  modelCache.set(cacheKey, {
+    promise,
+    result: null,
+  })
+
+  try {
+    const result = await promise
+    const cacheItem = modelCache.get(cacheKey)
+    if (cacheItem) {
+      cacheItem.result = result
+    }
+    return cloneCachedModel(result)
+  } catch (error) {
+    modelCache.delete(cacheKey)
+    throw error
+  }
+}
+
+async function loadUncached3DModel(
+  url: string,
+): Promise<THREE.Object3D | null> {
+  const modelExtension = getModelExtension(url)
+
+  if (modelExtension.endsWith(".stl")) {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,16 +99,16 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (modelExtension.endsWith(".obj")) {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (modelExtension.endsWith(".wrl")) {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  if (modelExtension.endsWith(".gltf") || modelExtension.endsWith(".glb")) {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene

--- a/tests/mixed-stl-model.test.ts
+++ b/tests/mixed-stl-model.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import type * as THREE from "three"
+import {
+  createMixedStlFallbackModel,
+  disposeObject3DResources,
+} from "../src/three-components/MixedStlModel"
+
+test("disposes mixed STL fallback mesh resources", () => {
+  const fallbackModel = createMixedStlFallbackModel()
+  let geometryDisposed = false
+  let materialDisposed = false
+
+  fallbackModel.geometry.dispose = () => {
+    geometryDisposed = true
+  }
+  ;(fallbackModel.material as THREE.Material).dispose = () => {
+    materialDisposed = true
+  }
+
+  disposeObject3DResources(fallbackModel)
+
+  expect(geometryDisposed).toBe(true)
+  expect(materialDisposed).toBe(true)
+})

--- a/tests/model-cache-key.test.ts
+++ b/tests/model-cache-key.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { getModelCacheKey } from "../src/utils/load-model"
+
+test("removes cachebust_origin from absolute model URLs", () => {
+  expect(
+    getModelCacheKey(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123&cachebust_origin=",
+    ),
+  ).toBe(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123",
+  )
+})
+
+test("removes cachebust_origin without dropping meaningful query params", () => {
+  expect(
+    getModelCacheKey("/models/chip.glb?foo=1&cachebust_origin=123&bar=2"),
+  ).toBe("/models/chip.glb?foo=1&bar=2")
+})
+
+test("preserves relative model URL shape", () => {
+  expect(getModelCacheKey("models/chip.obj?cachebust_origin=123")).toBe(
+    "models/chip.obj",
+  )
+})


### PR DESCRIPTION
/claim #93

## Summary
- cache in-flight and completed 3D model loads by normalized URL
- ignore only the `cachebust_origin` parameter so duplicate EasyEDA model URLs reuse the same load
- return cloned Object3D instances with cloned materials so each rendered component can keep independent transform/material state
- keep model extension detection working for URLs with query strings

## Verification
- `npx --yes bun test tests/model-cache-key.test.ts`
- `npm run build`