### PR TITLE
Fix cachebusted 3D model loading

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,97 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+export type ModelFormat = "stl" | "obj" | "wrl" | "gltf" | "glb"
+
+type CachedModel = {
+  promise: Promise<THREE.Object3D>
+  result: THREE.Object3D | null
+}
+
+const modelCache = new Map<string, CachedModel>()
+const CACHE_BUSTING_QUERY_PARAMS = ["cachebust_origin"]
+
+function cloneMaterial(material: THREE.Material | THREE.Material[]) {
+  if (Array.isArray(material)) {
+    return material.map((mat) => mat.clone())
+  }
+
+  return material.clone()
+}
+
+function cloneModelInstance(template: THREE.Object3D) {
+  const clone = template.clone(true)
+
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    if (child.geometry) {
+      child.geometry = child.geometry.clone()
+    }
+
+    if (child.material) {
+      child.material = cloneMaterial(child.material)
+    }
+  })
+
+  return clone
+}
+
+function getPathnameForFormatDetection(url: string) {
+  try {
+    return new URL(url, "https://model.local").pathname.toLowerCase()
+  } catch {
+    return url.split(/[?#]/, 1)[0]?.toLowerCase() ?? ""
+  }
+}
+
+function normalizeUrlForCache(url: string) {
+  try {
+    const parsed = new URL(url, "https://model.local")
+    for (const param of CACHE_BUSTING_QUERY_PARAMS) {
+      parsed.searchParams.delete(param)
+    }
+    parsed.searchParams.sort()
+    parsed.hash = ""
+
+    if (!/^[a-z][a-z\d+.-]*:/i.test(url)) {
+      return `${parsed.pathname}${parsed.search}`
+    }
+
+    return parsed.toString()
+  } catch {
+    const withoutHash = url.split("#", 1)[0] ?? ""
+    const [path, query = ""] = withoutHash.split("?", 2)
+    if (!query) return path
+
+    const params = new URLSearchParams(query)
+    for (const param of CACHE_BUSTING_QUERY_PARAMS) {
+      params.delete(param)
+    }
+    params.sort()
+    const normalizedQuery = params.toString()
+    return normalizedQuery ? `${path}?${normalizedQuery}` : path
+  }
+}
+
+function inferModelFormat(url: string): ModelFormat | null {
+  const pathname = getPathnameForFormatDetection(url)
+
+  if (pathname.endsWith(".stl")) return "stl"
+  if (pathname.endsWith(".obj")) return "obj"
+  if (pathname.endsWith(".wrl")) return "wrl"
+  if (pathname.endsWith(".gltf")) return "gltf"
+  if (pathname.endsWith(".glb")) return "glb"
+
+  return null
+}
+
+function getCacheKey(url: string, format: ModelFormat) {
+  return `${format}:${normalizeUrlForCache(url)}`
+}
+
+async function loadModelTemplate(url: string, format: ModelFormat) {
+  if (format === "stl") {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,21 +105,56 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (format === "obj") {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (format === "wrl") {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
-    const loader = new GLTFLoader()
-    const gltf = await loader.loadAsync(url)
-    return gltf.scene
+  const loader = new GLTFLoader()
+  const gltf = await loader.loadAsync(url)
+  return gltf.scene
+}
+
+export function clear3DModelCache() {
+  modelCache.clear()
+}
+
+export async function load3DModel(
+  url: string,
+  explicitFormat?: ModelFormat,
+): Promise<THREE.Object3D | null> {
+  const format = explicitFormat ?? inferModelFormat(url)
+
+  if (!format) {
+    console.error("Unsupported file format or failed to load 3D model.")
+    return null
   }
 
-  console.error("Unsupported file format or failed to load 3D model.")
-  return null
+  const cacheKey = getCacheKey(url, format)
+  const cached = modelCache.get(cacheKey)
+
+  if (cached?.result) {
+    return cloneModelInstance(cached.result)
+  }
+
+  if (cached) {
+    const template = await cached.promise
+    return cloneModelInstance(template)
+  }
+
+  const promise = loadModelTemplate(url, format)
+  modelCache.set(cacheKey, { promise, result: null })
+
+  try {
+    const template = await promise
+    modelCache.set(cacheKey, { promise, result: template })
+    return cloneModelInstance(template)
+  } catch (error) {
+    modelCache.delete(cacheKey)
+    throw error
+  }
 }

--- a/src/utils/render-component.tsx
+++ b/src/utils/render-component.tsx
@@ -7,7 +7,7 @@ import {
 import { executeJscadOperations } from "jscad-planner"
 import * as THREE from "three"
 import * as jscadModeling from "@jscad/modeling"
-import { load3DModel } from "./load-model"
+import { load3DModel, type ModelFormat } from "./load-model"
 import type { CadComponent } from "circuit-json"
 
 export async function renderComponent(
@@ -15,14 +15,20 @@ export async function renderComponent(
   scene: THREE.Scene,
 ) {
   // Handle STL/OBJ models first
-  const url =
-    component.model_obj_url ??
-    component.model_wrl_url ??
-    component.model_stl_url ??
-    component.model_glb_url ??
-    component.model_gltf_url
-  if (url) {
-    const model = await load3DModel(url)
+  const modelSource: { url: string; format: ModelFormat } | null =
+    component.model_obj_url
+      ? { url: component.model_obj_url, format: "obj" }
+      : component.model_wrl_url
+        ? { url: component.model_wrl_url, format: "wrl" }
+        : component.model_stl_url
+          ? { url: component.model_stl_url, format: "stl" }
+          : component.model_glb_url
+            ? { url: component.model_glb_url, format: "glb" }
+            : component.model_gltf_url
+              ? { url: component.model_gltf_url, format: "gltf" }
+              : null
+  if (modelSource) {
+    const model = await load3DModel(modelSource.url, modelSource.format)
     if (model) {
       if (component.position) {
         model.position.set(

--- a/tests/load-model.test.ts
+++ b/tests/load-model.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, expect, test } from "bun:test"
+import * as THREE from "three"
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
+import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
+import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
+import { clear3DModelCache, load3DModel } from "../src/utils/load-model"
+
+const originalObjLoadAsync = OBJLoader.prototype.loadAsync
+const originalStlLoadAsync = STLLoader.prototype.loadAsync
+const originalGltfLoadAsync = GLTFLoader.prototype.loadAsync
+
+function createLoadedGroup() {
+  const group = new THREE.Group()
+  group.add(
+    new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 1),
+      new THREE.MeshStandardMaterial({ color: 0xff0000 }),
+    ),
+  )
+  return group
+}
+
+function getFirstMesh(object: THREE.Object3D | null): THREE.Mesh | null {
+  let mesh: THREE.Mesh | null = null
+  object?.traverse((child) => {
+    if (!mesh && child instanceof THREE.Mesh) {
+      mesh = child
+    }
+  })
+  return mesh
+}
+
+afterEach(() => {
+  OBJLoader.prototype.loadAsync = originalObjLoadAsync
+  STLLoader.prototype.loadAsync = originalStlLoadAsync
+  GLTFLoader.prototype.loadAsync = originalGltfLoadAsync
+  clear3DModelCache()
+})
+
+test("loads explicit OBJ model URLs that do not have a .obj pathname", async () => {
+  const loadedUrls: string[] = []
+  OBJLoader.prototype.loadAsync = async (url: string) => {
+    loadedUrls.push(url)
+    return createLoadedGroup()
+  }
+
+  const url =
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+
+  const model = await load3DModel(url, "obj")
+
+  expect(model).toBeInstanceOf(THREE.Object3D)
+  expect(loadedUrls).toEqual([url])
+})
+
+test("detects model format from pathname before query and hash suffixes", async () => {
+  const loadedUrls: string[] = []
+  STLLoader.prototype.loadAsync = async (url: string) => {
+    loadedUrls.push(url)
+    return new THREE.BufferGeometry()
+  }
+
+  const url =
+    "https://cdn.example.com/models/chip.stl?cachebust_origin=local#body"
+  const model = await load3DModel(url)
+
+  expect(model).toBeInstanceOf(THREE.Mesh)
+  expect(loadedUrls).toEqual([url])
+})
+
+test("deduplicates equivalent cachebusted model loads and returns isolated clones", async () => {
+  let loadCount = 0
+  OBJLoader.prototype.loadAsync = async () => {
+    loadCount += 1
+    await Promise.resolve()
+    return createLoadedGroup()
+  }
+
+  const firstUrl =
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1&cachebust_origin=http%3A%2F%2Flocalhost%3A6006"
+  const secondUrl =
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+
+  const [firstModel, secondModel] = await Promise.all([
+    load3DModel(firstUrl, "obj"),
+    load3DModel(secondUrl, "obj"),
+  ])
+
+  expect(loadCount).toBe(1)
+  expect(firstModel).toBeInstanceOf(THREE.Object3D)
+  expect(secondModel).toBeInstanceOf(THREE.Object3D)
+  expect(firstModel).not.toBe(secondModel)
+
+  const firstMesh = getFirstMesh(firstModel)
+  const secondMesh = getFirstMesh(secondModel)
+
+  expect(firstMesh).toBeInstanceOf(THREE.Mesh)
+  expect(secondMesh).toBeInstanceOf(THREE.Mesh)
+  if (!firstMesh || !secondMesh) {
+    throw new Error("expected each loaded model clone to contain a mesh")
+  }
+  expect(firstMesh.geometry).not.toBe(secondMesh.geometry)
+  expect(firstMesh.material).not.toBe(secondMesh.material)
+})


### PR DESCRIPTION
## Summary

/claim #93

Fixes the slow/repeated model-loading path for cachebusted EasyEDA/modelcdn URLs by:

- passing the explicit model format from `renderComponent` (`model_obj_url`, `model_stl_url`, `model_wrl_url`, `model_glb_url`, `model_gltf_url`) into `load3DModel`
- detecting model extensions from the URL pathname before query/hash suffixes
- normalizing model-cache keys by removing `cachebust_origin` and sorting query params
- deduplicating in-flight/completed model loads while returning isolated clones per render
- cloning geometry/materials on returned instances so cached templates are not shared mutably

## Test plan

- ✅ `bun test tests/load-model.test.ts`
  - 3 pass / 0 fail / 12 assertions
- ✅ formatted touched files with Biome
- ✅ `bun run build`
  - ESM build success
  - DTS build success
- ✅ `bun run test:node-bundle`

Full-suite note:

- `bun test` currently reports 27 pass / 3 fail.
- The 3 failures are existing unrelated expectations in:
  - `tests/outline-bounds.test.ts` — SVG soldermask color expectation differs from generated SVG
  - `tests/preprocess-circuit-json.test.ts` — faux board z-offset expectations are off by 0.1
- The new targeted regression suite for this loader change passes.
