### PR TITLE
Clear stale OBJ loader state on URL changes

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import { loadVrml } from "src/utils/vrml"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
-import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
 interface CacheItem {
@@ -26,6 +26,7 @@ export function useGlobalObjLoader(
   const [obj, setObj] = useState<Object3D | null | Error>(null)
 
   useEffect(() => {
+    setObj(null)
     if (!url) return
 
     const cleanUrl = url.replace(/&cachebust_origin=$/, "")

--- a/tests/use-global-obj-loader-url-change.test.tsx
+++ b/tests/use-global-obj-loader-url-change.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, expect, test } from "bun:test"
+import { JSDOM } from "jsdom"
+import { act, useEffect } from "react"
+import { createRoot, type Root } from "react-dom/client"
+
+type DeferredResponse = {
+  promise: Promise<Response>
+  resolve: (response: Response) => void
+}
+
+const createDeferredResponse = (): DeferredResponse => {
+  let resolve!: (response: Response) => void
+  const promise = new Promise<Response>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const createObjResponse = () =>
+  new Response("o cached_model\nv 0 0 0\n", {
+    status: 200,
+    statusText: "OK",
+  })
+
+let root: Root | null = null
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount()
+    })
+    root = null
+  }
+})
+
+test("useGlobalObjLoader clears stale object while a new url is loading", async () => {
+  const dom = new JSDOM('<div id="root"></div>', {
+    url: "https://example.com",
+  })
+  globalThis.window = dom.window as unknown as Window & typeof globalThis
+  globalThis.document = dom.window.document
+  ;(
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+  window.TSCIRCUIT_OBJ_LOADER_CACHE = new Map()
+
+  const firstLoad = createDeferredResponse()
+  const secondLoad = createDeferredResponse()
+  const fetchCalls: string[] = []
+  globalThis.fetch = (input) => {
+    const url = input.toString()
+    fetchCalls.push(url)
+    if (url.endsWith("first.obj")) return firstLoad.promise
+    if (url.endsWith("second.obj")) return secondLoad.promise
+    throw new Error(`Unexpected fetch: ${url}`)
+  }
+
+  const { useGlobalObjLoader } = await import(
+    "../src/hooks/use-global-obj-loader"
+  )
+  const observedStates: Array<"object" | "null" | "error"> = []
+
+  function Probe({ url }: { url: string }) {
+    const obj = useGlobalObjLoader(url)
+    useEffect(() => {
+      observedStates.push(
+        obj instanceof Error ? "error" : obj === null ? "null" : "object",
+      )
+    }, [obj])
+    return null
+  }
+
+  const container = dom.window.document.getElementById("root")
+  if (!container) throw new Error("missing test root")
+  root = createRoot(container)
+
+  await act(async () => {
+    root?.render(<Probe url="https://cdn.example.com/first.obj" />)
+  })
+  expect(observedStates).toEqual(["null"])
+
+  await act(async () => {
+    firstLoad.resolve(createObjResponse())
+    await firstLoad.promise
+  })
+  expect(observedStates.at(-1)).toBe("object")
+
+  await act(async () => {
+    root?.render(<Probe url="https://cdn.example.com/second.obj" />)
+  })
+  expect(observedStates.at(-1)).toBe("null")
+
+  await act(async () => {
+    secondLoad.resolve(createObjResponse())
+    await secondLoad.promise
+  })
+  expect(observedStates.at(-1)).toBe("object")
+  expect(fetchCalls).toEqual([
+    "https://cdn.example.com/first.obj",
+    "https://cdn.example.com/second.obj",
+  ])
+})

--- a/tests/use-global-obj-loader-url-change.test.tsx
+++ b/tests/use-global-obj-loader-url-change.test.tsx
@@ -23,6 +23,12 @@ const createObjResponse = () =>
   })
 
 let root: Root | null = null
+const originalFetch = globalThis.fetch
+const originalWindow = globalThis.window
+const originalDocument = globalThis.document
+const originalActEnvironment = (
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT
 
 afterEach(() => {
   if (root) {
@@ -30,6 +36,17 @@ afterEach(() => {
       root?.unmount()
     })
     root = null
+  }
+  globalThis.fetch = originalFetch
+  globalThis.window = originalWindow
+  globalThis.document = originalDocument
+  const globalWithAct = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean
+  }
+  if (originalActEnvironment === undefined) {
+    delete globalWithAct.IS_REACT_ACT_ENVIRONMENT
+  } else {
+    globalWithAct.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment
   }
 })
 


### PR DESCRIPTION
/claim #93

## Summary
- Clear `useGlobalObjLoader` state whenever the requested OBJ/WRL URL changes or becomes null, so the previous `Object3D` is removed while the replacement load is pending.
- Add focused React hook coverage proving a loaded first model is cleared before a slower second URL resolves.

## Non-overlap
This is scoped to the OBJ/WRL React hook lifecycle. It does not add a global `load3DModel` cache, GLTF cache/lifecycle cleanup, STL cache/stale-load handling, or STEP blob/cache changes covered by existing open PRs.

## Validation
- `bun test tests/use-global-obj-loader-url-change.test.tsx` with `bunfig.toml` temporarily moved aside to bypass the repo-wide sharp/looks-same preload; focused test passed.
- `./node_modules/@biomejs/cli-darwin-arm64/biome check src/hooks/use-global-obj-loader.ts tests/use-global-obj-loader-url-change.test.tsx`
- `bun ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `bun ./node_modules/tsup/dist/cli-default.js`
- `git diff --check`

## Local environment note
`bun install`, `bunx`, direct `.bin` scripts, and `bun run build` hit a local Homebrew Node linker failure: missing `/opt/homebrew/opt/simdjson/lib/libsimdjson.30.dylib`. Running the same tools through Bun/native package binaries avoided that Node issue. The default Bun test preload also needs `sharp`, so the focused test was run with `bunfig.toml` temporarily restored immediately afterward.

## Disclosure
AI-assisted with Codex; I reviewed the diff and validation results before submitting.