### PR TITLE
Cache repeated model loads

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,24 +1,8 @@
 import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
+import { globalModelLoader } from "src/utils/cached-model-loader"
 import { loadVrml } from "src/utils/vrml"
-
-// Define the type for our cache
-interface CacheItem {
-  promise: Promise<any>
-  result: Object3D | null
-}
-
-declare global {
-  interface Window {
-    TSCIRCUIT_OBJ_LOADER_CACHE: Map<string, CacheItem>
-  }
-}
-
-// Ensure the global cache exists
-if (typeof window !== "undefined" && !window.TSCIRCUIT_OBJ_LOADER_CACHE) {
-  window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map<string, CacheItem>()
-}
 
 export function useGlobalObjLoader(
   url: string | null,
@@ -28,12 +12,11 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
-
-    const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false
 
-    async function loadAndParseObj() {
+    async function loadAndParseObj(
+      cleanUrl: string,
+    ): Promise<Object3D | Error> {
       try {
         if (cleanUrl.endsWith(".wrl")) {
           return await loadVrml(cleanUrl)
@@ -78,33 +61,8 @@ export function useGlobalObjLoader(
       }
     }
 
-    function loadUrl() {
-      if (cache.has(cleanUrl)) {
-        const cacheItem = cache.get(cleanUrl)!
-        if (cacheItem.result) {
-          // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
-        }
-        // If we're still loading, return the existing promise
-        return cacheItem.promise.then((result) => {
-          if (result instanceof Error) return result
-          return result.clone()
-        })
-      }
-      // If it's not in the cache, create a new promise and cache it
-      const promise = loadAndParseObj().then((result) => {
-        if (result instanceof Error) {
-          // If the result is an Error, return it
-          return result
-        }
-        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
-        return result
-      })
-      cache.set(cleanUrl, { promise, result: null })
-      return promise
-    }
-
-    loadUrl()
+    globalModelLoader
+      .load(url, loadAndParseObj)
       .then((result) => {
         if (hasUrlChanged) return
         setObj(result)

--- a/src/utils/cached-model-loader.ts
+++ b/src/utils/cached-model-loader.ts
@@ -1,0 +1,66 @@
+import * as THREE from "three"
+
+type CachedModelEntry = {
+  promise: Promise<THREE.Object3D | Error>
+  result: THREE.Object3D | null
+}
+
+export const normalizeModelCacheUrl = (url: string) =>
+  url.replace(/&cachebust_origin=$/, "")
+
+export function cloneCachedModel(model: THREE.Object3D): THREE.Object3D {
+  const clone = model.clone(true)
+
+  clone.traverse((node) => {
+    if (!(node instanceof THREE.Mesh)) return
+
+    node.geometry = node.geometry.clone()
+    node.material = Array.isArray(node.material)
+      ? node.material.map((material) => material.clone())
+      : node.material.clone()
+  })
+
+  return clone
+}
+
+export class CachedModelLoader {
+  private cache = new Map<string, CachedModelEntry>()
+
+  async load(
+    url: string,
+    loadModel: (cleanUrl: string) => Promise<THREE.Object3D | Error>,
+  ): Promise<THREE.Object3D | Error> {
+    const cleanUrl = normalizeModelCacheUrl(url)
+    const cached = this.cache.get(cleanUrl)
+
+    if (cached) {
+      if (cached.result) {
+        return cloneCachedModel(cached.result)
+      }
+
+      const result = await cached.promise
+      return result instanceof Error ? result : cloneCachedModel(result)
+    }
+
+    const promise = loadModel(cleanUrl).then((result) => {
+      if (!(result instanceof Error)) {
+        const entry = this.cache.get(cleanUrl)
+        if (entry) {
+          entry.result = result
+        }
+      }
+      return result
+    })
+
+    this.cache.set(cleanUrl, { promise, result: null })
+
+    const result = await promise
+    return result instanceof Error ? result : cloneCachedModel(result)
+  }
+
+  clear() {
+    this.cache.clear()
+  }
+}
+
+export const globalModelLoader = new CachedModelLoader()

--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -2,9 +2,17 @@ import * as THREE from "three"
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
+import { globalModelLoader } from "./cached-model-loader"
 import { loadVrml } from "./vrml"
 
 export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+  const model = await globalModelLoader.load(url, load3DModelUncached)
+  return model instanceof Error ? null : model
+}
+
+async function load3DModelUncached(
+  url: string,
+): Promise<THREE.Object3D | Error> {
   if (url.endsWith(".stl")) {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
@@ -32,5 +40,5 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
   }
 
   console.error("Unsupported file format or failed to load 3D model.")
-  return null
+  return new Error(`Unsupported file format or failed to load 3D model: ${url}`)
 }

--- a/tests/cached-model-loader.test.ts
+++ b/tests/cached-model-loader.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  CachedModelLoader,
+  normalizeModelCacheUrl,
+} from "../src/utils/cached-model-loader"
+
+test("normalizes empty cachebust_origin suffixes", () => {
+  expect(normalizeModelCacheUrl("/model.obj&cachebust_origin=")).toBe(
+    "/model.obj",
+  )
+})
+
+test("deduplicates model loads while returning cloned instances", async () => {
+  const loader = new CachedModelLoader()
+  let loadCount = 0
+
+  const sourceGeometry = new THREE.BoxGeometry()
+  const sourceMaterial = new THREE.MeshStandardMaterial({ color: "red" })
+
+  const [first, second] = await Promise.all([
+    loader.load("/chip.obj", async () => {
+      loadCount += 1
+      return new THREE.Mesh(sourceGeometry, sourceMaterial)
+    }),
+    loader.load("/chip.obj", async () => {
+      loadCount += 1
+      return new THREE.Mesh(sourceGeometry, sourceMaterial)
+    }),
+  ])
+
+  const third = await loader.load("/chip.obj", async () => {
+    loadCount += 1
+    return new THREE.Mesh(sourceGeometry, sourceMaterial)
+  })
+
+  expect(loadCount).toBe(1)
+  expect(first).toBeInstanceOf(THREE.Mesh)
+  expect(second).toBeInstanceOf(THREE.Mesh)
+  expect(third).toBeInstanceOf(THREE.Mesh)
+  expect(first).not.toBe(second)
+  expect(second).not.toBe(third)
+  expect((first as THREE.Mesh).geometry).not.toBe(
+    (second as THREE.Mesh).geometry,
+  )
+  expect((first as THREE.Mesh).material).not.toBe(
+    (second as THREE.Mesh).material,
+  )
+})


### PR DESCRIPTION
Fixes #93
/claim #93

This adds a shared model cache keyed by the cleaned model URL. Repeated components now reuse the same in-flight/completed load instead of fetching and parsing the same model again.

Each render still gets its own cloned model, including cloned geometry/materials, so hover and translucency state do not leak between duplicate parts.

Checked:
- bunx biome format src/utils/cached-model-loader.ts src/hooks/use-global-obj-loader.ts src/utils/load-model.ts tests/cached-model-loader.test.ts
- bunx tsc --noEmit
- bun run build

Note: I could not run the Bun test file locally because the repo preload imports looks-same/sharp, and sharp failed to finish installing libvips on this Windows machine.