### PR TITLE
Cache normalized 3D model loads

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,56 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
+type SupportedModelExtension = ".stl" | ".obj" | ".wrl" | ".gltf" | ".glb"
+
+const supportedModelExtensions = new Set<SupportedModelExtension>([
+  ".stl",
+  ".obj",
+  ".wrl",
+  ".gltf",
+  ".glb",
+])
+
+const modelCache = new Map<string, Promise<THREE.Object3D | null>>()
+
+export function getModelFileExtension(
+  url: string,
+): SupportedModelExtension | null {
+  const path = getUrlPathname(url).toLowerCase()
+  const dotIndex = path.lastIndexOf(".")
+  if (dotIndex === -1) return null
+
+  const extension = path.slice(dotIndex) as SupportedModelExtension
+  return supportedModelExtensions.has(extension) ? extension : null
+}
+
+export function getModelCacheKey(url: string): string {
+  const parsed = parseModelUrl(url)
+  if (!parsed) return url.replace(/([?&])cachebust_origin=[^&#]*&?/, "$1")
+
+  parsed.searchParams.delete("cachebust_origin")
+  return parsed.href
+}
+
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+  const cacheKey = getModelCacheKey(url)
+  let cachedModelPromise = modelCache.get(cacheKey)
+
+  if (!cachedModelPromise) {
+    cachedModelPromise = load3DModelUncached(url)
+    modelCache.set(cacheKey, cachedModelPromise)
+  }
+
+  const cachedModel = await cachedModelPromise
+  return cachedModel ? cloneModelForInstance(cachedModel) : null
+}
+
+async function load3DModelUncached(
+  url: string,
+): Promise<THREE.Object3D | null> {
+  const extension = getModelFileExtension(url)
+
+  if (extension === ".stl") {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,16 +64,16 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (extension === ".obj") {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (extension === ".wrl") {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  if (extension === ".gltf" || extension === ".glb") {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene
@@ -33,4 +81,33 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
 
   console.error("Unsupported file format or failed to load 3D model.")
   return null
+}
+
+function cloneModelForInstance(model: THREE.Object3D): THREE.Object3D {
+  const clone = model.clone(true)
+
+  clone.traverse((object) => {
+    if (!(object instanceof THREE.Mesh)) return
+
+    object.geometry = object.geometry.clone()
+    if (Array.isArray(object.material)) {
+      object.material = object.material.map((material) => material.clone())
+    } else {
+      object.material = object.material.clone()
+    }
+  })
+
+  return clone
+}
+
+function getUrlPathname(url: string): string {
+  return parseModelUrl(url)?.pathname ?? url.split(/[?#]/, 1)[0] ?? url
+}
+
+function parseModelUrl(url: string): URL | null {
+  try {
+    return new URL(url, "https://tscircuit.local")
+  } catch {
+    return null
+  }
 }

--- a/tests/load-model.test.ts
+++ b/tests/load-model.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { getModelCacheKey, getModelFileExtension } from "../src/utils/load-model"
+
+test("detects model file extensions before query strings and hashes", () => {
+  expect(getModelFileExtension("https://cdn.example.com/part.glb?cachebust_origin=a#v1")).toBe(
+    ".glb",
+  )
+  expect(getModelFileExtension("/models/bracket.STL?download=1")).toBe(".stl")
+  expect(getModelFileExtension("/models/shape.obj#preview")).toBe(".obj")
+  expect(getModelFileExtension("/models/shape.step?cachebust_origin=a")).toBeNull()
+})
+
+test("normalizes cachebust_origin without dropping meaningful query params", () => {
+  expect(
+    getModelCacheKey("https://cdn.example.com/part.glb?cachebust_origin=a&variant=left"),
+  ).toBe("https://cdn.example.com/part.glb?variant=left")
+  expect(getModelCacheKey("/models/part.obj?cachebust_origin=one")).toBe(
+    "https://tscircuit.local/models/part.obj",
+  )
+  expect(getModelCacheKey("/models/part.obj?variant=right")).toBe(
+    "https://tscircuit.local/models/part.obj?variant=right",
+  )
+})


### PR DESCRIPTION
Fixes a remaining duplicate-loading path in `load3DModel` for #93.

/claim #93

## Summary
- Detect supported model extensions from the URL pathname so query strings and hashes do not make valid model URLs unsupported.
- Normalize `cachebust_origin` out of the cache key while preserving meaningful query parameters.
- Share in-flight/completed model loads, then clone geometry and materials for each render instance so repeated models do not share mutable visual state.
- Add focused tests for extension detection and cache-key normalization.

## Verification
- Not run locally: this Codex environment could not create a normal git working tree or install/run the repo locally; the patch was prepared through the GitHub connector.

## Disclosure
AI-assisted with Codex; I reviewed the diff and kept the change scoped.