### PR TITLE
fix: add global model cache to prevent duplicate 3D model loading

### DIFF
--- a/src/utils/load-model.ts
+++ b/src/utils/load-model.ts
@@ -4,7 +4,22 @@ import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js"
 import { loadVrml } from "./vrml"
 
-export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+interface CacheEntry {
+  promise: Promise<THREE.Object3D | null>
+  result: THREE.Object3D | null
+}
+
+declare global {
+  interface Window {
+    TSCIRCUIT_3D_MODEL_CACHE: Map<string, CacheEntry>
+  }
+}
+
+if (typeof window !== "undefined" && !window.TSCIRCUIT_3D_MODEL_CACHE) {
+  window.TSCIRCUIT_3D_MODEL_CACHE = new Map()
+}
+
+async function loadModelInternal(url: string): Promise<THREE.Object3D | null> {
   if (url.endsWith(".stl")) {
     const loader = new STLLoader()
     const geometry = await loader.loadAsync(url)
@@ -33,4 +48,29 @@ export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
 
   console.error("Unsupported file format or failed to load 3D model.")
   return null
+}
+
+export async function load3DModel(url: string): Promise<THREE.Object3D | null> {
+  if (typeof window === "undefined") {
+    return loadModelInternal(url)
+  }
+
+  const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+  const cache = window.TSCIRCUIT_3D_MODEL_CACHE
+
+  if (cache.has(cleanUrl)) {
+    const entry = cache.get(cleanUrl)!
+    if (entry.result) {
+      return entry.result.clone() as THREE.Object3D
+    }
+    const result = await entry.promise
+    return result ? (result.clone() as THREE.Object3D) : null
+  }
+
+  const promise = loadModelInternal(cleanUrl)
+  cache.set(cleanUrl, { promise, result: null })
+
+  const result = await promise
+  cache.set(cleanUrl, { promise, result })
+  return result ? (result.clone() as THREE.Object3D) : null
 }


### PR DESCRIPTION
/claim #93

Adds a global model cache (`TSCIRCUIT_3D_MODEL_CACHE`) to `load3DModel()` to prevent duplicate loading of the same 3D model URL.

- Caches loaded models by cleaned URL (strips `cachebust_origin`)
- Deduplicates in-flight requests by reusing the same promise
- Returns cloned instances so each consumer gets an independent `Object3D`
- Works with STL, OBJ, WRL, GLTF, and GLB models
- SSR-safe: falls back to uncached loading when `window` is not available