### PR TITLE
fix: persist CadViewer engine and camera choices across remounts

### DIFF
--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -5,6 +5,14 @@ import * as THREE from "three"
 // Constants for camera initialization - defined once, reused across renders
 const DEFAULT_TARGET = new THREE.Vector3(0, 0, 0)
 const INITIAL_CAMERA_POSITION = [5, -5, 5] as const
+
+const readStoredCameraType = (): "perspective" | "orthographic" | undefined => {
+  if (typeof window === "undefined") return undefined
+  const stored = window.localStorage.getItem("cadViewerCameraType")
+  return stored === "orthographic" || stored === "perspective"
+    ? stored
+    : undefined
+}
 import { CadViewerJscad } from "./CadViewerJscad"
 import CadViewerManifold from "./CadViewerManifold"
 import { useContextMenu } from "./hooks/useContextMenu"
@@ -28,7 +36,10 @@ import { KeyboardShortcutsDialog } from "./components/KeyboardShortcutsDialog"
 import type { CameraController, CameraPreset } from "./hooks/cameraAnimation"
 
 const CadViewerInner = (props: any) => {
-  const [engine, setEngine] = useState<"jscad" | "manifold">("manifold")
+  const [engine, setEngine] = useState<"jscad" | "manifold">(() => {
+    const stored = window.localStorage.getItem("cadViewerEngine")
+    return stored === "jscad" || stored === "manifold" ? stored : "manifold"
+  })
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [isKeyboardShortcutsDialogOpen, setIsKeyboardShortcutsDialogOpen] =
     useState(false)
@@ -188,13 +199,6 @@ const CadViewerInner = (props: any) => {
   }, [])
 
   useEffect(() => {
-    const stored = window.localStorage.getItem("cadViewerEngine")
-    if (stored === "jscad" || stored === "manifold") {
-      setEngine(stored)
-    }
-  }, [])
-
-  useEffect(() => {
     window.localStorage.setItem("cadViewerEngine", engine)
   }, [engine])
 
@@ -208,14 +212,6 @@ const CadViewerInner = (props: any) => {
       String(autoRotateUserToggled),
     )
   }, [autoRotateUserToggled])
-
-  // Initialize camera type from localStorage
-  useEffect(() => {
-    const stored = window.localStorage.getItem("cadViewerCameraType")
-    if (stored === "orthographic" || stored === "perspective") {
-      setCameraType(stored)
-    }
-  }, [setCameraType])
 
   // Sync camera type to localStorage
   useEffect(() => {
@@ -313,6 +309,7 @@ export const CadViewer = (props: any) => {
     <CameraControllerProvider
       defaultTarget={DEFAULT_TARGET}
       initialCameraPosition={INITIAL_CAMERA_POSITION}
+      initialCameraType={readStoredCameraType()}
     >
       <LayerVisibilityProvider>
         <ToastProvider>

--- a/src/contexts/CameraControllerContext.tsx
+++ b/src/contexts/CameraControllerContext.tsx
@@ -91,16 +91,17 @@ interface CameraControllerProviderProps {
   children: React.ReactNode
   defaultTarget: THREE.Vector3
   initialCameraPosition?: readonly [number, number, number]
+  initialCameraType?: "perspective" | "orthographic"
 }
 
 export const CameraControllerProvider: React.FC<
   CameraControllerProviderProps
-> = ({ children, defaultTarget, initialCameraPosition }) => {
+> = ({ children, defaultTarget, initialCameraPosition, initialCameraType }) => {
   const controlsRef = useRef<ThreeOrbitControls | null>(null)
   const mainCameraRef = useRef<THREE.Camera | null>(null)
   const [controller, setController] = useState<CameraController | null>(null)
   const [cameraType, setCameraType] = useState<"perspective" | "orthographic">(
-    "perspective",
+    initialCameraType ?? "perspective",
   )
   const [cameraPosition, setCameraPosition] = useState<
     readonly [number, number, number] | null


### PR DESCRIPTION
## Summary

Fix a localStorage race in `CadViewer` that clobbered the user's persisted engine and camera-type choices on every mount.

**Root cause**

For both `engine` and `cameraType`, the component was using a pair of effects:
1. A read effect that loaded the stored value and called `setEngine` / `setCameraType`.
2. A write effect that mirrored current state into `localStorage`.

On mount, both effects fire after the first render. The write effect runs with the closure-captured initial state (`"manifold"` / `"perspective"`) and overwrites the stored value before the read effect's setter has a chance to commit. The persisted choice gets clobbered.

**Fix**

- `engine` is now lazy-initialized from `localStorage` directly in `useState`, so the first write effect already sees the correct value.
- `cameraType` lives in `CameraControllerContext`. Added an optional `initialCameraType` prop on the provider so `CadViewer` can synchronously read `localStorage` and pass it down — same lazy-init shape, just one layer up.
- Removed both now-redundant read effects.

`autoRotate` / `autoRotateUserToggled` were already correctly lazy-initialized; no change there. The `localStorage` write in `StepModel.tsx` is a content cache (no state mirroring), so it's not affected by this pattern.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run format:check` — clean
- [ ] Manual: pick JSCAD engine, reload page, verify it stays selected
- [ ] Manual: switch to orthographic camera, reload, verify it stays selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)