### PR TITLE
Reset model fallback boundary when model URLs change

### DIFF
--- a/src/AnyCadComponent.tsx
+++ b/src/AnyCadComponent.tsx
@@ -13,6 +13,7 @@ import { GltfModel } from "./three-components/GltfModel"
 import { JscadModel } from "./three-components/JscadModel"
 import { MixedStlModel } from "./three-components/MixedStlModel"
 import { StepModel } from "./three-components/StepModel"
+import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
 import {
   getCadLoaderTransformConfig,
   getCadLoaderTransformMatrix,
@@ -25,7 +26,6 @@ import {
 } from "./utils/get-cad-model-type"
 import { resolveModelUrl } from "./utils/resolve-model-url"
 import { tuple } from "./utils/tuple"
-import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
 
 const ModelLoadErrorReporter = ({
   error,
@@ -39,6 +39,28 @@ const ModelLoadErrorReporter = ({
   }, [error, onError])
 
   return null
+}
+
+export function getModelFallbackBoundaryKey({
+  cadComponentId,
+  fallbackModelIndex,
+  gltfUrl,
+  url,
+  stepUrl,
+}: {
+  cadComponentId: string
+  fallbackModelIndex: number
+  gltfUrl?: string | null
+  url?: string | null
+  stepUrl?: string | null
+}) {
+  return [
+    cadComponentId,
+    fallbackModelIndex,
+    gltfUrl ?? "",
+    url ?? "",
+    stepUrl ?? "",
+  ].join("|")
 }
 
 export const AnyCadComponent = ({
@@ -251,9 +273,18 @@ export const AnyCadComponent = ({
       return null
     }
 
+    const fallbackBoundaryKey = getModelFallbackBoundaryKey({
+      cadComponentId: cad_component.cad_component_id,
+      fallbackModelIndex,
+      gltfUrl,
+      url,
+      stepUrl,
+    })
+
     modelComponent = (
       <ThreeErrorBoundary
-        key={`${cad_component.cad_component_id}-fallback-${fallbackModelIndex}`}
+        key={fallbackBoundaryKey}
+        resetKey={fallbackBoundaryKey}
         fallback={({ error }) => (
           <ModelLoadErrorReporter
             error={error}

--- a/src/three-components/ThreeErrorBoundary.tsx
+++ b/src/three-components/ThreeErrorBoundary.tsx
@@ -3,6 +3,7 @@ import React from "react"
 interface Props {
   children: React.ReactNode
   fallback: (props: { error: Error }) => any
+  resetKey?: string
 }
 
 interface State {
@@ -18,6 +19,12 @@ export class ThreeErrorBoundary extends React.Component<Props, State> {
 
   static getDerivedStateFromError(error: Error): State {
     return { hasError: true, error }
+  }
+
+  override componentDidUpdate(prevProps: Props) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false, error: null })
+    }
   }
 
   override render() {

--- a/tests/model-fallback-boundary.test.ts
+++ b/tests/model-fallback-boundary.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { getModelFallbackBoundaryKey } from "../src/AnyCadComponent"
+import { ThreeErrorBoundary } from "../src/three-components/ThreeErrorBoundary"
+
+function createBoundary(resetKey: string) {
+  const boundary = new ThreeErrorBoundary({
+    resetKey,
+    fallback: () => null,
+    children: null,
+  } as any) as any
+
+  boundary.setState = (nextState: any) => {
+    boundary.state = {
+      ...boundary.state,
+      ...(typeof nextState === "function"
+        ? nextState(boundary.state, boundary.props)
+        : nextState),
+    }
+  }
+
+  return boundary
+}
+
+test("ThreeErrorBoundary clears captured errors when resetKey changes", () => {
+  const boundary = createBoundary("component-a|0|old.glb")
+  boundary.state = ThreeErrorBoundary.getDerivedStateFromError(
+    new Error("old model failed"),
+  )
+
+  const previousProps = boundary.props
+  boundary.props = { ...boundary.props, resetKey: "component-a|0|new.glb" }
+  boundary.componentDidUpdate(previousProps)
+
+  expect(boundary.state).toEqual({ hasError: false, error: null })
+})
+
+test("ThreeErrorBoundary keeps captured errors when resetKey is unchanged", () => {
+  const boundary = createBoundary("component-a|0|old.glb")
+  const error = new Error("old model failed")
+  boundary.state = ThreeErrorBoundary.getDerivedStateFromError(error)
+
+  boundary.componentDidUpdate(boundary.props)
+
+  expect(boundary.state).toEqual({ hasError: true, error })
+})
+
+test("model fallback boundary key changes when model URLs change", () => {
+  const oldKey = getModelFallbackBoundaryKey({
+    cadComponentId: "component-a",
+    fallbackModelIndex: 0,
+    gltfUrl: "https://cdn.example.com/old.glb",
+    url: null,
+    stepUrl: null,
+  })
+  const newKey = getModelFallbackBoundaryKey({
+    cadComponentId: "component-a",
+    fallbackModelIndex: 0,
+    gltfUrl: "https://cdn.example.com/new.glb",
+    url: null,
+    stepUrl: null,
+  })
+
+  expect(newKey).not.toBe(oldKey)
+})


### PR DESCRIPTION
## Summary
- Add a `resetKey` to `ThreeErrorBoundary` so captured loader errors can be cleared when the active model fallback source changes.
- Key the CAD model fallback error boundary by component id, fallback index, and the current GLTF/mesh/STEP URLs.
- Add focused regression coverage for reset behavior and URL-sensitive fallback keys.

## Why
On current main, the fallback `ThreeErrorBoundary` is keyed only by component id and fallback index. If a model URL fails once and then changes to a valid replacement URL, the existing boundary can stay in its old error state and immediately skip/advance the new candidate instead of retrying that replacement model. That creates unnecessary fallback churn and can prevent recovered model loads from displaying.

/claim #93

## Verification
- `bun test tests/model-fallback-boundary.test.ts` -> 3 pass
- `npx biome check src/AnyCadComponent.tsx src/three-components/ThreeErrorBoundary.tsx tests/model-fallback-boundary.test.ts` -> no fixes/errors
- `npx tsc --noEmit --pretty false` -> exit 0
- `npm run build` -> exit 0
- `npm run test:node-bundle` -> exit 0
- `git diff --check` -> exit 0

Full `bun test` currently reports 27 passing tests and 3 unrelated existing failures on this checkout:
- `tests/preprocess-circuit-json.test.ts`: faux-board z expectations are 0.1 higher than current output.
- `tests/outline-bounds.test.ts`: expected older soldermask color string does not match the current rendered SVG color.

AI-assisted with Codex; I reviewed the diff and local verification before submitting.