### PR TITLE
Clear stale STEP model while new URL loads

### DIFF
--- a/src/three-components/StepModel.tsx
+++ b/src/three-components/StepModel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 import {
   BufferGeometry,
   Color,
@@ -9,7 +10,6 @@ import {
 } from "three"
 import { GLTFExporter } from "three-stdlib"
 import { GltfModel } from "./GltfModel"
-import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 
 type OcctImportParams = {
   linearUnit?: "millimeter" | "centimeter" | "meter" | "inch" | "foot"
@@ -246,6 +246,9 @@ export const StepModel = ({
     let objectUrl: string | null = null
     let shouldRevokeObjectUrl = true
     const registry = getStepUrlConversionRegistry()
+
+    setStepGltfUrl(null)
+
     const cachedGlb = getCachedGlb(stepUrl)
     if (cachedGlb) {
       const cachedConverted: ConvertedStepFile = {

--- a/tests/step-model-url-change.test.tsx
+++ b/tests/step-model-url-change.test.tsx
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test"
+import { JSDOM } from "jsdom"
+import React, { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+
+;(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+const renderedGltfUrls: string[] = []
+const gltfModelMock = () => ({
+  GltfModel: ({ gltfUrl }: { gltfUrl: string }) => {
+    renderedGltfUrls.push(gltfUrl)
+    return React.createElement("span", { "data-testid": "gltf-url" }, gltfUrl)
+  },
+})
+
+mock.module("../src/three-components/GltfModel", gltfModelMock)
+mock.module("../src/three-components/GltfModel.tsx", gltfModelMock)
+
+const { StepModel } = await import("../src/three-components/StepModel")
+
+let dom: JSDOM
+let container: HTMLElement
+let root: Root
+let originalFetch: typeof globalThis.fetch
+let originalCreateObjectUrl: typeof URL.createObjectURL | undefined
+let originalRevokeObjectUrl: typeof URL.revokeObjectURL | undefined
+
+function renderStepModel(stepUrl: string) {
+  root.render(
+    <StepModel
+      stepUrl={stepUrl}
+      onHover={() => {}}
+      onUnhover={() => {}}
+      isHovered={false}
+    />,
+  )
+}
+
+beforeEach(() => {
+  dom = new JSDOM('<!doctype html><div id="root"></div>', {
+    url: "https://example.test",
+  })
+  container = dom.window.document.getElementById("root")!
+  root = createRoot(container)
+  renderedGltfUrls.length = 0
+  ;(
+    globalThis as { stepUrlToGltfModelConversions?: unknown }
+  ).stepUrlToGltfModelConversions = undefined
+
+  Object.defineProperty(globalThis, "window", {
+    value: dom.window,
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, "document", {
+    value: dom.window.document,
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, "localStorage", {
+    value: dom.window.localStorage,
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, "navigator", {
+    value: dom.window.navigator,
+    configurable: true,
+  })
+
+  originalFetch = globalThis.fetch
+  globalThis.fetch = (() => new Promise<Response>(() => {})) as typeof fetch
+
+  originalCreateObjectUrl = URL.createObjectURL
+  originalRevokeObjectUrl = URL.revokeObjectURL
+
+  let objectUrlCount = 0
+  URL.createObjectURL = mock(() => {
+    objectUrlCount += 1
+    return `blob:step-${objectUrlCount}`
+  })
+  URL.revokeObjectURL = mock(() => {})
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  globalThis.fetch = originalFetch
+  if (originalCreateObjectUrl) {
+    URL.createObjectURL = originalCreateObjectUrl
+  }
+  if (originalRevokeObjectUrl) {
+    URL.revokeObjectURL = originalRevokeObjectUrl
+  }
+  dom.window.close()
+})
+
+test("clears the previous converted STEP model while a new STEP URL is pending", async () => {
+  localStorage.setItem("step-glb-cache:first.step", "AQID")
+
+  await act(async () => {
+    renderStepModel("first.step")
+    await Promise.resolve()
+  })
+
+  expect(container.textContent).toBe("blob:step-1")
+
+  await act(async () => {
+    renderStepModel("second.step")
+    await Promise.resolve()
+  })
+
+  expect(container.textContent).toBe("")
+  expect(renderedGltfUrls).toContain("blob:step-1")
+})


### PR DESCRIPTION
/claim #93

## Summary
- Clear `StepModel`'s derived `stepGltfUrl` at the start of each new `stepUrl` load, so a previously converted STEP model is removed while the next STEP conversion is pending.
- Add focused React coverage for switching from a cached STEP model to a new pending STEP URL.

## Non-overlap
This is scoped to the STEP React lifecycle state for URL changes. It does not add or change STEP cache-key normalization, completed/blob reuse, temporary conversion resource disposal, generic `load3DModel` caching, GLTF lifecycle cleanup, OBJ/WRL loader behavior, or STL handling covered by existing PRs.

## Validation
- `npx --yes bun test tests/step-model-url-change.test.tsx` with `bunfig.toml` temporarily moved aside to bypass the repo-wide sharp/looks-same preload; focused test passed.
- `npx biome check src/three-components/StepModel.tsx tests/step-model-url-change.test.tsx`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `npm run test:node-bundle`
- `git diff --check`

## Local environment note
The default `bun test` preload imports `looks-same`/`sharp`; local dependencies were installed with scripts disabled, so the focused React test was run without the unrelated snapshot preload and `bunfig.toml` was restored afterward.

AI-assisted with Codex; I reviewed the diff and validation results before submitting.
