### PR TITLE
Fix GLTF model lifecycle cleanup

### DIFF
--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -1,13 +1,35 @@
-import { useState, useEffect } from "react"
-import * as THREE from "three"
-import { GLTFLoader } from "three-stdlib"
-import { useThree } from "src/react-three/ThreeContext"
+import { useEffect, useRef, useState } from "react"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
+import { useThree } from "src/react-three/ThreeContext"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import { disposeObject3DResources } from "src/utils/dispose-object3d-resources"
+import * as THREE from "three"
+import { GLTFLoader } from "three-stdlib"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
 
 const DEFAULT_ENV_MAP_INTENSITY = 1.25
+
+function applyModelTransparency(scene: THREE.Group, isTranslucent: boolean) {
+  scene.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.material) return
+
+    const setMaterialTransparency = (mat: THREE.Material) => {
+      mat.transparent = isTranslucent
+      mat.opacity = isTranslucent ? 0.5 : 1
+      mat.depthWrite = !isTranslucent
+      mat.needsUpdate = true
+    }
+
+    if (Array.isArray(child.material)) {
+      child.material.forEach(setMaterialTransparency)
+    } else {
+      setMaterialTransparency(child.material)
+    }
+
+    child.renderOrder = isTranslucent ? 2 : 1
+  })
+}
 
 export function GltfModel({
   gltfUrl,
@@ -41,6 +63,7 @@ export function GltfModel({
   const { renderer } = useThree()
   const [model, setModel] = useState<THREE.Group | null>(null)
   const [loadError, setLoadError] = useState<Error | null>(null)
+  const isTranslucentRef = useRef(isTranslucent)
   const { boardTransformGroup } = useCadModelTransformGraph({
     model,
     position,
@@ -54,34 +77,24 @@ export function GltfModel({
   })
 
   useEffect(() => {
+    isTranslucentRef.current = isTranslucent
+  }, [isTranslucent])
+
+  useEffect(() => {
     if (!gltfUrl) return
     const loader = new GLTFLoader()
     let isMounted = true
+    setModel(null)
+    setLoadError(null)
     loader.load(
       gltfUrl,
       (gltf) => {
-        if (!isMounted) return
+        if (!isMounted) {
+          disposeObject3DResources(gltf.scene)
+          return
+        }
         const scene = gltf.scene
-
-        scene.traverse((child) => {
-          if (child instanceof THREE.Mesh && child.material) {
-            const setMaterialTransparency = (mat: THREE.Material) => {
-              mat.transparent = isTranslucent
-              mat.opacity = isTranslucent ? 0.5 : 1
-              mat.depthWrite = !isTranslucent
-              mat.needsUpdate = true
-            }
-
-            if (Array.isArray(child.material)) {
-              child.material.forEach(setMaterialTransparency)
-            } else {
-              setMaterialTransparency(child.material)
-            }
-
-            child.renderOrder = isTranslucent ? 2 : 1
-          }
-        })
-
+        applyModelTransparency(scene, isTranslucentRef.current)
         setModel(scene)
       },
       undefined,
@@ -98,7 +111,12 @@ export function GltfModel({
     return () => {
       isMounted = false
     }
-  }, [gltfUrl, isTranslucent])
+  }, [gltfUrl])
+
+  useEffect(() => {
+    if (!model) return
+    applyModelTransparency(model, isTranslucent)
+  }, [model, isTranslucent])
 
   useEffect(() => {
     if (!model || !renderer) return
@@ -145,13 +163,24 @@ export function GltfModel({
     })
 
     return () => {
-      previousMaterialState.forEach(({ material, envMap, envMapIntensity }) => {
+      for (const {
+        material,
+        envMap,
+        envMapIntensity,
+      } of previousMaterialState) {
         material.envMap = envMap
         material.envMapIntensity = envMapIntensity
         material.needsUpdate = true
-      })
+      }
     }
   }, [model, renderer])
+
+  useEffect(() => {
+    if (!model) return
+    return () => {
+      disposeObject3DResources(model)
+    }
+  }, [model])
 
   useEffect(() => {
     if (!model) return

--- a/src/utils/dispose-object3d-resources.ts
+++ b/src/utils/dispose-object3d-resources.ts
@@ -1,0 +1,35 @@
+import * as THREE from "three"
+
+export function disposeObject3DResources(object: THREE.Object3D): void {
+  const disposedGeometries = new Set<THREE.BufferGeometry>()
+  const disposedMaterials = new Set<THREE.Material>()
+  const disposedTextures = new Set<THREE.Texture>()
+
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    if (child.geometry && !disposedGeometries.has(child.geometry)) {
+      child.geometry.dispose()
+      disposedGeometries.add(child.geometry)
+    }
+
+    const materials = Array.isArray(child.material)
+      ? child.material
+      : [child.material]
+
+    for (const material of materials) {
+      if (!material || disposedMaterials.has(material)) continue
+
+      for (const [key, value] of Object.entries(material)) {
+        if (key === "envMap") continue
+        if (value instanceof THREE.Texture && !disposedTextures.has(value)) {
+          value.dispose()
+          disposedTextures.add(value)
+        }
+      }
+
+      material.dispose()
+      disposedMaterials.add(material)
+    }
+  })
+}

--- a/tests/dispose-object3d-resources.test.ts
+++ b/tests/dispose-object3d-resources.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { disposeObject3DResources } from "../src/utils/dispose-object3d-resources"
+
+test("disposeObject3DResources disposes owned geometry, material, and textures once", () => {
+  const group = new THREE.Group()
+  const geometry = new THREE.BoxGeometry(1, 1, 1)
+  const texture = new THREE.Texture()
+  const material = new THREE.MeshStandardMaterial({ map: texture })
+  const firstMesh = new THREE.Mesh(geometry, material)
+  const secondMesh = new THREE.Mesh(geometry, material)
+  let geometryDisposals = 0
+  let materialDisposals = 0
+  let textureDisposals = 0
+
+  geometry.addEventListener("dispose", () => {
+    geometryDisposals += 1
+  })
+  material.addEventListener("dispose", () => {
+    materialDisposals += 1
+  })
+  texture.addEventListener("dispose", () => {
+    textureDisposals += 1
+  })
+
+  group.add(firstMesh, secondMesh)
+
+  disposeObject3DResources(group)
+
+  expect(geometryDisposals).toBe(1)
+  expect(materialDisposals).toBe(1)
+  expect(textureDisposals).toBe(1)
+})
+
+test("disposeObject3DResources leaves externally assigned env maps alone", () => {
+  const group = new THREE.Group()
+  const externalEnvMap = new THREE.Texture()
+  const material = new THREE.MeshStandardMaterial({ envMap: externalEnvMap })
+  let envMapDisposals = 0
+
+  externalEnvMap.addEventListener("dispose", () => {
+    envMapDisposals += 1
+  })
+
+  group.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material))
+
+  disposeObject3DResources(group)
+
+  expect(envMapDisposals).toBe(0)
+})


### PR DESCRIPTION
/claim #93

## Summary
- Load GLTF/GLB assets only when `gltfUrl` changes, so translucent-state toggles no longer start another `GLTFLoader` request.
- Clear stale GLTF state on URL changes and dispose scenes that finish loading after unmount.
- Add a small `Object3D` resource disposer for owned geometries, materials, and material textures, with coverage that shared environment maps are left intact.

## Validation
- `bun test tests/dispose-object3d-resources.test.ts`
- `bunx biome check src/utils/dispose-object3d-resources.ts src/three-components/GltfModel.tsx tests/dispose-object3d-resources.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bun run build`
- `git diff --check`
