### PR TITLE
Clear failed OBJ loader cache entries

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,11 +1,10 @@
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import { loadVrml } from "src/utils/vrml"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
-import { loadVrml } from "src/utils/vrml"
 
-// Define the type for our cache
-interface CacheItem {
-  promise: Promise<any>
+export interface CacheItem {
+  promise: Promise<Object3D | Error>
   result: Object3D | null
 }
 
@@ -18,6 +17,54 @@ declare global {
 // Ensure the global cache exists
 if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
   window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
+}
+
+export function loadGlobalObjFromCache({
+  cleanUrl,
+  cache,
+  loadModel,
+}: {
+  cleanUrl: string
+  cache: Map<string, CacheItem>
+  loadModel: () => Promise<Object3D | Error>
+}): Promise<Object3D | Error> {
+  if (cache.has(cleanUrl)) {
+    const cacheItem = cache.get(cleanUrl)!
+    if (cacheItem.result) {
+      // If we have a result, clone it
+      return Promise.resolve(cacheItem.result.clone())
+    }
+    // If we're still loading, return the existing promise
+    return cacheItem.promise.then((result) => {
+      if (result instanceof Error) return result
+      return result.clone()
+    })
+  }
+
+  let promise: Promise<Object3D | Error>
+  promise = Promise.resolve()
+    .then(loadModel)
+    .then((result) => {
+      if (result instanceof Error) {
+        if (cache.get(cleanUrl)?.promise === promise) {
+          cache.delete(cleanUrl)
+        }
+        return result
+      }
+      if (cache.get(cleanUrl)?.promise === promise) {
+        cache.set(cleanUrl, { promise, result })
+      }
+      return result
+    })
+    .catch((error) => {
+      if (cache.get(cleanUrl)?.promise === promise) {
+        cache.delete(cleanUrl)
+      }
+      return error instanceof Error ? error : new Error(String(error))
+    })
+
+  cache.set(cleanUrl, { promise, result: null })
+  return promise
 }
 
 export function useGlobalObjLoader(
@@ -78,33 +125,11 @@ export function useGlobalObjLoader(
       }
     }
 
-    function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
-        if (cacheItem.result) {
-          // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
-        }
-        // If we're still loading, return the existing promise
-        return cacheItem.promise.then((result) => {
-          if (result instanceof Error) return result
-          return result.clone()
-        })
-      }
-      // If it's not in the cache, create a new promise and cache it
-      const promise = loadAndParseObj().then((result) => {
-        if (result instanceof Error) {
-          // If the result is an Error, return it
-          return result
-        }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
-        return result
-      })
-      cache.set(cleanUrl, { promise, result: null })
-      return promise
-    }
-
-    loadUrl()
+    loadGlobalObjFromCache({
+      cleanUrl,
+      cache,
+      loadModel: loadAndParseObj,
+    })
       .then((result) => {
         if (hasUrlChanged) return
         setObj(result)

--- a/tests/global-obj-loader-cache.test.ts
+++ b/tests/global-obj-loader-cache.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test"
+import { Object3D } from "three"
+import {
+  type CacheItem,
+  loadGlobalObjFromCache,
+} from "../src/hooks/use-global-obj-loader"
+
+test("clears failed OBJ cache entries so later calls can retry", async () => {
+  const cleanUrl = "/models/part.obj"
+  const cache = new Map<string, CacheItem>()
+  const transientError = new Error("temporary fetch failure")
+  const loadedModel = new Object3D()
+  let loadCount = 0
+
+  const loadModel = async () => {
+    loadCount += 1
+    return loadCount === 1 ? transientError : loadedModel
+  }
+
+  const firstResult = await loadGlobalObjFromCache({
+    cleanUrl,
+    cache,
+    loadModel,
+  })
+
+  expect(firstResult).toBe(transientError)
+  expect(cache.has(cleanUrl)).toBe(false)
+
+  const secondResult = await loadGlobalObjFromCache({
+    cleanUrl,
+    cache,
+    loadModel,
+  })
+
+  expect(secondResult).toBe(loadedModel)
+  expect(loadCount).toBe(2)
+  expect(cache.get(cleanUrl)?.result).toBe(loadedModel)
+
+  const cachedResult = await loadGlobalObjFromCache({
+    cleanUrl,
+    cache,
+    loadModel,
+  })
+
+  expect(cachedResult).toBeInstanceOf(Object3D)
+  expect(cachedResult).not.toBe(loadedModel)
+  expect(loadCount).toBe(2)
+})
+
+test("clears rejected OBJ cache entries so later calls can retry", async () => {
+  const cleanUrl = "/models/rejecting.obj"
+  const cache = new Map<string, CacheItem>()
+  const transientError = new Error("network dropped")
+
+  const result = await loadGlobalObjFromCache({
+    cleanUrl,
+    cache,
+    loadModel: async () => {
+      throw transientError
+    },
+  })
+
+  expect(result).toBe(transientError)
+  expect(cache.has(cleanUrl)).toBe(false)
+})
+
+test("clears synchronously thrown OBJ cache errors", async () => {
+  const cleanUrl = "/models/throwing.obj"
+  const cache = new Map<string, CacheItem>()
+  const transientError = new Error("loader setup failed")
+
+  const result = await loadGlobalObjFromCache({
+    cleanUrl,
+    cache,
+    loadModel: () => {
+      throw transientError
+    },
+  })
+
+  expect(result).toBe(transientError)
+  expect(cache.has(cleanUrl)).toBe(false)
+})
+
+test("does not delete a newer cache entry when an older load fails late", async () => {
+  const cleanUrl = "/models/racing.obj"
+  const cache = new Map<string, CacheItem>()
+  const replacementModel = new Object3D()
+  let resolveFirstLoad: (result: Object3D | Error) => void = () => {}
+
+  const firstResultPromise = loadGlobalObjFromCache({
+    cleanUrl,
+    cache,
+    loadModel: () =>
+      new Promise<Object3D | Error>((resolve) => {
+        resolveFirstLoad = resolve
+      }),
+  })
+
+  await Promise.resolve()
+
+  const replacementPromise = Promise.resolve(replacementModel)
+  cache.set(cleanUrl, { promise: replacementPromise, result: replacementModel })
+
+  resolveFirstLoad(new Error("stale failure"))
+  await firstResultPromise
+
+  expect(cache.get(cleanUrl)?.result).toBe(replacementModel)
+})


### PR DESCRIPTION
/claim #93

## Summary
- Move the OBJ/WRL global cache flow into a focused helper so the cache lifecycle is covered by tests.
- Clear the matching `TSCIRCUIT_OBJ_LOADER_CACHE` entry when a model load returns an `Error`, rejects, or throws synchronously.
- Keep the successful cache path unchanged: successful loads are stored and later callers receive cloned `Object3D` instances.
- Guard cache deletion by promise identity so an older late failure cannot remove a newer successful cache entry.

## Why
On current main, a transient fetch/parse/VRML failure can leave an OBJ/WRL cache item with `result: null`. Later mounts for the same model URL then attach to the old failed promise and immediately receive the stale `Error`, so the model never retries even if the network/model server has recovered. This contributes to laggy or incomplete sessions when duplicate model URLs hit a temporary failure.

## Verification
- `npx -y bun test tests/global-obj-loader-cache.test.ts`
- `npx -y bun x biome check src/hooks/use-global-obj-loader.ts tests/global-obj-loader-cache.test.ts`
- `npx -y bun x tsc --noEmit`
- `npx -y bun run build`
- `npx -y bun run test:node-bundle`
- `git diff --check`

## Full test note
`npx -y bun test` currently reports 27 passing tests and 3 unrelated existing failures on this checkout:
- `tests/preprocess-circuit-json.test.ts`: expected faux-board z offsets are 0.1 higher than current output.
- `tests/outline-bounds.test.ts`: expected older soldermask color string does not match the current rendered SVG color.

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.