### PR TITLE
Fix cached STEP blob URL reuse

### DIFF
--- a/src/three-components/StepModel.tsx
+++ b/src/three-components/StepModel.tsx
@@ -195,7 +195,7 @@ type StepUrlConversionRegistry = {
   completed: Map<string, ConvertedStepFile>
 }
 
-function getStepUrlConversionRegistry(): StepUrlConversionRegistry {
+export function getStepUrlConversionRegistry(): StepUrlConversionRegistry {
   const globalScope = globalThis as {
     stepUrlToGltfModelConversions?: StepUrlConversionRegistry
   }
@@ -206,6 +206,30 @@ function getStepUrlConversionRegistry(): StepUrlConversionRegistry {
     }
   }
   return globalScope.stepUrlToGltfModelConversions
+}
+
+export function getCachedStepUrlConversion(
+  stepUrl: string,
+  registry: StepUrlConversionRegistry = getStepUrlConversionRegistry(),
+): ConvertedStepFile | null {
+  const existingCompleted = registry.completed.get(stepUrl)
+  if (existingCompleted) {
+    return existingCompleted
+  }
+
+  const cachedGlb = getCachedGlb(stepUrl)
+  if (!cachedGlb) {
+    return null
+  }
+
+  const cachedConverted: ConvertedStepFile = {
+    arrayBuffer: cachedGlb,
+    blobUrl: URL.createObjectURL(
+      new Blob([cachedGlb], { type: "model/gltf-binary" }),
+    ),
+  }
+  registry.completed.set(stepUrl, cachedConverted)
+  return cachedConverted
 }
 
 type StepModelProps = {
@@ -246,31 +270,11 @@ export const StepModel = ({
     let objectUrl: string | null = null
     let shouldRevokeObjectUrl = true
     const registry = getStepUrlConversionRegistry()
-    const cachedGlb = getCachedGlb(stepUrl)
-    if (cachedGlb) {
-      const cachedConverted: ConvertedStepFile = {
-        arrayBuffer: cachedGlb,
-        blobUrl: URL.createObjectURL(
-          new Blob([cachedGlb], { type: "model/gltf-binary" }),
-        ),
-      }
-      registry.completed.set(stepUrl, cachedConverted)
-      objectUrl = cachedConverted.blobUrl
+    const cachedConversion = getCachedStepUrlConversion(stepUrl, registry)
+    if (cachedConversion) {
+      objectUrl = cachedConversion.blobUrl
       shouldRevokeObjectUrl = false
-      setStepGltfUrl(cachedConverted.blobUrl)
-      return () => {
-        isActive = false
-        if (objectUrl && shouldRevokeObjectUrl) {
-          URL.revokeObjectURL(objectUrl)
-        }
-      }
-    }
-    const existingCompleted = registry.completed.get(stepUrl)
-    if (existingCompleted) {
-      objectUrl = existingCompleted.blobUrl
-      shouldRevokeObjectUrl = false
-      setStepGltfUrl(existingCompleted.blobUrl)
-      setCachedGlb(stepUrl, existingCompleted.arrayBuffer)
+      setStepGltfUrl(cachedConversion.blobUrl)
       return () => {
         isActive = false
         if (objectUrl && shouldRevokeObjectUrl) {

--- a/tests/step-model-cache.test.ts
+++ b/tests/step-model-cache.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { getCachedStepUrlConversion } from "../src/three-components/StepModel"
+
+type ConvertedStepFile = {
+  arrayBuffer: ArrayBuffer
+  blobUrl: string
+}
+
+type TestRegistry = {
+  inProgress: Map<string, Promise<ConvertedStepFile>>
+  completed: Map<string, ConvertedStepFile>
+}
+
+const createTestRegistry = (): TestRegistry => ({
+  inProgress: new Map(),
+  completed: new Map(),
+})
+
+let originalCreateObjectURL: typeof URL.createObjectURL
+let originalLocalStorageDescriptor: PropertyDescriptor | undefined
+
+beforeEach(() => {
+  originalCreateObjectURL = URL.createObjectURL
+  originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage",
+  )
+
+  const storage = new Map<string, string>()
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    },
+  })
+})
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(
+      globalThis,
+      "localStorage",
+      originalLocalStorageDescriptor,
+    )
+  } else {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: undefined,
+    })
+  }
+})
+
+function cacheGlb(stepUrl: string, bytes = [1, 2, 3]) {
+  localStorage.setItem(
+    `step-glb-cache:${stepUrl}`,
+    btoa(String.fromCharCode(...bytes)),
+  )
+}
+
+test("reuses the completed STEP conversion before reading localStorage again", () => {
+  const createdBlobs: Blob[] = []
+  URL.createObjectURL = ((blob: Blob) => {
+    createdBlobs.push(blob)
+    return `blob:step-${createdBlobs.length}`
+  }) as typeof URL.createObjectURL
+  const registry = createTestRegistry()
+  const stepUrl = "/models/repeated.step"
+  cacheGlb(stepUrl)
+
+  const firstConversion = getCachedStepUrlConversion(stepUrl, registry)
+  const secondConversion = getCachedStepUrlConversion(stepUrl, registry)
+
+  expect(firstConversion).not.toBeNull()
+  expect(secondConversion).toBe(firstConversion)
+  expect(firstConversion?.blobUrl).toBe("blob:step-1")
+  expect(createdBlobs).toHaveLength(1)
+})
+
+test("prefers the in-memory STEP conversion over a persistent cache hit", () => {
+  const createdBlobs: Blob[] = []
+  URL.createObjectURL = ((blob: Blob) => {
+    createdBlobs.push(blob)
+    return `blob:step-${createdBlobs.length}`
+  }) as typeof URL.createObjectURL
+  const registry = createTestRegistry()
+  const stepUrl = "/models/already-loaded.step"
+  const memoryConversion = {
+    arrayBuffer: new Uint8Array([9]).buffer,
+    blobUrl: "blob:existing-step",
+  }
+  registry.completed.set(stepUrl, memoryConversion)
+  cacheGlb(stepUrl, [4, 5, 6])
+
+  const conversion = getCachedStepUrlConversion(stepUrl, registry)
+
+  expect(conversion).toBe(memoryConversion)
+  expect(createdBlobs).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary
- Reuse completed STEP URL conversions before reading persistent cache
- Avoid recreating blob URLs for a STEP URL that is already present in the in-memory registry
- Add focused coverage for repeated cached STEP lookups

## Testing
- `bun test tests/step-model-cache.test.ts`
- `bunx tsc --noEmit`
- `bunx biome format src/three-components/StepModel.tsx tests/step-model-cache.test.ts`
- `bun run build`

Note: `bun test` still has existing failures in `outline-bounds.test.ts` and `preprocess-circuit-json.test.ts` that are unrelated to this STEP cache change.

/claim #93

AI-assisted with Codex; I reviewed the patch and verification results.