### PR TITLE
fix: update jscad-electronics dependency to version 0.0.132

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "bun-match-svg": "^0.0.9",
     "bun-types": "1.2.1",
     "debug": "^4.4.0",
-    "jscad-electronics": "^0.0.123",
+    "jscad-electronics": "^0.0.132",
     "jscad-planner": "^0.0.13",
     "jsdom": "^26.0.0",
     "manifold-3d": "^3.2.1",


### PR DESCRIPTION
male pinrow was fixed in latest jscad version
<img width="739" height="501" alt="image" src="https://github.com/user-attachments/assets/6334e5d4-2441-4283-91cf-d9920e919daa" />

will fix female in jscad
