### PR TITLE
Dispose MixedStlModel fallback resources

### DIFF
--- a/src/three-components/MixedStlModel.tsx
+++ b/src/three-components/MixedStlModel.tsx
@@ -1,9 +1,10 @@
+import { useEffect, useMemo } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { useGlobalObjLoader } from "src/hooks/use-global-obj-loader"
-import type { Euler, Vector3 } from "three"
-import { useMemo } from "react"
-import * as THREE from "three"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import { disposeOwnedObjectResources } from "src/utils/dispose-owned-object-resources"
+import type { Euler, Vector3 } from "three"
+import * as THREE from "three"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 export function MixedStlModel({
@@ -36,7 +37,7 @@ export function MixedStlModel({
   isTranslucent?: boolean
 }) {
   const obj = useGlobalObjLoader(url)
-  const model = useMemo(() => {
+  const modelState = useMemo(() => {
     if (obj && !(obj instanceof Error)) {
       obj.traverse((child) => {
         if (child instanceof THREE.Mesh && child.material) {
@@ -56,10 +57,9 @@ export function MixedStlModel({
           child.renderOrder = isTranslucent ? 2 : 1
         }
       })
-      return obj
+      return { model: obj, ownsResources: false }
     }
-    // Fallback mesh
-    return new THREE.Mesh(
+    const fallbackMesh = new THREE.Mesh(
       new THREE.BoxGeometry(0.5, 0.5, 0.5),
       new THREE.MeshStandardMaterial({
         transparent: true,
@@ -67,7 +67,18 @@ export function MixedStlModel({
         opacity: 0.25,
       }),
     )
+    return { model: fallbackMesh, ownsResources: true }
   }, [obj, isTranslucent])
+  const { model, ownsResources } = modelState
+
+  useEffect(() => {
+    return () => {
+      if (ownsResources) {
+        disposeOwnedObjectResources(model)
+      }
+    }
+  }, [model, ownsResources])
+
   const { boardTransformGroup } = useCadModelTransformGraph({
     model,
     position: Array.isArray(position)

--- a/src/three-components/StepModel.tsx
+++ b/src/three-components/StepModel.tsx
@@ -208,6 +208,26 @@ function getStepUrlConversionRegistry(): StepUrlConversionRegistry {
   return globalScope.stepUrlToGltfModelConversions
 }
 
+export function getOrCreateStepConversionFromCachedGlb(
+  stepUrl: string,
+  glb: ArrayBuffer,
+  registry = getStepUrlConversionRegistry(),
+): ConvertedStepFile {
+  const existingCompleted = registry.completed.get(stepUrl)
+  if (existingCompleted) {
+    return existingCompleted
+  }
+
+  const cachedConverted: ConvertedStepFile = {
+    arrayBuffer: glb,
+    blobUrl: URL.createObjectURL(
+      new Blob([glb], { type: "model/gltf-binary" }),
+    ),
+  }
+  registry.completed.set(stepUrl, cachedConverted)
+  return cachedConverted
+}
+
 type StepModelProps = {
   stepUrl: string
   position?: [number, number, number]
@@ -246,18 +266,12 @@ export const StepModel = ({
     let objectUrl: string | null = null
     let shouldRevokeObjectUrl = true
     const registry = getStepUrlConversionRegistry()
-    const cachedGlb = getCachedGlb(stepUrl)
-    if (cachedGlb) {
-      const cachedConverted: ConvertedStepFile = {
-        arrayBuffer: cachedGlb,
-        blobUrl: URL.createObjectURL(
-          new Blob([cachedGlb], { type: "model/gltf-binary" }),
-        ),
-      }
-      registry.completed.set(stepUrl, cachedConverted)
-      objectUrl = cachedConverted.blobUrl
+    const existingCompleted = registry.completed.get(stepUrl)
+    if (existingCompleted) {
+      objectUrl = existingCompleted.blobUrl
       shouldRevokeObjectUrl = false
-      setStepGltfUrl(cachedConverted.blobUrl)
+      setStepGltfUrl(existingCompleted.blobUrl)
+      setCachedGlb(stepUrl, existingCompleted.arrayBuffer)
       return () => {
         isActive = false
         if (objectUrl && shouldRevokeObjectUrl) {
@@ -265,12 +279,16 @@ export const StepModel = ({
         }
       }
     }
-    const existingCompleted = registry.completed.get(stepUrl)
-    if (existingCompleted) {
-      objectUrl = existingCompleted.blobUrl
+    const cachedGlb = getCachedGlb(stepUrl)
+    if (cachedGlb) {
+      const cachedConverted = getOrCreateStepConversionFromCachedGlb(
+        stepUrl,
+        cachedGlb,
+        registry,
+      )
+      objectUrl = cachedConverted.blobUrl
       shouldRevokeObjectUrl = false
-      setStepGltfUrl(existingCompleted.blobUrl)
-      setCachedGlb(stepUrl, existingCompleted.arrayBuffer)
+      setStepGltfUrl(cachedConverted.blobUrl)
       return () => {
         isActive = false
         if (objectUrl && shouldRevokeObjectUrl) {

--- a/src/utils/dispose-owned-object-resources.ts
+++ b/src/utils/dispose-owned-object-resources.ts
@@ -1,0 +1,19 @@
+import * as THREE from "three"
+
+const disposeMaterial = (material: THREE.Material) => {
+  material.dispose()
+}
+
+export const disposeOwnedObjectResources = (object: THREE.Object3D) => {
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    child.geometry?.dispose()
+
+    if (Array.isArray(child.material)) {
+      child.material.forEach(disposeMaterial)
+    } else if (child.material) {
+      disposeMaterial(child.material)
+    }
+  })
+}

--- a/tests/dispose-owned-object-resources.test.ts
+++ b/tests/dispose-owned-object-resources.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { disposeOwnedObjectResources } from "../src/utils/dispose-owned-object-resources"
+
+test("disposes geometry and every material in an owned object tree", () => {
+  const root = new THREE.Group()
+  const geometry = new THREE.BoxGeometry()
+  const materialA = new THREE.MeshStandardMaterial()
+  const materialB = new THREE.MeshStandardMaterial()
+  const mesh = new THREE.Mesh(geometry, [materialA, materialB])
+
+  let geometryDisposed = false
+  let materialADisposed = false
+  let materialBDisposed = false
+
+  geometry.dispose = () => {
+    geometryDisposed = true
+  }
+  materialA.dispose = () => {
+    materialADisposed = true
+  }
+  materialB.dispose = () => {
+    materialBDisposed = true
+  }
+
+  root.add(mesh)
+
+  disposeOwnedObjectResources(root)
+
+  expect(geometryDisposed).toBe(true)
+  expect(materialADisposed).toBe(true)
+  expect(materialBDisposed).toBe(true)
+})

--- a/tests/step-model-cache.test.ts
+++ b/tests/step-model-cache.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { getOrCreateStepConversionFromCachedGlb } from "../src/three-components/StepModel"
+
+test("reuses a registered STEP blob URL when the cached GLB is read again", () => {
+  const originalCreateObjectUrl = URL.createObjectURL
+  const createdObjectUrls: string[] = []
+  const registry = {
+    inProgress: new Map(),
+    completed: new Map(),
+  }
+
+  URL.createObjectURL = ((blob: Blob) => {
+    const objectUrl = `blob:step-cache-${createdObjectUrls.length + 1}`
+    createdObjectUrls.push(`${objectUrl}:${blob.size}`)
+    return objectUrl
+  }) as typeof URL.createObjectURL
+
+  try {
+    const stepUrl = "https://example.com/model.step"
+    const cachedGlb = new ArrayBuffer(8)
+
+    const firstConversion = getOrCreateStepConversionFromCachedGlb(
+      stepUrl,
+      cachedGlb,
+      registry,
+    )
+    const secondConversion = getOrCreateStepConversionFromCachedGlb(
+      stepUrl,
+      cachedGlb,
+      registry,
+    )
+
+    expect(secondConversion).toBe(firstConversion)
+    expect(secondConversion.blobUrl).toBe("blob:step-cache-1")
+    expect(createdObjectUrls).toEqual(["blob:step-cache-1:8"])
+  } finally {
+    URL.createObjectURL = originalCreateObjectUrl
+  }
+})


### PR DESCRIPTION
/claim #93

## Summary
- Track whether `MixedStlModel` is rendering its locally-owned red fallback mesh or a loaded cached model.
- Dispose the fallback mesh geometry/material when it is replaced or unmounted.
- Reuse already-registered STEP-to-GLB blob URLs before reading the localStorage GLB cache again, avoiding duplicate object URLs for repeated STEP mounts.
- Keep loaded OBJ/WRL model instances untouched so shared/cached loader resources are not accidentally disposed.
- Add focused helper tests for owned-resource disposal and STEP blob URL reuse.

## Why
When a board has many duplicate or slow-loading models, `MixedStlModel` creates fallback meshes while the model loader is pending. The transform graph removes those placeholders when the real model arrives, but the placeholder geometry/material were not disposed. The follow-up also closes a small STEP cache reuse gap where a cached GLB could create another blob URL even though the global conversion registry already had one for the same STEP URL.

## Verification
- `bun test tests/step-model-cache.test.ts tests/dispose-owned-object-resources.test.ts`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run test:node-bundle`
- `git diff --check`

## Full test note
`bun test` previously had 3 failures unrelated to this change in this checkout:
- `tests/preprocess-circuit-json.test.ts`: expected faux-board z offsets are 0.1 higher than current output.
- `tests/outline-bounds.test.ts`: expected soldermask color string does not match current rendered SVG color.

AI-assisted with Codex; I reviewed the diff and verification output before opening and updating this PR.