### PR TITLE
fix: cache render model loading

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,8 +4,88 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
+export type SupportedModelFormat = "stl" | "obj" | "wrl" | "gltf" | "glb"
+
+interface CachedModelLoad {
+  promise: Promise<THREE.Object3D | null>
+  result: THREE.Object3D | null
+}
+
+const modelCache = new Map<string, CachedModelLoad>()
+
+export function getModelCacheKey(url: string): string {
+  try {
+    const parsed = new URL(url, "https://tscircuit.invalid")
+    parsed.searchParams.delete("cachebust_origin")
+    const normalized = `${parsed.pathname}${parsed.search}${parsed.hash}`
+    return url.startsWith("http://") || url.startsWith("https://")
+      ? parsed.toString()
+      : normalized
+  } catch {
+    return url
+      .replace(/([?&])cachebust_origin=[^&#]*&?/g, "$1")
+      .replace(/[?&]$/, "")
+  }
+}
+
+export function getModelFormat(
+  url: string,
+  explicitFormat?: SupportedModelFormat,
+): SupportedModelFormat | null {
+  if (explicitFormat) return explicitFormat
+
+  try {
+    const pathname = new URL(url, "https://tscircuit.invalid").pathname
+    const match = pathname.toLowerCase().match(/\.([a-z0-9]+)$/)
+    const extension = match?.[1]
+    if (
+      extension === "stl" ||
+      extension === "obj" ||
+      extension === "wrl" ||
+      extension === "gltf" ||
+      extension === "glb"
+    ) {
+      return extension
+    }
+    return null
+  } catch {
+    const match = url
+      .toLowerCase()
+      .split(/[?#]/)[0]
+      ?.match(/\.([a-z0-9]+)$/)
+    const extension = match?.[1]
+    if (
+      extension === "stl" ||
+      extension === "obj" ||
+      extension === "wrl" ||
+      extension === "gltf" ||
+      extension === "glb"
+    ) {
+      return extension
+    }
+    return null
+  }
+}
+
+function cloneModel(model: THREE.Object3D): THREE.Object3D {
+  const clone = model.clone(true)
+
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.material) return
+
+    child.material = Array.isArray(child.material)
+      ? child.material.map((material) => material.clone())
+      : child.material.clone()
+  })
+
+  return clone
+}
+
+async function load3DModelUncached(
+  url: string,
+  format: SupportedModelFormat,
+): Promise<THREE.Object3D | null> {
+  if (format === "stl") {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
     const material = new THREE.MeshStandardMaterial({
@@ -16,21 +96,58 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
     return new THREE.Mesh(geometry, material)
   }
 
-  if (url.endsWith(".obj")) {
+  if (format === "obj") {
     const loader = new OBJLoader()
     return await loader.loadAsync(url)
   }
 
-  if (url.endsWith(".wrl")) {
+  if (format === "wrl") {
     return await loadVrml(url)
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+  if (format === "gltf" || format === "glb") {
     const loader = new GLTFLoader()
     const gltf = await loader.loadAsync(url)
     return gltf.scene
   }
 
-  console.error("Unsupported file format or failed to load 3D model.")
   return null
+}
+
+export async function load3DModel(
+  url: string,
+  explicitFormat?: SupportedModelFormat,
+): Promise<THREE.Object3D | null> {
+  const format = getModelFormat(url, explicitFormat)
+  if (!format) {
+    console.error("Unsupported file format or failed to load 3D model.")
+    return null
+  }
+
+  const cacheKey = `${format}:${getModelCacheKey(url)}`
+  const cached = modelCache.get(cacheKey)
+  if (cached) {
+    if (cached.result) return cloneModel(cached.result)
+    const result = await cached.promise
+    return result ? cloneModel(result) : null
+  }
+
+  const promise = load3DModelUncached(url, format)
+    .then((result) => {
+      if (!result) {
+        modelCache.delete(cacheKey)
+        return null
+      }
+      const cachedLoad = modelCache.get(cacheKey)
+      if (cachedLoad) cachedLoad.result = result
+      return result
+    })
+    .catch((error) => {
+      modelCache.delete(cacheKey)
+      throw error
+    })
+
+  modelCache.set(cacheKey, { promise, result: null })
+  const result = await promise
+  return result ? cloneModel(result) : null
 }

--- a/src/utils/render-component.tsx
+++ b/src/utils/render-component.tsx
@@ -22,7 +22,16 @@ export async function renderComponent(
     component.model_glb_url ??
     component.model_gltf_url
   if (url) {
-    const model = await load3DModel(url)
+    const modelFormat = component.model_obj_url
+      ? "obj"
+      : component.model_wrl_url
+        ? "wrl"
+        : component.model_stl_url
+          ? "stl"
+          : component.model_glb_url
+            ? "glb"
+            : "gltf"
+    const model = await load3DModel(url, modelFormat)
     if (model) {
       if (component.position) {
         model.position.set(

--- a/tests/load-model.test.ts
+++ b/tests/load-model.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { getModelCacheKey, getModelFormat } from "../src/utils/load-model"
+
+test("normalizes cache-busting params without dropping meaningful query data", () => {
+  const cacheKey = getModelCacheKey(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&cachebust_origin=123&pn=C1#part",
+  )
+
+  expect(cacheKey).toBe(
+    "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1#part",
+  )
+})
+
+test("detects model format from path before query and hash suffixes", () => {
+  expect(getModelFormat("/models/chip.glb?cachebust_origin=1#mesh")).toBe("glb")
+  expect(getModelFormat("https://example.com/model.wrl?version=2")).toBe("wrl")
+})
+
+test("uses explicit model format for extensionless CDN download URLs", () => {
+  expect(
+    getModelFormat(
+      "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=abc&pn=C1",
+      "obj",
+    ),
+  ).toBe("obj")
+})


### PR DESCRIPTION
## Summary
- add shared in-flight/completed caching for load3DModel in the render/SVG utility path
- normalize cache keys by removing only cachebust_origin while preserving meaningful query params and hashes
- pass explicit model formats from renderComponent so extensionless EasyEDA/CDN download URLs still load through the correct loader
- return cloned model instances with cloned materials so per-render mutations do not leak into the cached template

## Verification
- npx @biomejs/biome@2.1.4 format src/utils/load-model.ts src/utils/render-component.tsx tests/load-model.test.ts
- git diff --check
- npm run build (blocked locally: npm install fails while extracting node_modules/three with TAR_ENTRY_ERROR in this Google Drive workspace, so tsup is unavailable)

/claim #93