### PR TITLE
Dispose temporary STEP conversion resources

### DIFF
--- a/src/three-components/StepModel.tsx
+++ b/src/three-components/StepModel.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react"
+import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import { disposeStepConversionResources } from "src/utils/dispose-step-conversion-resources"
 import {
   BufferGeometry,
   Color,
@@ -9,7 +11,6 @@ import {
 } from "three"
 import { GLTFExporter } from "three-stdlib"
 import { GltfModel } from "./GltfModel"
-import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 
 type OcctImportParams = {
   linearUnit?: "millimeter" | "centimeter" | "meter" | "inch" | "foot"
@@ -121,24 +122,27 @@ async function convertStepUrlToGlb(stepUrl: string): Promise<ArrayBuffer> {
     throw new Error("occt-import-js failed to convert STEP file")
   }
   const group = occtMeshesToGroup(result.meshes)
-  const exporter = new GLTFExporter()
-  const glb = await new Promise<ArrayBuffer>((resolve, reject) => {
-    exporter.parse(
-      group,
-      (output) => {
-        if (output instanceof ArrayBuffer) {
-          resolve(output)
-        } else {
-          reject(new Error("GLTFExporter did not return binary output"))
-        }
-      },
-      (error) => {
-        reject(error)
-      },
-      { binary: true },
-    )
-  })
-  return glb
+  try {
+    const exporter = new GLTFExporter()
+    return await new Promise<ArrayBuffer>((resolve, reject) => {
+      exporter.parse(
+        group,
+        (output) => {
+          if (output instanceof ArrayBuffer) {
+            resolve(output)
+          } else {
+            reject(new Error("GLTFExporter did not return binary output"))
+          }
+        },
+        (error) => {
+          reject(error)
+        },
+        { binary: true },
+      )
+    })
+  } finally {
+    disposeStepConversionResources(group)
+  }
 }
 
 const CACHE_PREFIX = "step-glb-cache:"

--- a/src/utils/dispose-step-conversion-resources.ts
+++ b/src/utils/dispose-step-conversion-resources.ts
@@ -1,0 +1,17 @@
+import * as THREE from "three"
+
+export function disposeStepConversionResources(group: THREE.Group): void {
+  group.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    child.geometry.dispose()
+
+    if (Array.isArray(child.material)) {
+      for (const material of child.material) {
+        material.dispose()
+      }
+    } else {
+      child.material.dispose()
+    }
+  })
+}

--- a/tests/dispose-step-conversion-resources.test.ts
+++ b/tests/dispose-step-conversion-resources.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { disposeStepConversionResources } from "../src/utils/dispose-step-conversion-resources"
+
+test("disposes mesh geometry and material resources in a group", () => {
+  const group = new THREE.Group()
+  const geometry = new THREE.BoxGeometry()
+  const material = new THREE.MeshBasicMaterial()
+  let geometryDisposeCount = 0
+  let materialDisposeCount = 0
+
+  geometry.dispose = () => {
+    geometryDisposeCount += 1
+  }
+  material.dispose = () => {
+    materialDisposeCount += 1
+  }
+
+  group.add(new THREE.Object3D())
+  group.add(new THREE.Mesh(geometry, material))
+
+  disposeStepConversionResources(group)
+
+  expect(geometryDisposeCount).toBe(1)
+  expect(materialDisposeCount).toBe(1)
+})
+
+test("disposes every material in mesh material arrays", () => {
+  const group = new THREE.Group()
+  const geometry = new THREE.BoxGeometry()
+  const firstMaterial = new THREE.MeshBasicMaterial()
+  const secondMaterial = new THREE.MeshBasicMaterial()
+  const materialDisposeCounts = [0, 0]
+  let geometryDisposeCount = 0
+
+  geometry.dispose = () => {
+    geometryDisposeCount += 1
+  }
+  firstMaterial.dispose = () => {
+    materialDisposeCounts[0] += 1
+  }
+  secondMaterial.dispose = () => {
+    materialDisposeCounts[1] += 1
+  }
+
+  group.add(new THREE.Mesh(geometry, [firstMaterial, secondMaterial]))
+
+  disposeStepConversionResources(group)
+
+  expect(geometryDisposeCount).toBe(1)
+  expect(materialDisposeCounts).toEqual([1, 1])
+})

--- a/tests/dispose-step-conversion-resources.test.ts
+++ b/tests/dispose-step-conversion-resources.test.ts
@@ -30,17 +30,18 @@ test("disposes every material in mesh material arrays", () => {
   const geometry = new THREE.BoxGeometry()
   const firstMaterial = new THREE.MeshBasicMaterial()
   const secondMaterial = new THREE.MeshBasicMaterial()
-  const materialDisposeCounts = [0, 0]
+  let firstMaterialDisposeCount = 0
+  let secondMaterialDisposeCount = 0
   let geometryDisposeCount = 0
 
   geometry.dispose = () => {
     geometryDisposeCount += 1
   }
   firstMaterial.dispose = () => {
-    materialDisposeCounts[0] += 1
+    firstMaterialDisposeCount += 1
   }
   secondMaterial.dispose = () => {
-    materialDisposeCounts[1] += 1
+    secondMaterialDisposeCount += 1
   }
 
   group.add(new THREE.Mesh(geometry, [firstMaterial, secondMaterial]))
@@ -48,5 +49,6 @@ test("disposes every material in mesh material arrays", () => {
   disposeStepConversionResources(group)
 
   expect(geometryDisposeCount).toBe(1)
-  expect(materialDisposeCounts).toEqual([1, 1])
+  expect(firstMaterialDisposeCount).toBe(1)
+  expect(secondMaterialDisposeCount).toBe(1)
 })


### PR DESCRIPTION
Summary:
- Dispose the temporary OCCT-generated Three.js group after STEP-to-GLB export completes or fails.
- Free conversion-only geometries and materials immediately instead of retaining them until GC.
- Leave the existing GLB/localStorage/blob cache behavior unchanged.

/claim #93

Checks:
- `bun -e 'import * as THREE from "three"; import { disposeStepConversionResources } from "./src/utils/dispose-step-conversion-resources"; const group = new THREE.Group(); const geometry = new THREE.BufferGeometry(); const material = new THREE.MeshStandardMaterial(); let geometryDisposed = 0; let materialDisposed = 0; geometry.dispose = () => { geometryDisposed += 1 }; material.dispose = () => { materialDisposed += 1 }; group.add(new THREE.Mesh(geometry, material)); disposeStepConversionResources(group); if (geometryDisposed !== 1 || materialDisposed !== 1) throw new Error(`dispose failed: ${geometryDisposed}/${materialDisposed}`); console.log("dispose smoke passed")'`
- `bunx biome check src/three-components/StepModel.tsx src/utils/dispose-step-conversion-resources.ts`

Note: `bun run build` completed the ESM bundle locally, then stalled in DTS generation for several minutes, so I stopped it.
