### PR TITLE
Cache GLTF model loads

### DIFF
--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -1,10 +1,13 @@
-import { useState, useEffect } from "react"
-import * as THREE from "three"
-import { GLTFLoader } from "three-stdlib"
-import { useThree } from "src/react-three/ThreeContext"
+import { useEffect, useRef, useState } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
+import { useThree } from "src/react-three/ThreeContext"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import {
+  disposeGltfModelInstance,
+  loadCachedGltfScene,
+} from "src/utils/gltf-model-cache"
+import * as THREE from "three"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 const DEFAULT_ENV_MAP_INTENSITY = 1.25
@@ -40,6 +43,7 @@ export function GltfModel({
 }) {
   const { renderer } = useThree()
   const [model, setModel] = useState<THREE.Group | null>(null)
+  const modelRef = useRef<THREE.Group | null>(null)
   const [loadError, setLoadError] = useState<Error | null>(null)
   const { boardTransformGroup } = useCadModelTransformGraph({
     model,
@@ -55,50 +59,70 @@ export function GltfModel({
 
   useEffect(() => {
     if (!gltfUrl) return
-    const loader = new GLTFLoader()
-    let isMounted = true
-    loader.load(
-      gltfUrl,
-      (gltf) => {
-        if (!isMounted) return
-        const scene = gltf.scene
+    let isCancelled = false
 
-        scene.traverse((child) => {
-          if (child instanceof THREE.Mesh && child.material) {
-            const setMaterialTransparency = (mat: THREE.Material) => {
-              mat.transparent = isTranslucent
-              mat.opacity = isTranslucent ? 0.5 : 1
-              mat.depthWrite = !isTranslucent
-              mat.needsUpdate = true
-            }
+    if (modelRef.current) {
+      disposeGltfModelInstance(modelRef.current)
+      modelRef.current = null
+    }
+    setModel(null)
+    setLoadError(null)
 
-            if (Array.isArray(child.material)) {
-              child.material.forEach(setMaterialTransparency)
-            } else {
-              setMaterialTransparency(child.material)
-            }
-
-            child.renderOrder = isTranslucent ? 2 : 1
-          }
-        })
-
+    loadCachedGltfScene(gltfUrl)
+      .then((scene) => {
+        if (isCancelled) {
+          disposeGltfModelInstance(scene)
+          return
+        }
+        modelRef.current = scene
         setModel(scene)
-      },
-      undefined,
-      (error) => {
-        if (!isMounted) return
+      })
+      .catch((error) => {
+        if (isCancelled) return
         console.error(`An error happened loading ${gltfUrl}`, error)
         const err =
           error instanceof Error
             ? error
             : new Error(`Failed to load glTF model from ${gltfUrl}`)
         setLoadError(err)
-      },
-    )
+      })
+
     return () => {
-      isMounted = false
+      isCancelled = true
     }
-  }, [gltfUrl, isTranslucent])
+  }, [gltfUrl])
+
+  useEffect(() => {
+    if (!model) return
+
+    model.traverse((child) => {
+      if (!(child instanceof THREE.Mesh) || !child.material) return
+
+      const setMaterialTransparency = (mat: THREE.Material) => {
+        mat.transparent = isTranslucent
+        mat.opacity = isTranslucent ? 0.5 : 1
+        mat.depthWrite = !isTranslucent
+        mat.needsUpdate = true
+      }
+
+      if (Array.isArray(child.material)) {
+        child.material.forEach(setMaterialTransparency)
+      } else {
+        setMaterialTransparency(child.material)
+      }
+
+      child.renderOrder = isTranslucent ? 2 : 1
+    })
+  }, [model, isTranslucent])
+
+  useEffect(() => {
+    return () => {
+      if (modelRef.current) {
+        disposeGltfModelInstance(modelRef.current)
+        modelRef.current = null
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (!model || !renderer) return
@@ -145,11 +169,15 @@ export function GltfModel({
     })
 
     return () => {
-      previousMaterialState.forEach(({ material, envMap, envMapIntensity }) => {
+      for (const {
+        material,
+        envMap,
+        envMapIntensity,
+      } of previousMaterialState) {
         material.envMap = envMap
         material.envMapIntensity = envMapIntensity
         material.needsUpdate = true
-      })
+      }
     }
   }, [model, renderer])
 

--- a/src/utils/gltf-model-cache.ts
+++ b/src/utils/gltf-model-cache.ts
@@ -1,0 +1,94 @@
+import * as THREE from "three"
+import { GLTFLoader } from "three-stdlib"
+
+interface GltfCacheItem {
+  promise: Promise<THREE.Group>
+  result: THREE.Group | null
+}
+
+const gltfModelCache = new Map<string, GltfCacheItem>()
+
+export const normalizeGltfModelUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(url, globalThis.location?.href)
+    if (parsedUrl.searchParams.get("cachebust_origin") === "") {
+      parsedUrl.searchParams.delete("cachebust_origin")
+    }
+
+    if (/^[a-z][a-z\d+\-.]*:/i.test(url)) {
+      return parsedUrl.toString()
+    }
+
+    return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+  } catch {
+    return url.replace(/([?&])cachebust_origin=$/, "")
+  }
+}
+
+export const cloneGltfSceneForInstance = (scene: THREE.Group) => {
+  const clonedScene = scene.clone(true)
+
+  clonedScene.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    if (Array.isArray(child.material)) {
+      child.material = child.material.map((material) => material.clone())
+    } else if (child.material) {
+      child.material = child.material.clone()
+    }
+  })
+
+  return clonedScene
+}
+
+export const disposeGltfModelInstance = (scene: THREE.Object3D) => {
+  scene.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    const material = child.material
+    if (Array.isArray(material)) {
+      for (const mat of material) {
+        mat.dispose()
+      }
+    } else if (material) {
+      material.dispose()
+    }
+  })
+}
+
+export const loadCachedGltfScene = async (
+  gltfUrl: string,
+  loader = new GLTFLoader(),
+) => {
+  const cacheKey = normalizeGltfModelUrl(gltfUrl)
+  const cached = gltfModelCache.get(cacheKey)
+
+  if (cached?.result) {
+    return cloneGltfSceneForInstance(cached.result)
+  }
+
+  if (cached?.promise) {
+    const scene = await cached.promise
+    return cloneGltfSceneForInstance(scene)
+  }
+
+  const promise = loader
+    .loadAsync(gltfUrl)
+    .then((gltf) => {
+      const scene = gltf.scene
+      gltfModelCache.set(cacheKey, { promise, result: scene })
+      return scene
+    })
+    .catch((error) => {
+      gltfModelCache.delete(cacheKey)
+      throw error
+    })
+
+  gltfModelCache.set(cacheKey, { promise, result: null })
+  const scene = await promise
+  return cloneGltfSceneForInstance(scene)
+}
+
+export const clearGltfModelCache = () => {
+  gltfModelCache.clear()
+}

--- a/tests/gltf-model-cache.test.ts
+++ b/tests/gltf-model-cache.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  cloneGltfSceneForInstance,
+  normalizeGltfModelUrl,
+} from "../src/utils/gltf-model-cache"
+
+test("normalizes empty cachebust_origin from GLTF model URLs", () => {
+  expect(
+    normalizeGltfModelUrl(
+      "https://modelcdn.tscircuit.com/model.glb?uuid=abc&cachebust_origin=",
+    ),
+  ).toBe("https://modelcdn.tscircuit.com/model.glb?uuid=abc")
+
+  expect(normalizeGltfModelUrl("/model.glb?cachebust_origin=")).toBe(
+    "/model.glb",
+  )
+})
+
+test("clones GLTF scene materials per rendered instance", () => {
+  const scene = new THREE.Group()
+  const material = new THREE.MeshStandardMaterial({ opacity: 1 })
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material)
+  scene.add(mesh)
+
+  const firstInstance = cloneGltfSceneForInstance(scene)
+  const secondInstance = cloneGltfSceneForInstance(scene)
+
+  const firstMaterial = (firstInstance.children[0] as THREE.Mesh)
+    .material as THREE.MeshStandardMaterial
+  const secondMaterial = (secondInstance.children[0] as THREE.Mesh)
+    .material as THREE.MeshStandardMaterial
+
+  firstMaterial.opacity = 0.5
+
+  expect(firstMaterial).not.toBe(material)
+  expect(secondMaterial).not.toBe(material)
+  expect(firstMaterial).not.toBe(secondMaterial)
+  expect(secondMaterial.opacity).toBe(1)
+})


### PR DESCRIPTION
Closes #93

/claim #93

## Changes
- Adds a shared GLTF/GLB scene cache keyed by normalized model URL, matching the existing OBJ-path idea so repeated models do not refetch/reparse.
- Clones cached scenes per rendered instance and clones mesh materials so hover/translucency/env-map mutations do not leak across repeated parts.
- Splits GLTF loading from `isTranslucent` updates, so translucency changes update materials on the loaded scene without triggering a fresh model load.
- Disposes cloned instance materials when a model is replaced, unmounted, or finishes loading after cancellation.

## Validation
- `./node_modules/.bin/biome check src/three-components/GltfModel.tsx src/utils/gltf-model-cache.ts tests/gltf-model-cache.test.ts`
- `npx --yes tsc --noEmit --pretty false`
- `npx --yes bun test tests/gltf-model-cache.test.ts tests/cad-model-transform.test.ts tests/cad-model-fit.test.ts` -> 17 passed
- `npm run build`
- `git diff --check`

Note: the local shell does not have a global `bun`, so I used `npx --yes bun` for the focused Bun tests and npm-installed tooling for build/type/format verification.
