### PR TITLE
Fix #93: normalize 3D model cache keys

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import { loadVrml } from "src/utils/vrml"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
-import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
 interface CacheItem {
@@ -20,6 +20,19 @@ if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
   window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
 }
 
+const getObjLoaderCacheKey = (url: string) => {
+  try {
+    const parsedUrl = new URL(url, window.location.href)
+    parsedUrl.searchParams.delete("cachebust_origin")
+    parsedUrl.hash = ""
+    return parsedUrl.toString()
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&#]*&?/, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
 export function useGlobalObjLoader(
   url: string | null,
 ): Object3D | null | Error {
@@ -28,7 +41,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = getObjLoaderCacheKey(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
@@ -94,7 +107,7 @@ export function useGlobalObjLoader(
       // If it's not in the cache, create a new promise and cache it
       const promise = loadAndParseObj().then((result) => {
         if (result instanceof Error) {
-          // If the result is an Error, return it
+          cache.delete(cleanUrl)
           return result
         }
         cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })


### PR DESCRIPTION
## Summary
- Normalizes OBJ/WRL loader cache keys through `URL` before looking up the global model cache.
- Removes `cachebust_origin` and URL hash fragments so duplicate model URLs reuse the same cache entry instead of reloading duplicate models.
- Deletes failed loads from the cache, allowing transient network/parse failures to retry instead of poisoning the cache.

## Validation
- `bun install`
- `bunx biome check src/hooks/use-global-obj-loader.ts`
- `bun run build`
- `bun run test:node-bundle`
- `git diff --check`

/claim #93