### PR TITLE
Reduce duplicate 3D model loading for cachebusted URLs

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
+import { getGlobalObjLoaderCacheKey } from "src/utils/global-obj-loader-cache-key"
 import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
@@ -28,21 +29,22 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const requestUrl = url.replace(/&cachebust_origin=$/, "")
+    const cacheKey = getGlobalObjLoaderCacheKey(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
     async function loadAndParseObj() {
       try {
-        if (cleanUrl.endsWith(".wrl")) {
-          return await loadVrml(cleanUrl)
+        if (requestUrl.endsWith(".wrl")) {
+          return await loadVrml(requestUrl)
         }
 
-        const response = await fetch(cleanUrl)
+        const response = await fetch(requestUrl)
         if (!response.ok) {
           throw new Error(
-            `Failed to fetch "${cleanUrl}": ${response.status} ${response.statusText}`,
+            `Failed to fetch "${requestUrl}": ${response.status} ${response.statusText}`,
           )
         }
         const text = await response.text()
@@ -79,8 +81,8 @@ export function useGlobalObjLoader(
     }
 
     function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
+      if (cache.has(cacheKey)) {
+        const cacheItem = cache.get(cacheKey)!
         if (cacheItem.result) {
           // If we have a result, clone it
           return Promise.resolve(cacheItem.result.clone())
@@ -97,10 +99,10 @@ export function useGlobalObjLoader(
           // If the result is an Error, return it
           return result
         }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+        cache.set(cacheKey, { ...cache.get(cacheKey)!, result })
         return result
       })
-      cache.set(cleanUrl, { promise, result: null })
+      cache.set(cacheKey, { promise, result: null })
       return promise
     }
 

--- a/src/utils/global-obj-loader-cache-key.ts
+++ b/src/utils/global-obj-loader-cache-key.ts
@@ -1,0 +1,28 @@
+export function getGlobalObjLoaderCacheKey(url: string): string {
+  try {
+    const parsedUrl = new URL(url, "https://tscircuit.local")
+    const isAbsoluteUrl = /^[a-z][a-z\d+\-.]*:/i.test(url)
+    const isProtocolRelativeUrl = url.startsWith("//")
+    const isRootRelativeUrl = url.startsWith("/")
+
+    parsedUrl.searchParams.delete("cachebust_origin")
+
+    if (isAbsoluteUrl) {
+      return parsedUrl.toString()
+    }
+
+    const pathAndQuery = `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+
+    if (isProtocolRelativeUrl) {
+      return `//${parsedUrl.host}${pathAndQuery}`
+    }
+
+    if (isRootRelativeUrl) {
+      return pathAndQuery
+    }
+
+    return pathAndQuery.replace(/^\//, "")
+  } catch {
+    return url
+  }
+}

--- a/tests/global-obj-loader.test.ts
+++ b/tests/global-obj-loader.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getGlobalObjLoaderCacheKey } from "../src/utils/global-obj-loader-cache-key"
+
+test("uses the same OBJ cache key when only cachebust_origin changes", () => {
+  const modelUrl =
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc123&pn=C1"
+
+  expect(
+    getGlobalObjLoaderCacheKey(`${modelUrl}&cachebust_origin=https://a.test`),
+  ).toBe(modelUrl)
+  expect(
+    getGlobalObjLoaderCacheKey(`${modelUrl}&cachebust_origin=https://b.test`),
+  ).toBe(modelUrl)
+})
+
+test("keeps other query parameters in the OBJ cache key", () => {
+  expect(
+    getGlobalObjLoaderCacheKey(
+      "/easyeda_models/download?uuid=abc123&pn=C1&cachebust_origin=https://a.test",
+    ),
+  ).toBe("/easyeda_models/download?uuid=abc123&pn=C1")
+
+  expect(
+    getGlobalObjLoaderCacheKey(
+      "/easyeda_models/download?uuid=abc123&pn=C2&cachebust_origin=https://a.test",
+    ),
+  ).toBe("/easyeda_models/download?uuid=abc123&pn=C2")
+})


### PR DESCRIPTION
## Summary
- Reuse the same loaded 3D model when only `cachebust_origin` changes in the model URL.
- Add a unit test covering repeated model URLs.
- Keep other URL parameters in the model identity so different models still load separately.

Fixes tscircuit/3d-viewer#93

## Checks
- Passed: `bun test tests/global-obj-loader.test.ts`
- Passed: changed files format check
- Passed: `npm run build`
- Passed: `npm run test:node-bundle`

Note: the full `bun test` suite still has unrelated board/SVG failures that were not touched by this change.