### PR TITLE
Fix glTF model lifecycle cleanup

### DIFF
--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -1,10 +1,14 @@
-import { useState, useEffect } from "react"
-import * as THREE from "three"
-import { GLTFLoader } from "three-stdlib"
-import { useThree } from "src/react-three/ThreeContext"
+import { useCallback, useEffect, useRef, useState } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
+import { useThree } from "src/react-three/ThreeContext"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import {
+  applyGltfSceneMaterialState,
+  disposeGltfSceneResources,
+} from "src/utils/gltf-scene-lifecycle"
+import * as THREE from "three"
+import { GLTFLoader } from "three-stdlib"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 const DEFAULT_ENV_MAP_INTENSITY = 1.25
@@ -41,6 +45,16 @@ export function GltfModel({
   const { renderer } = useThree()
   const [model, setModel] = useState<THREE.Group | null>(null)
   const [loadError, setLoadError] = useState<Error | null>(null)
+  const ownedModelRef = useRef<THREE.Group | null>(null)
+  const replaceOwnedModel = useCallback((nextModel: THREE.Group | null) => {
+    setModel((previousModel) => {
+      if (previousModel && previousModel !== nextModel) {
+        disposeGltfSceneResources(previousModel)
+      }
+      ownedModelRef.current = nextModel
+      return nextModel
+    })
+  }, [])
   const { boardTransformGroup } = useCadModelTransformGraph({
     model,
     position,
@@ -54,35 +68,28 @@ export function GltfModel({
   })
 
   useEffect(() => {
-    if (!gltfUrl) return
+    if (!gltfUrl) {
+      setLoadError(null)
+      replaceOwnedModel(null)
+      return
+    }
+
     const loader = new GLTFLoader()
     let isMounted = true
+    setLoadError(null)
+    replaceOwnedModel(null)
+
     loader.load(
       gltfUrl,
       (gltf) => {
-        if (!isMounted) return
         const scene = gltf.scene
 
-        scene.traverse((child) => {
-          if (child instanceof THREE.Mesh && child.material) {
-            const setMaterialTransparency = (mat: THREE.Material) => {
-              mat.transparent = isTranslucent
-              mat.opacity = isTranslucent ? 0.5 : 1
-              mat.depthWrite = !isTranslucent
-              mat.needsUpdate = true
-            }
+        if (!isMounted) {
+          disposeGltfSceneResources(scene)
+          return
+        }
 
-            if (Array.isArray(child.material)) {
-              child.material.forEach(setMaterialTransparency)
-            } else {
-              setMaterialTransparency(child.material)
-            }
-
-            child.renderOrder = isTranslucent ? 2 : 1
-          }
-        })
-
-        setModel(scene)
+        replaceOwnedModel(scene)
       },
       undefined,
       (error) => {
@@ -98,7 +105,21 @@ export function GltfModel({
     return () => {
       isMounted = false
     }
-  }, [gltfUrl, isTranslucent])
+  }, [gltfUrl, replaceOwnedModel])
+
+  useEffect(() => {
+    return () => {
+      if (ownedModelRef.current) {
+        disposeGltfSceneResources(ownedModelRef.current)
+        ownedModelRef.current = null
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!model) return
+    applyGltfSceneMaterialState(model, { isTranslucent })
+  }, [model, isTranslucent])
 
   useEffect(() => {
     if (!model || !renderer) return
@@ -145,11 +166,15 @@ export function GltfModel({
     })
 
     return () => {
-      previousMaterialState.forEach(({ material, envMap, envMapIntensity }) => {
+      for (const {
+        material,
+        envMap,
+        envMapIntensity,
+      } of previousMaterialState) {
         material.envMap = envMap
         material.envMapIntensity = envMapIntensity
         material.needsUpdate = true
-      })
+      }
     }
   }, [model, renderer])
 

--- a/src/utils/gltf-scene-lifecycle.ts
+++ b/src/utils/gltf-scene-lifecycle.ts
@@ -1,0 +1,65 @@
+import * as THREE from "three"
+
+export function applyGltfSceneMaterialState(
+  scene: THREE.Object3D,
+  { isTranslucent }: { isTranslucent: boolean },
+) {
+  scene.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.material) return
+
+    const setMaterialTransparency = (material: THREE.Material) => {
+      material.transparent = isTranslucent
+      material.opacity = isTranslucent ? 0.5 : 1
+      material.depthWrite = !isTranslucent
+      material.needsUpdate = true
+    }
+
+    if (Array.isArray(child.material)) {
+      child.material.forEach(setMaterialTransparency)
+    } else {
+      setMaterialTransparency(child.material)
+    }
+
+    child.renderOrder = isTranslucent ? 2 : 1
+  })
+}
+
+export function disposeGltfSceneResources(scene: THREE.Object3D) {
+  const disposedGeometries = new Set<THREE.BufferGeometry>()
+  const disposedMaterials = new Set<THREE.Material>()
+  const disposedTextures = new Set<THREE.Texture>()
+
+  const disposeTexture = (texture: THREE.Texture) => {
+    if (disposedTextures.has(texture)) return
+    disposedTextures.add(texture)
+    texture.dispose()
+  }
+
+  const disposeMaterial = (material: THREE.Material) => {
+    if (disposedMaterials.has(material)) return
+    disposedMaterials.add(material)
+
+    for (const value of Object.values(material)) {
+      if (value instanceof THREE.Texture) {
+        disposeTexture(value)
+      }
+    }
+
+    material.dispose()
+  }
+
+  scene.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    if (child.geometry && !disposedGeometries.has(child.geometry)) {
+      disposedGeometries.add(child.geometry)
+      child.geometry.dispose()
+    }
+
+    if (Array.isArray(child.material)) {
+      child.material.forEach(disposeMaterial)
+    } else if (child.material) {
+      disposeMaterial(child.material)
+    }
+  })
+}

--- a/tests/gltf-scene-lifecycle.test.ts
+++ b/tests/gltf-scene-lifecycle.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  applyGltfSceneMaterialState,
+  disposeGltfSceneResources,
+} from "../src/utils/gltf-scene-lifecycle"
+
+test("applyGltfSceneMaterialState updates mesh materials without reloading scenes", () => {
+  const scene = new THREE.Group()
+  const material = new THREE.MeshStandardMaterial({ opacity: 1 })
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material)
+  scene.add(mesh)
+
+  applyGltfSceneMaterialState(scene, { isTranslucent: true })
+
+  expect(material.transparent).toBe(true)
+  expect(material.opacity).toBe(0.5)
+  expect(material.depthWrite).toBe(false)
+  expect(mesh.renderOrder).toBe(2)
+
+  applyGltfSceneMaterialState(scene, { isTranslucent: false })
+
+  expect(material.transparent).toBe(false)
+  expect(material.opacity).toBe(1)
+  expect(material.depthWrite).toBe(true)
+  expect(mesh.renderOrder).toBe(1)
+})
+
+test("disposeGltfSceneResources disposes shared geometry, material, and textures once", () => {
+  const scene = new THREE.Group()
+  const geometry = new THREE.BoxGeometry(1, 1, 1)
+  const texture = new THREE.Texture()
+  const material = new THREE.MeshStandardMaterial({ map: texture })
+  const firstMesh = new THREE.Mesh(geometry, material)
+  const secondMesh = new THREE.Mesh(geometry, material)
+
+  let geometryDisposeCount = 0
+  let materialDisposeCount = 0
+  let textureDisposeCount = 0
+  geometry.dispose = () => {
+    geometryDisposeCount += 1
+  }
+  material.dispose = () => {
+    materialDisposeCount += 1
+  }
+  texture.dispose = () => {
+    textureDisposeCount += 1
+  }
+
+  scene.add(firstMesh)
+  scene.add(secondMesh)
+
+  disposeGltfSceneResources(scene)
+
+  expect(geometryDisposeCount).toBe(1)
+  expect(materialDisposeCount).toBe(1)
+  expect(textureDisposeCount).toBe(1)
+})


### PR DESCRIPTION
/claim #93

## Summary
- stop reloading GLTF scenes when only `isTranslucent` changes
- clear and dispose previous GLTF scenes on URL replacement/unmount, and dispose late-loaded scenes after cleanup
- add focused tests for material-state updates and shared resource disposal

## Validation
- `npm exec -- bun test tests/gltf-scene-lifecycle.test.ts`
- `./node_modules/.bin/biome check src/utils/gltf-scene-lifecycle.ts src/three-components/GltfModel.tsx tests/gltf-scene-lifecycle.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check`

## Note
- Full `npm exec -- bun test tests` currently fails in existing `outline-bounds` and `preprocess-circuit-json` assertions outside this patch.