### PR TITLE
Cache glTF model scenes

### DIFF
--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from "react"
 import * as THREE from "three"
-import { GLTFLoader } from "three-stdlib"
 import { useThree } from "src/react-three/ThreeContext"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import { loadCachedGltfScene } from "src/utils/gltf-model-cache"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 const DEFAULT_ENV_MAP_INTENSITY = 1.25
@@ -55,13 +55,10 @@ export function GltfModel({
 
   useEffect(() => {
     if (!gltfUrl) return
-    const loader = new GLTFLoader()
     let isMounted = true
-    loader.load(
-      gltfUrl,
-      (gltf) => {
+    loadCachedGltfScene(gltfUrl)
+      .then((scene) => {
         if (!isMounted) return
-        const scene = gltf.scene
 
         scene.traverse((child) => {
           if (child instanceof THREE.Mesh && child.material) {
@@ -83,9 +80,8 @@ export function GltfModel({
         })
 
         setModel(scene)
-      },
-      undefined,
-      (error) => {
+      })
+      .catch((error) => {
         if (!isMounted) return
         console.error(`An error happened loading ${gltfUrl}`, error)
         const err =
@@ -93,8 +89,7 @@ export function GltfModel({
             ? error
             : new Error(`Failed to load glTF model from ${gltfUrl}`)
         setLoadError(err)
-      },
-    )
+      })
     return () => {
       isMounted = false
     }

--- a/src/utils/gltf-model-cache.ts
+++ b/src/utils/gltf-model-cache.ts
@@ -71,10 +71,16 @@ export async function loadCachedGltfScene(
   }
 
   const loader = new GLTFLoader()
-  const promise = loader.loadAsync(gltfUrl).then((gltf) => {
-    cache.set(cacheKey, { promise, scene: gltf.scene })
-    return gltf.scene
-  })
+  const promise = loader
+    .loadAsync(gltfUrl)
+    .then((gltf) => {
+      cache.set(cacheKey, { promise, scene: gltf.scene })
+      return gltf.scene
+    })
+    .catch((error) => {
+      cache.delete(cacheKey)
+      throw error
+    })
 
   cache.set(cacheKey, { promise, scene: null })
 

--- a/src/utils/gltf-model-cache.ts
+++ b/src/utils/gltf-model-cache.ts
@@ -1,0 +1,83 @@
+import * as THREE from "three"
+import { GLTFLoader } from "three-stdlib"
+
+type GltfCacheItem = {
+  promise: Promise<THREE.Group>
+  scene: THREE.Group | null
+}
+
+declare global {
+  interface Window {
+    TSCIRCUIT_GLTF_LOADER_CACHE?: Map<string, GltfCacheItem>
+  }
+}
+
+const moduleCache = new Map<string, GltfCacheItem>()
+
+const getGltfCache = () => {
+  if (typeof window === "undefined") return moduleCache
+  window.TSCIRCUIT_GLTF_LOADER_CACHE ??= new Map<string, GltfCacheItem>()
+  return window.TSCIRCUIT_GLTF_LOADER_CACHE
+}
+
+export const normalizeGltfModelCacheKey = (url: string) => {
+  try {
+    const parsedUrl = new URL(url, "https://cache-key.tscircuit.local")
+    parsedUrl.searchParams.delete("cachebust_origin")
+    const normalizedPath = `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return `${parsedUrl.origin}${normalizedPath}`
+    }
+
+    return normalizedPath
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&]*&?/g, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
+export const cloneSceneWithIndependentMaterials = <T extends THREE.Object3D>(
+  scene: T,
+): T => {
+  const clone = scene.clone(true)
+
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.material) return
+
+    child.material = Array.isArray(child.material)
+      ? child.material.map((material) => material.clone())
+      : child.material.clone()
+  })
+
+  return clone
+}
+
+export async function loadCachedGltfScene(
+  gltfUrl: string,
+): Promise<THREE.Group> {
+  const cacheKey = normalizeGltfModelCacheKey(gltfUrl)
+  const cache = getGltfCache()
+  const cached = cache.get(cacheKey)
+
+  if (cached?.scene) {
+    return cloneSceneWithIndependentMaterials(cached.scene)
+  }
+
+  if (cached) {
+    const scene = await cached.promise
+    return cloneSceneWithIndependentMaterials(scene)
+  }
+
+  const loader = new GLTFLoader()
+  const promise = loader.loadAsync(gltfUrl).then((gltf) => {
+    cache.set(cacheKey, { promise, scene: gltf.scene })
+    return gltf.scene
+  })
+
+  cache.set(cacheKey, { promise, scene: null })
+
+  const scene = await promise
+  return cloneSceneWithIndependentMaterials(scene)
+}

--- a/tests/gltf-model-cache.test.ts
+++ b/tests/gltf-model-cache.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from "bun:test"
-import * as THREE from "three"
-import {
-  cloneSceneWithIndependentMaterials,
-  normalizeGltfModelCacheKey,
-} from "../src/utils/gltf-model-cache"
+import { normalizeGltfModelCacheKey } from "../src/utils/gltf-model-cache"
 
 test("normalizes cachebust_origin without dropping meaningful query params", () => {
   expect(
@@ -15,19 +11,4 @@ test("normalizes cachebust_origin without dropping meaningful query params", () 
   expect(
     normalizeGltfModelCacheKey("/models/chip.glb?cachebust_origin=abc"),
   ).toBe("/models/chip.glb")
-})
-
-test("clones cached scenes with independent material instances", () => {
-  const material = new THREE.MeshStandardMaterial({ color: 0x00ff00 })
-  const original = new THREE.Group()
-  original.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material))
-
-  const firstClone = cloneSceneWithIndependentMaterials(original)
-  const secondClone = cloneSceneWithIndependentMaterials(original)
-  const firstMesh = firstClone.children[0] as THREE.Mesh
-  const secondMesh = secondClone.children[0] as THREE.Mesh
-
-  expect(firstMesh.material).not.toBe(material)
-  expect(secondMesh.material).not.toBe(material)
-  expect(firstMesh.material).not.toBe(secondMesh.material)
 })

--- a/tests/gltf-model-cache.test.ts
+++ b/tests/gltf-model-cache.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  cloneSceneWithIndependentMaterials,
+  normalizeGltfModelCacheKey,
+} from "../src/utils/gltf-model-cache"
+
+test("normalizes cachebust_origin without dropping meaningful query params", () => {
+  expect(
+    normalizeGltfModelCacheKey(
+      "https://assets.tscircuit.com/chip.glb?foo=1&cachebust_origin=abc&bar=2",
+    ),
+  ).toBe("https://assets.tscircuit.com/chip.glb?foo=1&bar=2")
+
+  expect(
+    normalizeGltfModelCacheKey("/models/chip.glb?cachebust_origin=abc"),
+  ).toBe("/models/chip.glb")
+})
+
+test("clones cached scenes with independent material instances", () => {
+  const material = new THREE.MeshStandardMaterial({ color: 0x00ff00 })
+  const original = new THREE.Group()
+  original.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material))
+
+  const firstClone = cloneSceneWithIndependentMaterials(original)
+  const secondClone = cloneSceneWithIndependentMaterials(original)
+  const firstMesh = firstClone.children[0] as THREE.Mesh
+  const secondMesh = secondClone.children[0] as THREE.Mesh
+
+  expect(firstMesh.material).not.toBe(material)
+  expect(secondMesh.material).not.toBe(material)
+  expect(firstMesh.material).not.toBe(secondMesh.material)
+})

--- a/tests/gltf-model-cache2.test.ts
+++ b/tests/gltf-model-cache2.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { cloneSceneWithIndependentMaterials } from "../src/utils/gltf-model-cache"
+
+test("clones cached scenes with independent material instances", () => {
+  const material = new THREE.MeshStandardMaterial({ color: 0x00ff00 })
+  const original = new THREE.Group()
+  original.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material))
+
+  const firstClone = cloneSceneWithIndependentMaterials(original)
+  const secondClone = cloneSceneWithIndependentMaterials(original)
+  const firstMesh = firstClone.children[0] as THREE.Mesh
+  const secondMesh = secondClone.children[0] as THREE.Mesh
+
+  expect(firstMesh.material).not.toBe(material)
+  expect(secondMesh.material).not.toBe(material)
+  expect(firstMesh.material).not.toBe(secondMesh.material)
+})


### PR DESCRIPTION
## Summary
- cache loaded GLTF/GLB scenes by normalized model URL so duplicate model instances share the same in-flight/completed load
- strip only cachebust_origin from cache keys while preserving meaningful query params
- clone cached scenes with independent material instances so translucency, env-map, and hover mutations do not leak between components
- switch GltfModel to use the shared cache helper

## Tests
- bun test tests/gltf-model-cache.test.ts
- bun run build

/claim #93
