### PR TITLE
fix: normalize filled cachebust_origin values in model cache key (#93)

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
+import { get3DModelCacheKey } from "src/utils/get-3d-model-cache-key"
 import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
@@ -28,7 +29,7 @@ export function useGlobalObjLoader(
   useEffect(() => {
     if (!url) return
 
-    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cleanUrl = get3DModelCacheKey(url)
 
     const cache = window.TSCIRCUIT_OBJ_LOADER_CACHE
     let hasUrlChanged = false

--- a/src/utils/get-3d-model-cache-key.ts
+++ b/src/utils/get-3d-model-cache-key.ts
@@ -1,0 +1,39 @@
+/**
+ * Returns a normalized cache key for a 3D model URL.
+ *
+ * Strips the `cachebust_origin` query parameter wherever it appears in the
+ * query string, regardless of whether it has a value. `cachebust_origin`
+ * records the consumer's origin and is not meaningful to the underlying
+ * model — two URLs that differ only in `cachebust_origin` must hit the
+ * same cache entry, otherwise the same model is fetched and parsed twice.
+ *
+ * Without this normalization the in-place regex previously used in
+ * `useGlobalObjLoader` only matched the trailing empty form
+ * (`&cachebust_origin=`) and missed the filled form
+ * (`&cachebust_origin=https%3A%2F%2Ftscircuit.com`), which is what real
+ * fixtures send (see `stories/assets/complex-board.json`,
+ * `nine-key-keyboard.json`, etc.).
+ */
+export function get3DModelCacheKey(url: string): string {
+  if (!url) return url
+
+  const hashIndex = url.indexOf("#")
+  const hash = hashIndex >= 0 ? url.slice(hashIndex) : ""
+  const beforeHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url
+
+  const queryIndex = beforeHash.indexOf("?")
+  if (queryIndex < 0) return beforeHash + hash
+
+  const base = beforeHash.slice(0, queryIndex)
+  const query = beforeHash.slice(queryIndex + 1)
+
+  const filteredQuery = query
+    .split("&")
+    .filter(
+      (pair) =>
+        pair !== "cachebust_origin" && !pair.startsWith("cachebust_origin="),
+    )
+    .join("&")
+
+  return filteredQuery ? `${base}?${filteredQuery}${hash}` : `${base}${hash}`
+}

--- a/tests/get-3d-model-cache-key.test.ts
+++ b/tests/get-3d-model-cache-key.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import { get3DModelCacheKey } from "../src/utils/get-3d-model-cache-key"
+
+test("returns the original URL when no cachebust_origin is present", () => {
+  expect(get3DModelCacheKey("https://cdn.com/model.obj")).toBe(
+    "https://cdn.com/model.obj",
+  )
+})
+
+test("strips trailing cachebust_origin with empty value", () => {
+  expect(
+    get3DModelCacheKey("https://cdn.com/model.obj?uuid=abc&cachebust_origin="),
+  ).toBe("https://cdn.com/model.obj?uuid=abc")
+})
+
+test("strips trailing cachebust_origin with a URL-encoded value", () => {
+  expect(
+    get3DModelCacheKey(
+      "https://cdn.com/model.obj?uuid=abc&cachebust_origin=https%3A%2F%2Ftscircuit.com",
+    ),
+  ).toBe("https://cdn.com/model.obj?uuid=abc")
+})
+
+test("strips cachebust_origin when it is the only query parameter", () => {
+  expect(
+    get3DModelCacheKey("https://cdn.com/model.obj?cachebust_origin=foo"),
+  ).toBe("https://cdn.com/model.obj")
+})
+
+test("strips cachebust_origin from the start of the query and preserves following params", () => {
+  expect(
+    get3DModelCacheKey(
+      "https://cdn.com/model.obj?cachebust_origin=foo&uuid=abc",
+    ),
+  ).toBe("https://cdn.com/model.obj?uuid=abc")
+})
+
+test("strips cachebust_origin from the middle of the query", () => {
+  expect(
+    get3DModelCacheKey(
+      "https://cdn.com/model.obj?uuid=abc&cachebust_origin=foo&pn=C123",
+    ),
+  ).toBe("https://cdn.com/model.obj?uuid=abc&pn=C123")
+})
+
+test("preserves URL fragment when stripping cachebust_origin", () => {
+  expect(
+    get3DModelCacheKey(
+      "https://cdn.com/model.obj?uuid=abc&cachebust_origin=foo#section1",
+    ),
+  ).toBe("https://cdn.com/model.obj?uuid=abc#section1")
+})
+
+test("does not strip parameters with similar prefixes", () => {
+  expect(
+    get3DModelCacheKey(
+      "https://cdn.com/model.obj?cachebust_origin_extra=foo&cachebust=bar",
+    ),
+  ).toBe("https://cdn.com/model.obj?cachebust_origin_extra=foo&cachebust=bar")
+})
+
+test("returns the same value for two URLs that differ only in cachebust_origin", () => {
+  const a =
+    "https://cdn.com/model.obj?uuid=abc&cachebust_origin=https%3A%2F%2Fa.com"
+  const b =
+    "https://cdn.com/model.obj?uuid=abc&cachebust_origin=https%3A%2F%2Fb.com"
+  expect(get3DModelCacheKey(a)).toBe(get3DModelCacheKey(b))
+})
+
+test("returns the same value for trailing-empty vs filled cachebust_origin", () => {
+  const a = "https://cdn.com/model.obj?uuid=abc&cachebust_origin="
+  const b =
+    "https://cdn.com/model.obj?uuid=abc&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  expect(get3DModelCacheKey(a)).toBe(get3DModelCacheKey(b))
+})
+
+test("returns empty string when input is empty", () => {
+  expect(get3DModelCacheKey("")).toBe("")
+})
+
+test("normalizes a real production URL from complex-board fixture", () => {
+  const url =
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=229b69761e2c45dba6a83d8866dec72d&pn=C61423&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  const expected =
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=229b69761e2c45dba6a83d8866dec72d&pn=C61423"
+  expect(get3DModelCacheKey(url)).toBe(expected)
+})
+
+test("handles cachebust_origin appearing as a value-less parameter", () => {
+  expect(
+    get3DModelCacheKey("https://cdn.com/model.obj?uuid=abc&cachebust_origin"),
+  ).toBe("https://cdn.com/model.obj?uuid=abc")
+})


### PR DESCRIPTION
## Summary

Fixes a narrow but real duplicate-load case in `useGlobalObjLoader` that #93 was opened for: URLs that differ only in their `cachebust_origin` query parameter currently produce different cache keys, so the same OBJ is fetched, parsed, and cloned twice.

The existing strip only matched the trailing empty form `&cachebust_origin=`. Real production fixtures send the **filled** form (`&cachebust_origin=https%3A%2F%2Ftscircuit.com`), which slipped through unchanged. Two boards that reference the same underlying model from different origins hit the cache miss path on every render.

Evidence in the repo (no changes to fixtures, just demonstrating the gap):

- `stories/assets/left-flashlight-board.json` — uses the empty form (handled by old regex)
- `stories/assets/complex-board.json`, `nine-key-keyboard.json` — use the filled form (**not** handled by old regex)

## Change

1. New pure utility `src/utils/get-3d-model-cache-key.ts` — strips `cachebust_origin` regardless of position (first / middle / last / only-param), with or without a value, and preserves the URL fragment. No dependency on `URL` (which would throw on relative inputs).

2. `useGlobalObjLoader` swaps the inline regex for the utility — one-line wire-up, no behavior change for URLs that don't carry `cachebust_origin`.

3. New `tests/get-3d-model-cache-key.test.ts` — 13 unit tests covering:
   - Empty and filled trailing values
   - First / middle / only-param positions
   - URLs with a `#fragment`
   - Lookalike prefixes (`cachebust_origin_extra`) — must NOT be stripped
   - Value-less `cachebust_origin` (no `=`)
   - Two URLs that differ only in `cachebust_origin` → same key
   - A real production URL from `complex-board.json`

## Test results

```
bun test tests/get-3d-model-cache-key.test.ts
 13 pass
 0 fail
 13 expect() calls
Ran 13 tests across 1 file. [29.00ms]
```

Full suite shows the same 5 pre-existing failures before and after this change (all in `preprocess-circuit-json` / SVG snapshot tests, unrelated to the cache layer).

## Why this is scoped narrowly

The repo already has several recently-merged PRs propagating cache layers to other loaders (GLTF/STL/STEP/WRL). This PR intentionally only touches the OBJ loader path and extracts the normalization into a reusable utility. The utility is exported so other loaders can adopt it incrementally without duplicating the logic.

## Algora

/claim #93
