### PR TITLE
Fix OBJ loader cache isolation

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,11 +1,11 @@
-import { useState, useEffect } from "react"
-import type { Object3D } from "three"
-import { MTLLoader, OBJLoader } from "three-stdlib"
+import { useEffect, useState } from "react"
 import { loadVrml } from "src/utils/vrml"
+import { type Material, Mesh, type Object3D } from "three"
+import { MTLLoader, OBJLoader } from "three-stdlib"
 
 // Define the type for our cache
 interface CacheItem {
-  promise: Promise<any>
+  promise: Promise<Object3D | Error>
   result: Object3D | null
 }
 
@@ -20,6 +20,51 @@ if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
   window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
 }
 
+function removeCachebustOriginFallback(url: string): string {
+  return url
+    .replace(/([?&])cachebust_origin=[^&#]*&/g, "$1")
+    .replace(/[?&]cachebust_origin=[^&#]*(?=#|$)/g, "")
+    .replace(/\?&/, "?")
+}
+
+export function getGlobalObjLoaderCacheKey(url: string): string {
+  try {
+    const isAbsoluteUrl = /^[a-z][a-z\d+\-.]*:/i.test(url)
+    const parsed = new URL(url, "https://tscircuit.local")
+    parsed.searchParams.delete("cachebust_origin")
+    if (isAbsoluteUrl) {
+      return parsed.toString()
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return removeCachebustOriginFallback(url)
+  }
+}
+
+function cloneMaterial(material: Material | Material[]): Material | Material[] {
+  if (Array.isArray(material)) {
+    return material.map((item) => item.clone())
+  }
+  return material.clone()
+}
+
+export function cloneObject3DForLoaderCache(object: Object3D): Object3D {
+  const clone = object.clone(true)
+  clone.traverse((child) => {
+    if (child instanceof Mesh && child.material) {
+      child.material = cloneMaterial(child.material)
+    }
+  })
+  return clone
+}
+
+function cloneLoadedObject(result: Object3D | Error): Object3D | Error {
+  if (result instanceof Error) {
+    return result
+  }
+  return cloneObject3DForLoaderCache(result)
+}
+
 export function useGlobalObjLoader(
   url: string | null,
 ): Object3D | null | Error {
@@ -28,7 +73,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = getGlobalObjLoaderCacheKey(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
@@ -82,26 +127,32 @@ export function useGlobalObjLoader(
       if (cache.has(cleanUrl)) {
         const cacheItem = cache.get(cleanUrl)!
         if (cacheItem.result) {
-          // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
+          return Promise.resolve(cloneObject3DForLoaderCache(cacheItem.result))
         }
-        // If we're still loading, return the existing promise
-        return cacheItem.promise.then((result) => {
-          if (result instanceof Error) return result
-          return result.clone()
-        })
+        return cacheItem.promise.then(cloneLoadedObject)
       }
-      // If it's not in the cache, create a new promise and cache it
-      const promise = loadAndParseObj().then((result) => {
-        if (result instanceof Error) {
-          // If the result is an Error, return it
+      let promise: Promise<Object3D | Error>
+      promise = loadAndParseObj()
+        .then((result) => {
+          if (result instanceof Error) {
+            if (cache.get(cleanUrl)?.promise === promise) {
+              cache.delete(cleanUrl)
+            }
+            return result
+          }
+          if (cache.get(cleanUrl)?.promise === promise) {
+            cache.set(cleanUrl, { promise, result })
+          }
           return result
-        }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
-        return result
-      })
+        })
+        .catch((error) => {
+          if (cache.get(cleanUrl)?.promise === promise) {
+            cache.delete(cleanUrl)
+          }
+          throw error
+        })
       cache.set(cleanUrl, { promise, result: null })
-      return promise
+      return promise.then(cloneLoadedObject)
     }
 
     loadUrl()

--- a/tests/use-global-obj-loader.test.ts
+++ b/tests/use-global-obj-loader.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import {
+  BoxGeometry,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+} from "three"
+import {
+  cloneObject3DForLoaderCache,
+  getGlobalObjLoaderCacheKey,
+} from "../src/hooks/use-global-obj-loader"
+
+test("normalizes cachebust_origin out of OBJ loader cache keys", () => {
+  expect(
+    getGlobalObjLoaderCacheKey(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&cachebust_origin=https%3A%2F%2Ftscircuit.com&pn=C123",
+    ),
+  ).toBe(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C123",
+  )
+
+  expect(
+    getGlobalObjLoaderCacheKey(
+      "/models/chip.obj?cachebust_origin=http%3A%2F%2Flocalhost%3A6006#mesh",
+    ),
+  ).toBe("/models/chip.obj#mesh")
+})
+
+test("clones cached loader objects with independent materials", () => {
+  const geometry = new BoxGeometry(1, 1, 1)
+  const sourceMaterial = new MeshStandardMaterial({ opacity: 1 })
+  const source = new Group()
+  source.add(new Mesh(geometry, sourceMaterial))
+
+  const firstClone = cloneObject3DForLoaderCache(source) as Group
+  const secondClone = cloneObject3DForLoaderCache(source) as Group
+
+  const firstMesh = firstClone.children[0] as Mesh
+  const secondMesh = secondClone.children[0] as Mesh
+  const firstMaterial = firstMesh.material as MeshStandardMaterial
+  const secondMaterial = secondMesh.material as MeshStandardMaterial
+
+  firstMaterial.opacity = 0.25
+  firstMaterial.transparent = true
+
+  expect(firstMaterial).not.toBe(secondMaterial)
+  expect(firstMaterial).not.toBe(sourceMaterial)
+  expect(secondMaterial.opacity).toBe(1)
+  expect(secondMaterial.transparent).toBe(false)
+  expect(sourceMaterial.opacity).toBe(1)
+})
+
+test("clones material arrays for cached loader objects", () => {
+  const source = new Group()
+  source.add(
+    new Mesh(new BoxGeometry(1, 1, 1), [
+      new MeshBasicMaterial({ color: "red" }),
+      new MeshBasicMaterial({ color: "blue" }),
+    ]),
+  )
+
+  const clone = cloneObject3DForLoaderCache(source) as Group
+  const sourceMaterials = (source.children[0] as Mesh)
+    .material as MeshBasicMaterial[]
+  const clonedMaterials = (clone.children[0] as Mesh)
+    .material as MeshBasicMaterial[]
+
+  expect(clonedMaterials).toHaveLength(2)
+  expect(clonedMaterials[0]).not.toBe(sourceMaterials[0])
+  expect(clonedMaterials[1]).not.toBe(sourceMaterials[1])
+})


### PR DESCRIPTION
## Summary
- normalize OBJ/WRL loader cache keys by removing `cachebust_origin` while preserving meaningful query params
- keep cached loaded objects as templates and return material-isolated clones to each component instance
- evict failed loader cache entries so transient OBJ/WRL load failures can retry

/claim #93

## Verification
- `bun test tests/use-global-obj-loader.test.ts`
- `bunx biome check src/hooks/use-global-obj-loader.ts tests/use-global-obj-loader.test.ts`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run test:node-bundle`
- `git diff --check`

Note: a full local `bun test` also runs unrelated existing tests that currently fail on main around faux-board z offsets and one SVG color assertion; the new focused loader tests pass.