### PR TITLE
Surface STEP conversion errors

### DIFF
--- a/src/three-components/StepModel.tsx
+++ b/src/three-components/StepModel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 import {
   BufferGeometry,
   Color,
@@ -9,7 +10,6 @@ import {
 } from "three"
 import { GLTFExporter } from "three-stdlib"
 import { GltfModel } from "./GltfModel"
-import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 
 type OcctImportParams = {
   linearUnit?: "millimeter" | "centimeter" | "meter" | "inch" | "foot"
@@ -240,11 +240,13 @@ export const StepModel = ({
   isTranslucent,
 }: StepModelProps) => {
   const [stepGltfUrl, setStepGltfUrl] = useState<string | null>(null)
+  const [loadError, setLoadError] = useState<Error | null>(null)
 
   useEffect(() => {
     let isActive = true
     let objectUrl: string | null = null
     let shouldRevokeObjectUrl = true
+    setLoadError(null)
     const registry = getStepUrlConversionRegistry()
     const cachedGlb = getCachedGlb(stepUrl)
     if (cachedGlb) {
@@ -311,6 +313,11 @@ export const StepModel = ({
       .catch((error) => {
         console.error("Failed to convert STEP file to GLB", error)
         if (isActive) {
+          setLoadError(
+            error instanceof Error
+              ? error
+              : new Error("Failed to convert STEP file to GLB"),
+          )
           setStepGltfUrl(null)
         }
       })
@@ -321,6 +328,10 @@ export const StepModel = ({
       }
     }
   }, [stepUrl])
+
+  if (loadError) {
+    throw loadError
+  }
 
   if (!stepGltfUrl) {
     return null

--- a/tests/step-model-error.test.tsx
+++ b/tests/step-model-error.test.tsx
@@ -1,0 +1,95 @@
+import { expect, mock, test } from "bun:test"
+import { JSDOM } from "jsdom"
+import React, { act } from "react"
+import { createRoot } from "react-dom/client"
+import { StepModel } from "../src/three-components/StepModel"
+
+class CaptureErrorBoundary extends React.Component<
+  { children: React.ReactNode; onError: (error: Error) => void },
+  { error: Error | null }
+> {
+  override state = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  override componentDidCatch(error: Error) {
+    this.props.onError(error)
+  }
+
+  override render() {
+    return this.state.error ? null : this.props.children
+  }
+}
+
+const waitForEffects = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
+test("StepModel surfaces STEP conversion failures to error boundaries", async () => {
+  const dom = new JSDOM('<div id="root"></div>', {
+    url: "https://example.test/",
+  })
+  const container = dom.window.document.getElementById("root")
+  if (!container) {
+    throw new Error("Missing test root")
+  }
+
+  const originalWindow = globalThis.window
+  const originalDocument = globalThis.document
+  const originalLocalStorage = globalThis.localStorage
+  const originalFetch = globalThis.fetch
+  const originalConsoleError = console.error
+
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  ;(globalThis as any).window = dom.window
+  ;(globalThis as any).document = dom.window.document
+  ;(globalThis as any).localStorage = dom.window.localStorage
+  globalThis.fetch = mock(async () => {
+    return new Response("", { status: 404, statusText: "Not Found" })
+  }) as typeof fetch
+  console.error = mock(() => {}) as typeof console.error
+
+  let capturedError: Error | null = null
+  const root = createRoot(container)
+
+  try {
+    await act(async () => {
+      root.render(
+        <CaptureErrorBoundary
+          onError={(error) => {
+            capturedError = error
+          }}
+        >
+          <StepModel
+            stepUrl="https://example.test/missing.step"
+            onHover={() => {}}
+            onUnhover={() => {}}
+            isHovered={false}
+          />
+        </CaptureErrorBoundary>,
+      )
+    })
+
+    for (let i = 0; i < 20 && !capturedError; i += 1) {
+      await act(async () => {
+        await waitForEffects()
+      })
+    }
+
+    const error = capturedError as Error | null
+    expect(error?.message).toBe("Failed to fetch STEP file: Not Found")
+  } finally {
+    await act(async () => {
+      root.unmount()
+    })
+    ;(globalThis as any).window = originalWindow
+    ;(globalThis as any).document = originalDocument
+    ;(globalThis as any).localStorage = originalLocalStorage
+    globalThis.fetch = originalFetch
+    console.error = originalConsoleError
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT
+  }
+})


### PR DESCRIPTION
/claim #93

## Summary
- Track STEP-to-GLB conversion failures in `StepModel` instead of only logging them.
- Throw the stored conversion error during render so the existing `ThreeErrorBoundary`/CAD fallback flow can surface `Error3d` instead of leaving a silent empty STEP model.
- Add focused React coverage for a failed STEP fetch reaching an error boundary.

## Testing
- `bun test C:\Users\gamec\AppData\Local\Temp\codex-bounty-scout\3d-viewer\tests\step-model-error.test.tsx` (run from `C:\Users\gamec\AppData\Local\Temp` to avoid this Windows checkout's broken `sharp` preload after install scripts failed)
- `bun x biome check src/three-components/StepModel.tsx tests/step-model-error.test.tsx`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and kept the patch scoped.