### PR TITLE
Dispose Error3d fallback mesh resources

### DIFF
--- a/src/three-components/Error3d.tsx
+++ b/src/three-components/Error3d.tsx
@@ -4,6 +4,7 @@ import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { Html } from "src/react-three/Html"
 import { Text } from "src/react-three/Text"
 import { useThree } from "src/react-three/ThreeContext"
+import { disposeMeshResources } from "src/utils/dispose-mesh-resources"
 import * as THREE from "three"
 
 export const Error3d = ({
@@ -125,6 +126,7 @@ const ErrorBox = ({ parent }: { parent: THREE.Object3D }) => {
     parent.add(mesh)
     return () => {
       parent.remove(mesh)
+      disposeMeshResources(mesh)
     }
   }, [parent, mesh])
 

--- a/src/utils/dispose-mesh-resources.ts
+++ b/src/utils/dispose-mesh-resources.ts
@@ -1,0 +1,15 @@
+import * as THREE from "three"
+
+export const disposeMeshResources = (
+  mesh: THREE.Mesh<THREE.BufferGeometry, THREE.Material | THREE.Material[]>,
+) => {
+  mesh.geometry.dispose()
+
+  if (Array.isArray(mesh.material)) {
+    for (const material of mesh.material) {
+      material.dispose()
+    }
+  } else {
+    mesh.material.dispose()
+  }
+}

--- a/tests/dispose-mesh-resources.test.ts
+++ b/tests/dispose-mesh-resources.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { disposeMeshResources } from "../src/utils/dispose-mesh-resources"
+
+test("disposeMeshResources disposes geometry and a single material", () => {
+  const geometry = new THREE.BoxGeometry()
+  const material = new THREE.MeshStandardMaterial()
+  const mesh = new THREE.Mesh(geometry, material)
+
+  let geometryDisposed = false
+  let materialDisposed = false
+  geometry.addEventListener("dispose", () => {
+    geometryDisposed = true
+  })
+  material.addEventListener("dispose", () => {
+    materialDisposed = true
+  })
+
+  disposeMeshResources(mesh)
+
+  expect(geometryDisposed).toBe(true)
+  expect(materialDisposed).toBe(true)
+})
+
+test("disposeMeshResources disposes every material in a material array", () => {
+  const geometry = new THREE.BoxGeometry()
+  const materials: THREE.Material[] = [
+    new THREE.MeshStandardMaterial(),
+    new THREE.MeshBasicMaterial(),
+  ]
+  const mesh = new THREE.Mesh(geometry, materials)
+
+  const disposedMaterials: THREE.Material[] = []
+  for (const material of materials) {
+    material.addEventListener("dispose", () => {
+      disposedMaterials.push(material)
+    })
+  }
+
+  disposeMeshResources(mesh)
+
+  expect(disposedMaterials).toEqual(materials)
+})


### PR DESCRIPTION
/claim #93

## Summary
- add a small `disposeMeshResources` helper for mesh geometry and material cleanup
- dispose the `Error3d` fallback box mesh resources when it unmounts
- add unit coverage for single-material and material-array meshes

## Verification
All verification was run inside Docker on a copied workspace:
- `bun test tests/dispose-mesh-resources.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`