### PR TITLE
Dispose generated model resources on cleanup

### DIFF
--- a/src/three-components/FootprinterModel.tsx
+++ b/src/three-components/FootprinterModel.tsx
@@ -5,8 +5,8 @@ import {
 } from "jscad-electronics/vanilla"
 import { useEffect, useMemo } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
-import { configureObjectShadows } from "src/utils/configure-object-shadows"
 import { useThree } from "src/react-three/ThreeContext"
+import { configureObjectShadows } from "src/utils/configure-object-shadows"
 import { disposeThreeObjectResources } from "src/utils/dispose-three-object-resources"
 import * as THREE from "three"
 

--- a/src/three-components/FootprinterModel.tsx
+++ b/src/three-components/FootprinterModel.tsx
@@ -1,13 +1,14 @@
+import * as jscadModeling from "@jscad/modeling"
 import {
   convertCSGToThreeGeom,
   getJscadModelForFootprint,
 } from "jscad-electronics/vanilla"
-import { useMemo, useEffect } from "react"
-import * as jscadModeling from "@jscad/modeling"
-import * as THREE from "three"
-import { useThree } from "src/react-three/ThreeContext"
+import { useEffect, useMemo } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { configureObjectShadows } from "src/utils/configure-object-shadows"
+import { useThree } from "src/react-three/ThreeContext"
+import { disposeThreeObjectResources } from "src/utils/dispose-three-object-resources"
+import * as THREE from "three"
 
 export const FootprinterModel = ({
   positionOffset,
@@ -69,6 +70,7 @@ export const FootprinterModel = ({
     rootObject.add(group)
     return () => {
       rootObject.remove(group)
+      disposeThreeObjectResources(group)
     }
   }, [rootObject, group])
 

--- a/src/three-components/JscadModel.tsx
+++ b/src/three-components/JscadModel.tsx
@@ -1,12 +1,13 @@
-import type { JscadOperation } from "jscad-planner"
-import { executeJscadOperations } from "jscad-planner"
 import jscad from "@jscad/modeling"
 import { convertCSGToThreeGeom } from "jscad-electronics/vanilla"
-import * as THREE from "three"
-import { useMemo, useEffect } from "react"
+import type { JscadOperation } from "jscad-planner"
+import { executeJscadOperations } from "jscad-planner"
+import { useEffect, useMemo } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 import { configureObjectShadows } from "src/utils/configure-object-shadows"
+import { disposeThreeObjectResources } from "src/utils/dispose-three-object-resources"
+import * as THREE from "three"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 export const JscadModel = ({
@@ -78,6 +79,13 @@ export const JscadModel = ({
     modelFitMode,
     scale,
   })
+
+  useEffect(() => {
+    if (!mesh) return
+    return () => {
+      disposeThreeObjectResources(mesh)
+    }
+  }, [mesh])
 
   useEffect(() => {
     if (!material) return

--- a/src/utils/dispose-three-object-resources.ts
+++ b/src/utils/dispose-three-object-resources.ts
@@ -1,0 +1,24 @@
+import * as THREE from "three"
+
+function disposeMaterial(material: THREE.Material | THREE.Material[]) {
+  if (Array.isArray(material)) {
+    for (const entry of material) {
+      entry.dispose()
+    }
+    return
+  }
+
+  material.dispose()
+}
+
+export function disposeThreeObjectResources(object: THREE.Object3D) {
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    child.geometry?.dispose()
+
+    if (child.material) {
+      disposeMaterial(child.material)
+    }
+  })
+}

--- a/tests/dispose-three-object-resources.test.ts
+++ b/tests/dispose-three-object-resources.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { disposeThreeObjectResources } from "../src/utils/dispose-three-object-resources"
+
+test("disposes geometry and material resources on nested meshes", () => {
+  const group = new THREE.Group()
+  const geometry = new THREE.BufferGeometry()
+  const material = new THREE.MeshStandardMaterial()
+  let geometryDisposed = 0
+  let materialDisposed = 0
+
+  geometry.dispose = () => {
+    geometryDisposed += 1
+  }
+  material.dispose = () => {
+    materialDisposed += 1
+  }
+
+  group.add(new THREE.Mesh(geometry, material))
+
+  disposeThreeObjectResources(group)
+
+  expect(geometryDisposed).toBe(1)
+  expect(materialDisposed).toBe(1)
+})
+
+test("disposes every material in a material array", () => {
+  const geometry = new THREE.BufferGeometry()
+  const firstMaterial = new THREE.MeshStandardMaterial()
+  const secondMaterial = new THREE.MeshStandardMaterial()
+  const mesh = new THREE.Mesh(geometry, [firstMaterial, secondMaterial])
+  const disposedMaterials: string[] = []
+
+  geometry.dispose = () => {}
+  firstMaterial.dispose = () => {
+    disposedMaterials.push("first")
+  }
+  secondMaterial.dispose = () => {
+    disposedMaterials.push("second")
+  }
+
+  disposeThreeObjectResources(mesh)
+
+  expect(disposedMaterials).toEqual(["first", "second"])
+})


### PR DESCRIPTION
## Summary

- Add a small Three.js cleanup helper that disposes mesh geometries and both single/material-array materials.
- Dispose generated Footprinter and JSCAD model resources when React removes those generated objects.
- Add unit coverage for nested mesh cleanup and material-array cleanup.

## Testing

- `bunx biome check src/utils/dispose-three-object-resources.ts src/three-components/FootprinterModel.tsx src/three-components/JscadModel.tsx tests/dispose-three-object-resources.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run test:node-bundle`
- Targeted Bun test for `tests/dispose-three-object-resources.test.ts` without the global snapshot preload

Note: the default repo-wide `bun test` path is blocked in this local Windows checkout by the unrelated `sharp` native module used by the snapshot preload, so I validated the new test in isolation plus the package build/type/bundle checks above.

/claim #93