### PR TITLE
[codex] Reuse cached 3D model loads

### DIFF
--- a/src/three-components/StepModel.tsx
+++ b/src/three-components/StepModel.tsx
@@ -1,4 +1,11 @@
 import { useEffect, useState } from "react"
+import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import {
+  createConvertedStepFile,
+  getCachedConvertedStepFile,
+  type StepUrlConversionRegistry,
+  setCachedStepGlb,
+} from "src/utils/step-model-cache"
 import {
   BufferGeometry,
   Color,
@@ -9,7 +16,6 @@ import {
 } from "three"
 import { GLTFExporter } from "three-stdlib"
 import { GltfModel } from "./GltfModel"
-import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 
 type OcctImportParams = {
   linearUnit?: "millimeter" | "centimeter" | "meter" | "inch" | "foot"
@@ -141,60 +147,6 @@ async function convertStepUrlToGlb(stepUrl: string): Promise<ArrayBuffer> {
   return glb
 }
 
-const CACHE_PREFIX = "step-glb-cache:"
-
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer)
-  const chunkSize = 0x8000
-  let binary = ""
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    const chunk = bytes.subarray(i, i + chunkSize)
-    binary += String.fromCharCode(...chunk)
-  }
-  return btoa(binary)
-}
-
-function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binary = atob(base64)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i += 1) {
-    bytes[i] = binary.charCodeAt(i)
-  }
-  return bytes.buffer
-}
-
-function getCachedGlb(stepUrl: string): ArrayBuffer | null {
-  try {
-    const cached = localStorage.getItem(`${CACHE_PREFIX}${stepUrl}`)
-    if (!cached) {
-      return null
-    }
-    return base64ToArrayBuffer(cached)
-  } catch (error) {
-    console.warn("Failed to read STEP GLB cache", error)
-    return null
-  }
-}
-
-function setCachedGlb(stepUrl: string, glb: ArrayBuffer): void {
-  try {
-    const encoded = arrayBufferToBase64(glb)
-    localStorage.setItem(`${CACHE_PREFIX}${stepUrl}`, encoded)
-  } catch (error) {
-    console.warn("Failed to write STEP GLB cache", error)
-  }
-}
-
-type ConvertedStepFile = {
-  arrayBuffer: ArrayBuffer
-  blobUrl: string
-}
-
-type StepUrlConversionRegistry = {
-  inProgress: Map<string, Promise<ConvertedStepFile>>
-  completed: Map<string, ConvertedStepFile>
-}
-
 function getStepUrlConversionRegistry(): StepUrlConversionRegistry {
   const globalScope = globalThis as {
     stepUrlToGltfModelConversions?: StepUrlConversionRegistry
@@ -246,31 +198,12 @@ export const StepModel = ({
     let objectUrl: string | null = null
     let shouldRevokeObjectUrl = true
     const registry = getStepUrlConversionRegistry()
-    const cachedGlb = getCachedGlb(stepUrl)
-    if (cachedGlb) {
-      const cachedConverted: ConvertedStepFile = {
-        arrayBuffer: cachedGlb,
-        blobUrl: URL.createObjectURL(
-          new Blob([cachedGlb], { type: "model/gltf-binary" }),
-        ),
-      }
-      registry.completed.set(stepUrl, cachedConverted)
+    const cachedConverted = getCachedConvertedStepFile(stepUrl, registry)
+    if (cachedConverted) {
       objectUrl = cachedConverted.blobUrl
       shouldRevokeObjectUrl = false
       setStepGltfUrl(cachedConverted.blobUrl)
-      return () => {
-        isActive = false
-        if (objectUrl && shouldRevokeObjectUrl) {
-          URL.revokeObjectURL(objectUrl)
-        }
-      }
-    }
-    const existingCompleted = registry.completed.get(stepUrl)
-    if (existingCompleted) {
-      objectUrl = existingCompleted.blobUrl
-      shouldRevokeObjectUrl = false
-      setStepGltfUrl(existingCompleted.blobUrl)
-      setCachedGlb(stepUrl, existingCompleted.arrayBuffer)
+      setCachedStepGlb(stepUrl, cachedConverted.arrayBuffer)
       return () => {
         isActive = false
         if (objectUrl && shouldRevokeObjectUrl) {
@@ -282,12 +215,7 @@ export const StepModel = ({
     if (!conversionPromise) {
       conversionPromise = convertStepUrlToGlb(stepUrl)
         .then((glbBuffer) => {
-          const converted: ConvertedStepFile = {
-            arrayBuffer: glbBuffer,
-            blobUrl: URL.createObjectURL(
-              new Blob([glbBuffer], { type: "model/gltf-binary" }),
-            ),
-          }
+          const converted = createConvertedStepFile(glbBuffer)
           registry.completed.set(stepUrl, converted)
           registry.inProgress.delete(stepUrl)
           return converted
@@ -306,7 +234,7 @@ export const StepModel = ({
         objectUrl = converted.blobUrl
         shouldRevokeObjectUrl = false
         setStepGltfUrl(converted.blobUrl)
-        setCachedGlb(stepUrl, converted.arrayBuffer)
+        setCachedStepGlb(stepUrl, converted.arrayBuffer)
       })
       .catch((error) => {
         console.error("Failed to convert STEP file to GLB", error)

--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,7 +4,52 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
+type ModelLoadCache = Map<string, Promise<THREE.Object3D | null>>
+
+type ModelLoadGlobal = typeof globalThis & {
+  TSCIRCUIT_MODEL_CACHE?: ModelLoadCache
+}
+
+function cloneLoadedModel(model: THREE.Object3D | null): THREE.Object3D | null {
+  return model ? model.clone(true) : null
+}
+
+export function getModelLoadCache(): ModelLoadCache {
+  const globalScope = globalThis as ModelLoadGlobal
+  if (!globalScope.TSCIRCUIT_MODEL_CACHE) {
+    globalScope.TSCIRCUIT_MODEL_CACHE = new Map()
+  }
+  return globalScope.TSCIRCUIT_MODEL_CACHE
+}
+
+export async function loadCached3DModel(
+  url: string,
+  loadModel: () => Promise<THREE.Object3D | null>,
+): Promise<THREE.Object3D | null> {
+  const cache = getModelLoadCache()
+  const cachedLoad = cache.get(url)
+  if (cachedLoad) {
+    return cloneLoadedModel(await cachedLoad)
+  }
+
+  const loadPromise = loadModel().catch((error) => {
+    if (cache.get(url) === loadPromise) {
+      cache.delete(url)
+    }
+    throw error
+  })
+  cache.set(url, loadPromise)
+
+  return cloneLoadedModel(await loadPromise)
+}
+
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+  return loadCached3DModel(url, () => loadUncached3DModel(url))
+}
+
+async function loadUncached3DModel(
+  url: string,
+): Promise<THREE.Object3D | null> {
   if (url.endsWith(".stl")) {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)

--- a/src/utils/step-model-cache.ts
+++ b/src/utils/step-model-cache.ts
@@ -1,0 +1,83 @@
+export const STEP_GLB_CACHE_PREFIX = "step-glb-cache:"
+
+export type ConvertedStepFile = {
+  arrayBuffer: ArrayBuffer
+  blobUrl: string
+}
+
+export type StepUrlConversionRegistry = {
+  inProgress: Map<string, Promise<ConvertedStepFile>>
+  completed: Map<string, ConvertedStepFile>
+}
+
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  const chunkSize = 0x8000
+  let binary = ""
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize)
+    binary += String.fromCharCode(...chunk)
+  }
+  return btoa(binary)
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes.buffer
+}
+
+export function getCachedStepGlb(stepUrl: string): ArrayBuffer | null {
+  try {
+    const cached = localStorage.getItem(`${STEP_GLB_CACHE_PREFIX}${stepUrl}`)
+    if (!cached) {
+      return null
+    }
+    return base64ToArrayBuffer(cached)
+  } catch (error) {
+    console.warn("Failed to read STEP GLB cache", error)
+    return null
+  }
+}
+
+export function setCachedStepGlb(stepUrl: string, glb: ArrayBuffer): void {
+  try {
+    const encoded = arrayBufferToBase64(glb)
+    localStorage.setItem(`${STEP_GLB_CACHE_PREFIX}${stepUrl}`, encoded)
+  } catch (error) {
+    console.warn("Failed to write STEP GLB cache", error)
+  }
+}
+
+export function createConvertedStepFile(
+  arrayBuffer: ArrayBuffer,
+): ConvertedStepFile {
+  return {
+    arrayBuffer,
+    blobUrl: URL.createObjectURL(
+      new Blob([arrayBuffer], { type: "model/gltf-binary" }),
+    ),
+  }
+}
+
+export function getCachedConvertedStepFile(
+  stepUrl: string,
+  registry: StepUrlConversionRegistry,
+): ConvertedStepFile | null {
+  const existingCompleted = registry.completed.get(stepUrl)
+  if (existingCompleted) {
+    return existingCompleted
+  }
+
+  const cachedGlb = getCachedStepGlb(stepUrl)
+  if (!cachedGlb) {
+    return null
+  }
+
+  const cachedConverted = createConvertedStepFile(cachedGlb)
+  registry.completed.set(stepUrl, cachedConverted)
+  return cachedConverted
+}

--- a/tests/load-model-cache.test.ts
+++ b/tests/load-model-cache.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, expect, test } from "bun:test"
+import { Object3D } from "three"
+import { getModelLoadCache, loadCached3DModel } from "../src/utils/load-model"
+
+beforeEach(() => {
+  getModelLoadCache().clear()
+})
+
+test("deduplicates model loads and returns independent clones", async () => {
+  const sourceModel = new Object3D()
+  sourceModel.name = "cached-source"
+  let loadCount = 0
+
+  const firstLoad = loadCached3DModel("/models/chip.glb", async () => {
+    loadCount += 1
+    return sourceModel
+  })
+  const secondLoad = loadCached3DModel("/models/chip.glb", async () => {
+    loadCount += 1
+    return new Object3D()
+  })
+
+  const [firstModel, secondModel] = await Promise.all([firstLoad, secondLoad])
+
+  expect(loadCount).toBe(1)
+  expect(firstModel).not.toBe(sourceModel)
+  expect(secondModel).not.toBe(sourceModel)
+  expect(firstModel).not.toBe(secondModel)
+
+  if (!firstModel || !secondModel) {
+    throw new Error("Expected cached model loads to return clones")
+  }
+
+  firstModel.position.set(1, 2, 3)
+
+  const thirdModel = await loadCached3DModel("/models/chip.glb", async () => {
+    loadCount += 1
+    return new Object3D()
+  })
+
+  expect(loadCount).toBe(1)
+  expect(secondModel.position.x).toBe(0)
+  expect(thirdModel?.position.x).toBe(0)
+})
+
+test("drops failed model loads so the URL can be retried", async () => {
+  let loadCount = 0
+
+  await expect(
+    loadCached3DModel("/models/broken.glb", async () => {
+      loadCount += 1
+      throw new Error("network failed")
+    }),
+  ).rejects.toThrow("network failed")
+
+  expect(getModelLoadCache().has("/models/broken.glb")).toBe(false)
+
+  const model = await loadCached3DModel("/models/broken.glb", async () => {
+    loadCount += 1
+    return new Object3D()
+  })
+
+  expect(loadCount).toBe(2)
+  expect(model).toBeInstanceOf(Object3D)
+})

--- a/tests/step-model-cache.test.ts
+++ b/tests/step-model-cache.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import {
+  arrayBufferToBase64,
+  getCachedConvertedStepFile,
+  STEP_GLB_CACHE_PREFIX,
+  type StepUrlConversionRegistry,
+} from "../src/utils/step-model-cache"
+
+class MemoryStorage {
+  private items = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value)
+  }
+}
+
+const originalLocalStorage = globalThis.localStorage
+const originalCreateObjectUrl = URL.createObjectURL
+let createObjectUrlCount = 0
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+  })
+  createObjectUrlCount = 0
+  URL.createObjectURL = (() => {
+    createObjectUrlCount += 1
+    return `blob:step-model-${createObjectUrlCount}`
+  }) as typeof URL.createObjectURL
+})
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: originalLocalStorage,
+  })
+  URL.createObjectURL = originalCreateObjectUrl
+})
+
+function createRegistry(): StepUrlConversionRegistry {
+  return {
+    inProgress: new Map(),
+    completed: new Map(),
+  }
+}
+
+test("reuses completed STEP conversions before reading saved GLB cache", () => {
+  const stepUrl = "/models/chip.step"
+  const registry = createRegistry()
+  const existingConverted = {
+    arrayBuffer: new Uint8Array([4, 5, 6]).buffer,
+    blobUrl: "blob:existing-step-model",
+  }
+  registry.completed.set(stepUrl, existingConverted)
+  localStorage.setItem(
+    `${STEP_GLB_CACHE_PREFIX}${stepUrl}`,
+    arrayBufferToBase64(new Uint8Array([1, 2, 3]).buffer),
+  )
+
+  const converted = getCachedConvertedStepFile(stepUrl, registry)
+
+  expect(converted).toBe(existingConverted)
+  expect(createObjectUrlCount).toBe(0)
+})
+
+test("hydrates one reusable converted STEP file from saved GLB cache", () => {
+  const stepUrl = "/models/chip.step"
+  const registry = createRegistry()
+  localStorage.setItem(
+    `${STEP_GLB_CACHE_PREFIX}${stepUrl}`,
+    arrayBufferToBase64(new Uint8Array([1, 2, 3]).buffer),
+  )
+
+  const firstConverted = getCachedConvertedStepFile(stepUrl, registry)
+  const secondConverted = getCachedConvertedStepFile(stepUrl, registry)
+
+  if (!firstConverted) {
+    throw new Error("Expected saved STEP GLB cache to hydrate a converted file")
+  }
+
+  expect(firstConverted.blobUrl).toBe("blob:step-model-1")
+  expect(secondConverted).toBe(firstConverted)
+  expect(registry.completed.get(stepUrl)).toBe(firstConverted)
+  expect(createObjectUrlCount).toBe(1)
+})


### PR DESCRIPTION
## Summary
- Reuse completed STEP conversions before hydrating the saved GLB cache, so repeated STEP mounts do not create duplicate blob URLs.
- Add a shared `load3DModel` cache so repeated STL/OBJ/WRL/GLTF/GLB URLs reuse one in-flight/completed load instead of fetching and parsing duplicates.
- Return independent clones from cached model loads and evict failed loads so retries are not poisoned by a transient failure.
- Add regression coverage for registry-first STEP reuse, one-time saved-cache hydration, shared model-load dedupe, clone isolation, and failed-load retry.

## Verification
- npm run format:check
- npx biome check src/utils/load-model.ts tests/load-model-cache.test.ts
- npx --yes bun test tests/load-model-cache.test.ts tests/step-model-cache.test.ts
- npx tsc --noEmit
- npm run build
- npm run test:node-bundle

Closes #93

/claim #93