### PR TITLE
fix: add global model cache to prevent duplicate loads and browser lag

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -19,13 +19,13 @@ import * as THREE from "three"
     if (typeof window !== "undefined") {
       const cache = window.TSCIRCUIT_MODEL_CACHE
       if (cache.has(url)) {
-        const cached = await cache.get(url)!
+        const cached = await cache.get(url)
         // Clone so each usage gets its own independent scene graph node
         return cached ? (cached.clone() as THREE.Object3D) : null
       }
     }
 
-    const loadPromise = _load3DModel(url)
+    const loadPromise = loadModel(url)
 
     if (typeof window !== "undefined") {
       window.TSCIRCUIT_MODEL_CACHE.set(url, loadPromise)
@@ -34,7 +34,7 @@ import * as THREE from "three"
     return loadPromise
   }
 
-  async function _load3DModel(url: string): Promise<THREE.Object3D | null> {
+  async function loadModel(url: string): Promise<THREE.Object3D | null> {
     if (url.endsWith(".stl")) {
       const loader = new STLLoader()
       const geometry = await loader.loadAsync(url)

--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -1,36 +1,67 @@
 import * as THREE from "three"
-import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
-import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
-import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
-import { loadVrml } from "./vrml"
+  import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
+  import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
+  import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
+  import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-  if (url.endsWith(".stl")) {
-    const loader = new STLLoader()
-    const geometry = await loader.loadAsync(url)
-    const material = new THREE.MeshStandardMaterial({
-      color: 0x888888,
-      metalness: 0.5,
-      roughness: 0.5,
-    })
-    return new THREE.Mesh(geometry, material)
+  // Global model cache to prevent duplicate loads and browser lag
+  declare global {
+    interface Window {
+      TSCIRCUIT_MODEL_CACHE: Map<string, Promise<THREE.Object3D | null>>
+    }
   }
 
-  if (url.endsWith(".obj")) {
-    const loader = new OBJLoader()
-    return await loader.loadAsync(url)
+  if (typeof window !== "undefined" && !window.TSCIRCUIT_MODEL_CACHE) {
+    window.TSCIRCUIT_MODEL_CACHE = new Map()
   }
 
-  if (url.endsWith(".wrl")) {
-    return await loadVrml(url)
+  export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+    if (typeof window !== "undefined") {
+      const cache = window.TSCIRCUIT_MODEL_CACHE
+      if (cache.has(url)) {
+        const cached = await cache.get(url)!
+        // Clone so each usage gets its own independent scene graph node
+        return cached ? (cached.clone() as THREE.Object3D) : null
+      }
+    }
+
+    const loadPromise = _load3DModel(url)
+
+    if (typeof window !== "undefined") {
+      window.TSCIRCUIT_MODEL_CACHE.set(url, loadPromise)
+    }
+
+    return loadPromise
   }
 
-  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
-    const loader = new GLTFLoader()
-    const gltf = await loader.loadAsync(url)
-    return gltf.scene
-  }
+  async function _load3DModel(url: string): Promise<THREE.Object3D | null> {
+    if (url.endsWith(".stl")) {
+      const loader = new STLLoader()
+      const geometry = await loader.loadAsync(url)
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x888888,
+        metalness: 0.5,
+        roughness: 0.5,
+      })
+      return new THREE.Mesh(geometry, material)
+    }
 
-  console.error("Unsupported file format or failed to load 3D model.")
-  return null
-}
+    if (url.endsWith(".obj")) {
+      const loader = new OBJLoader()
+      return await loader.loadAsync(url)
+    }
+
+    if (url.endsWith(".wrl")) {
+      return await loadVrml(url)
+    }
+
+    if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+      const loader = new GLTFLoader()
+      const gltf = await loader.loadAsync(url)
+      return gltf.scene
+    }
+
+    console.error("Unsupported file format or failed to load 3D model.")
+    return null
+  }
+  

--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -1,67 +1,66 @@
 import * as THREE from "three"
-  import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
-  import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
-  import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
-  import { loadVrml } from "./vrml"
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
+import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
+import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
+import { loadVrml } from "./vrml"
 
-  // Global model cache to prevent duplicate loads and browser lag
-  declare global {
-    interface Window {
-      TSCIRCUIT_MODEL_CACHE: Map<string, Promise<THREE.Object3D | null>>
+// Global model cache to prevent duplicate loads and browser lag
+declare global {
+  interface Window {
+    TSCIRCUIT_MODEL_CACHE: Map<string, Promise<THREE.Object3D | null>>
+  }
+}
+
+if (typeof window !== "undefined" && !window.TSCIRCUIT_MODEL_CACHE) {
+  window.TSCIRCUIT_MODEL_CACHE = new Map()
+}
+
+export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+  if (typeof window !== "undefined") {
+    const cache = window.TSCIRCUIT_MODEL_CACHE
+    if (cache.has(url)) {
+      const cached = await cache.get(url)
+      // Clone so each usage gets its own independent scene graph node
+      return cached ? (cached.clone() as THREE.Object3D) : null
     }
   }
 
-  if (typeof window !== "undefined" && !window.TSCIRCUIT_MODEL_CACHE) {
-    window.TSCIRCUIT_MODEL_CACHE = new Map()
+  const loadPromise = loadModel(url)
+
+  if (typeof window !== "undefined") {
+    window.TSCIRCUIT_MODEL_CACHE.set(url, loadPromise)
   }
 
-  export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
-    if (typeof window !== "undefined") {
-      const cache = window.TSCIRCUIT_MODEL_CACHE
-      if (cache.has(url)) {
-        const cached = await cache.get(url)
-        // Clone so each usage gets its own independent scene graph node
-        return cached ? (cached.clone() as THREE.Object3D) : null
-      }
-    }
+  return loadPromise
+}
 
-    const loadPromise = loadModel(url)
-
-    if (typeof window !== "undefined") {
-      window.TSCIRCUIT_MODEL_CACHE.set(url, loadPromise)
-    }
-
-    return loadPromise
+async function loadModel(url: string): Promise<THREE.Object3D | null> {
+  if (url.endsWith(".stl")) {
+    const loader = new STLLoader()
+    const geometry = await loader.loadAsync(url)
+    const material = new THREE.MeshStandardMaterial({
+      color: 0x888888,
+      metalness: 0.5,
+      roughness: 0.5,
+    })
+    return new THREE.Mesh(geometry, material)
   }
 
-  async function loadModel(url: string): Promise<THREE.Object3D | null> {
-    if (url.endsWith(".stl")) {
-      const loader = new STLLoader()
-      const geometry = await loader.loadAsync(url)
-      const material = new THREE.MeshStandardMaterial({
-        color: 0x888888,
-        metalness: 0.5,
-        roughness: 0.5,
-      })
-      return new THREE.Mesh(geometry, material)
-    }
-
-    if (url.endsWith(".obj")) {
-      const loader = new OBJLoader()
-      return await loader.loadAsync(url)
-    }
-
-    if (url.endsWith(".wrl")) {
-      return await loadVrml(url)
-    }
-
-    if (url.endsWith(".gltf") || url.endsWith(".glb")) {
-      const loader = new GLTFLoader()
-      const gltf = await loader.loadAsync(url)
-      return gltf.scene
-    }
-
-    console.error("Unsupported file format or failed to load 3D model.")
-    return null
+  if (url.endsWith(".obj")) {
+    const loader = new OBJLoader()
+    return await loader.loadAsync(url)
   }
-  
+
+  if (url.endsWith(".wrl")) {
+    return await loadVrml(url)
+  }
+
+  if (url.endsWith(".gltf") || url.endsWith(".glb")) {
+    const loader = new GLTFLoader()
+    const gltf = await loader.loadAsync(url)
+    return gltf.scene
+  }
+
+  console.error("Unsupported file format or failed to load 3D model.")
+  return null
+}


### PR DESCRIPTION
Closes #93

  ## Problem
  The `load3DModel` utility had no caching, so the same 3D model file (STL/OBJ/GLTF/WRL) would be fetched and parsed multiple times when multiple components share the same model URL. This caused duplicate network requests and redundant Three.js geometry creation, making the browser laggy.

  ## Fix
  Added a `window.TSCIRCUIT_MODEL_CACHE` global Map that stores in-flight load promises. Before fetching, the function checks the cache. If a cached result exists, it clones the `Object3D` (so each usage gets its own independent scene graph node) instead of re-fetching.

  This follows the same pattern already used in `use-global-obj-loader.ts`.