### PR TITLE
Fix duplicate 3D model loading cache

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,7 +1,11 @@
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import {
+  cloneObject3DWithIndependentMaterials,
+  normalizeModelCacheKey,
+} from "src/utils/load-model"
+import { loadVrml } from "src/utils/vrml"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
-import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
 interface CacheItem {
@@ -28,7 +32,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = normalizeModelCacheKey(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
@@ -83,18 +87,20 @@ export function useGlobalObjLoader(
         const cacheItem = cache.get(cleanUrl)!
         if (cacheItem.result) {
           // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
+          return Promise.resolve(
+            cloneObject3DWithIndependentMaterials(cacheItem.result),
+          )
         }
         // If we're still loading, return the existing promise
         return cacheItem.promise.then((result) => {
           if (result instanceof Error) return result
-          return result.clone()
+          return cloneObject3DWithIndependentMaterials(result)
         })
       }
       // If it's not in the cache, create a new promise and cache it
       const promise = loadAndParseObj().then((result) => {
         if (result instanceof Error) {
-          // If the result is an Error, return it
+          cache.delete(cleanUrl)
           return result
         }
         cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })

--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,130 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+export type ModelFileFormat = "stl" | "obj" | "wrl" | "gltf" | "glb"
+
+type LoadModelTemplate = (
+  url: string,
+  format: ModelFileFormat,
+) => Promise<THREE.Object3D | null>
+
+type Load3DModelOptions = {
+  modelFormat?: ModelFileFormat
+  loadModel?: LoadModelTemplate
+}
+
+const modelCache = new Map<string, Promise<THREE.Object3D | null>>()
+
+export function clear3DModelCache() {
+  modelCache.clear()
+}
+
+export function getModelFileFormat(url: string): ModelFileFormat | null {
+  const path = getUrlPathname(url).toLowerCase()
+  const extension = path.match(/\.([^./]+)$/)?.[1]
+
+  if (
+    extension === "stl" ||
+    extension === "obj" ||
+    extension === "wrl" ||
+    extension === "gltf" ||
+    extension === "glb"
+  ) {
+    return extension
+  }
+
+  return null
+}
+
+export function normalizeModelCacheKey(url: string): string {
+  try {
+    const parsed = new URL(url, "https://tscircuit.local")
+    parsed.searchParams.delete("cachebust_origin")
+
+    if (parsed.origin === "https://tscircuit.local") {
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`
+    }
+
+    return parsed.toString()
+  } catch {
+    return url.replace(/([?&])cachebust_origin=[^&#]*&?/g, (_, prefix) =>
+      prefix === "?" ? "?" : "",
+    )
+  }
+}
+
+export function cloneObject3DWithIndependentMaterials(
+  object: THREE.Object3D,
+): THREE.Object3D {
+  const clone = object.clone(true)
+
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.material) return
+
+    child.material = Array.isArray(child.material)
+      ? child.material.map((material) => material.clone())
+      : child.material.clone()
+  })
+
+  return clone
+}
+
+export async function load3DModel(
+  url: string,
+  options: Load3DModelOptions = {},
+): Promise<THREE.Object3D | null> {
+  const format = options.modelFormat ?? getModelFileFormat(url)
+
+  if (!format) {
+    console.error("Unsupported file format or failed to load 3D model.")
+    return null
+  }
+
+  const loadModel = options.loadModel ?? loadFreshModelTemplate
+  const cacheKey = `${format}:${normalizeModelCacheKey(url)}`
+  let cachedTemplate = modelCache.get(cacheKey)
+
+  if (!cachedTemplate) {
+    let templatePromise: Promise<THREE.Object3D | null>
+    templatePromise = loadModel(url, format)
+      .then((model) => {
+        if (!model) {
+          if (modelCache.get(cacheKey) === templatePromise) {
+            modelCache.delete(cacheKey)
+          }
+          return null
+        }
+
+        return model
+      })
+      .catch((error) => {
+        if (modelCache.get(cacheKey) === templatePromise) {
+          modelCache.delete(cacheKey)
+        }
+        throw error
+      })
+
+    modelCache.set(cacheKey, templatePromise)
+    cachedTemplate = templatePromise
+  }
+
+  const template = await cachedTemplate
+  return template ? cloneObject3DWithIndependentMaterials(template) : null
+}
+
+function getUrlPathname(url: string): string {
+  try {
+    return new URL(url, "https://tscircuit.local").pathname
+  } catch {
+    return url.split(/[?#]/)[0] ?? url
+  }
+}
+
+async function loadFreshModelTemplate(
+  url: string,
+  format: ModelFileFormat,
+): Promise<THREE.Object3D | null> {
+  if (format === "stl") {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,21 +138,20 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (format === "obj") {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (format === "wrl") {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  if (format === "gltf" || format === "glb") {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene
   }
 
-  console.error("Unsupported file format or failed to load 3D model.")
   return null
 }

--- a/src/utils/render-component.tsx
+++ b/src/utils/render-component.tsx
@@ -1,28 +1,45 @@
-import jscad from "@jscad/modeling"
-import type { AnyCircuitElement } from "circuit-json"
+import jscad, * as jscadModeling from "@jscad/modeling"
+import type { CadComponent } from "circuit-json"
 import {
   convertCSGToThreeGeom,
   getJscadModelForFootprint,
 } from "jscad-electronics/vanilla"
 import { executeJscadOperations } from "jscad-planner"
 import * as THREE from "three"
-import * as jscadModeling from "@jscad/modeling"
-import { load3DModel } from "./load-model"
-import type { CadComponent } from "circuit-json"
+import { load3DModel, type ModelFileFormat } from "./load-model"
+
+function getCadModelUrlAndFormat(
+  component: CadComponent,
+): { url: string; modelFormat: ModelFileFormat } | null {
+  if (component.model_obj_url) {
+    return { url: component.model_obj_url, modelFormat: "obj" }
+  }
+  if (component.model_wrl_url) {
+    return { url: component.model_wrl_url, modelFormat: "wrl" }
+  }
+  if (component.model_stl_url) {
+    return { url: component.model_stl_url, modelFormat: "stl" }
+  }
+  if (component.model_glb_url) {
+    return { url: component.model_glb_url, modelFormat: "glb" }
+  }
+  if (component.model_gltf_url) {
+    return { url: component.model_gltf_url, modelFormat: "gltf" }
+  }
+
+  return null
+}
 
 export async function renderComponent(
   component: CadComponent,
   scene: THREE.Scene,
 ) {
   // Handle STL/OBJ models first
-  const url =
-    component.model_obj_url ??
-    component.model_wrl_url ??
-    component.model_stl_url ??
-    component.model_glb_url ??
-    component.model_gltf_url
-  if (url) {
-    const model = await load3DModel(url)
+  const cadModel = getCadModelUrlAndFormat(component)
+  if (cadModel) {
+    const model = await load3DModel(cadModel.url, {
+      modelFormat: cadModel.modelFormat,
+    })
     if (model) {
       if (component.position) {
         model.position.set(

--- a/tests/load-model.test.ts
+++ b/tests/load-model.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  clear3DModelCache,
+  getModelFileFormat,
+  load3DModel,
+  type ModelFileFormat,
+  normalizeModelCacheKey,
+} from "../src/utils/load-model"
+
+function createTemplateModel() {
+  const group = new THREE.Group()
+  const geometry = new THREE.BoxGeometry(1, 1, 1)
+  const material = new THREE.MeshStandardMaterial({ color: 0xff0000 })
+  group.add(new THREE.Mesh(geometry, material))
+  return group
+}
+
+function getFirstMaterial(object: THREE.Object3D) {
+  return (object.children[0] as THREE.Mesh)
+    .material as THREE.MeshStandardMaterial
+}
+
+beforeEach(() => {
+  clear3DModelCache()
+})
+
+test("detects model file formats from URL paths with query strings", () => {
+  expect(getModelFileFormat("https://cdn.example.com/model.glb?cache=1")).toBe(
+    "glb",
+  )
+  expect(getModelFileFormat("/models/part.obj#mesh")).toBe("obj")
+  expect(
+    getModelFileFormat(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=123",
+    ),
+  ).toBeNull()
+})
+
+test("normalizes cache keys by removing cachebust_origin only", () => {
+  expect(
+    normalizeModelCacheKey(
+      "https://cdn.example.com/part.obj?cachebust_origin=first&pn=C1#body",
+    ),
+  ).toBe("https://cdn.example.com/part.obj?pn=C1#body")
+
+  expect(
+    normalizeModelCacheKey("/models/part.obj?pn=C1&cachebust_origin=second"),
+  ).toBe("/models/part.obj?pn=C1")
+})
+
+test("deduplicates equivalent in-flight loads and returns isolated material clones", async () => {
+  const template = createTemplateModel()
+  let loadCount = 0
+  const loadModel = async (_url: string, _format: ModelFileFormat) => {
+    loadCount += 1
+    await Promise.resolve()
+    return template
+  }
+
+  const [first, second] = await Promise.all([
+    load3DModel(
+      "https://cdn.example.com/part.obj?cachebust_origin=first&pn=C1",
+      { modelFormat: "obj", loadModel },
+    ),
+    load3DModel(
+      "https://cdn.example.com/part.obj?pn=C1&cachebust_origin=second",
+      { modelFormat: "obj", loadModel },
+    ),
+  ])
+
+  expect(loadCount).toBe(1)
+  expect(first).toBeInstanceOf(THREE.Object3D)
+  expect(second).toBeInstanceOf(THREE.Object3D)
+  expect(first).not.toBe(second)
+
+  const firstMaterial = getFirstMaterial(first!)
+  const secondMaterial = getFirstMaterial(second!)
+  const templateMaterial = getFirstMaterial(template)
+
+  expect(firstMaterial).not.toBe(secondMaterial)
+  expect(firstMaterial).not.toBe(templateMaterial)
+
+  firstMaterial.opacity = 0.25
+  expect(secondMaterial.opacity).toBe(1)
+})
+
+test("clears failed loads from cache so a later attempt can retry", async () => {
+  const template = createTemplateModel()
+  let loadCount = 0
+  const loadModel = async (_url: string, _format: ModelFileFormat) => {
+    loadCount += 1
+    if (loadCount === 1) {
+      throw new Error("temporary load failure")
+    }
+    return template
+  }
+
+  await expect(
+    load3DModel("https://cdn.example.com/part.obj", {
+      modelFormat: "obj",
+      loadModel,
+    }),
+  ).rejects.toThrow("temporary load failure")
+
+  const model = await load3DModel("https://cdn.example.com/part.obj", {
+    modelFormat: "obj",
+    loadModel,
+  })
+
+  expect(model).toBeInstanceOf(THREE.Object3D)
+  expect(loadCount).toBe(2)
+})
+
+test("supports explicit formats for opaque model download URLs", async () => {
+  let loadedFormat: ModelFileFormat | null = null
+  const loadModel = async (_url: string, format: ModelFileFormat) => {
+    loadedFormat = format
+    return createTemplateModel()
+  }
+
+  const model = await load3DModel(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=123&cachebust_origin=",
+    { modelFormat: "obj", loadModel },
+  )
+
+  expect(model).toBeInstanceOf(THREE.Object3D)
+  expect(loadedFormat).toBe("obj")
+})


### PR DESCRIPTION
/claim #93

## Summary
- Add normalized shared caching for `load3DModel` so duplicate/cache-busted model URLs share the same in-flight/completed load.
- Return clone-per-call model instances with independent materials so hover/translucency mutations do not leak between repeated models.
- Pass explicit model formats from `renderComponent` so opaque EasyEDA download URLs still use the correct loader.
- Reuse the cache-key/material-clone helpers in the OBJ/WRL React loader and clear failed cache entries so transient failures can retry.

## Verification
- `bun test tests/load-model.test.ts`
- `bunx biome check src/utils/load-model.ts src/hooks/use-global-obj-loader.ts src/utils/render-component.tsx tests/load-model.test.ts`
- `bun run build`
- `bun run test:node-bundle`
- `git diff --check`

Full `bun test` still has three existing baseline failures in `outline-bounds.test.ts` and `preprocess-circuit-json.test.ts` that are outside this model-loading patch.