### PR TITLE
Cache cloned glTF model loads

### DIFF
--- a/src/hooks/use-global-gltf-loader.ts
+++ b/src/hooks/use-global-gltf-loader.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react"
+import type * as THREE from "three"
+import { GLTFLoader } from "three-stdlib"
+import { cloneObject3DWithMaterials } from "src/utils/clone-object3d-with-materials"
+
+interface CacheItem {
+  promise: Promise<THREE.Group | Error>
+  result: THREE.Group | null
+}
+
+declare global {
+  interface Window {
+    TSCIRCUIT_GLTF_LOADER_CACHE: Map<string, CacheItem>
+  }
+}
+
+if (typeof window !== "undefined" && !window.TSCIRCUIT_GLTF_LOADER_CACHE) {
+  window.TSCIRCUIT_GLTF_LOADER_CACHE = new Map<string, CacheItem>()
+}
+
+export function useGlobalGltfLoader(
+  url: string | null,
+): THREE.Group | null | Error {
+  const [model, setModel] = useState<THREE.Group | null | Error>(null)
+
+  useEffect(() => {
+    if (!url) return
+
+    const cleanUrl = url.replace(/&cachebust_origin=$/, "")
+    const cache = window.TSCIRCUIT_GLTF_LOADER_CACHE
+    let hasUrlChanged = false
+
+    async function loadAndParseGltf() {
+      try {
+        const loader = new GLTFLoader()
+        const gltf = await loader.loadAsync(cleanUrl)
+        return gltf.scene
+      } catch (error) {
+        return error instanceof Error
+          ? error
+          : new Error(`Failed to load glTF model from ${cleanUrl}`)
+      }
+    }
+
+    function loadUrl() {
+      if (cache.has(cleanUrl)) {
+        const cacheItem = cache.get(cleanUrl)!
+        if (cacheItem.result) {
+          return Promise.resolve(cloneObject3DWithMaterials(cacheItem.result))
+        }
+
+        return cacheItem.promise.then((result) => {
+          if (result instanceof Error) return result
+          return cloneObject3DWithMaterials(result)
+        })
+      }
+
+      const promise = loadAndParseGltf().then((result) => {
+        if (result instanceof Error) return result
+        cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
+        return cloneObject3DWithMaterials(result)
+      })
+
+      cache.set(cleanUrl, { promise, result: null })
+      return promise
+    }
+
+    loadUrl()
+      .then((result) => {
+        if (hasUrlChanged) return
+        setModel(result)
+      })
+      .catch((error) => {
+        console.error(error)
+      })
+
+    return () => {
+      hasUrlChanged = true
+    }
+  }, [url])
+
+  return model
+}

--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
+import { cloneObject3DWithMaterials } from "src/utils/clone-object3d-with-materials"
 import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
@@ -82,13 +83,12 @@ export function useGlobalObjLoader(
       if (cache.has(cleanUrl)) {
         const cacheItem = cache.get(cleanUrl)!
         if (cacheItem.result) {
-          // If we have a result, clone it
-          return Promise.resolve(cacheItem.result.clone())
+          return Promise.resolve(cloneObject3DWithMaterials(cacheItem.result))
         }
         // If we're still loading, return the existing promise
         return cacheItem.promise.then((result) => {
           if (result instanceof Error) return result
-          return result.clone()
+          return cloneObject3DWithMaterials(result)
         })
       }
       // If it's not in the cache, create a new promise and cache it
@@ -98,7 +98,7 @@ export function useGlobalObjLoader(
           return result
         }
         cache.set(cleanUrl, { ...cache.get(cleanUrl)!, result })
-        return result
+        return cloneObject3DWithMaterials(result)
       })
       cache.set(cleanUrl, { promise, result: null })
       return promise

--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from "react"
+import { useEffect } from "react"
 import * as THREE from "three"
-import { GLTFLoader } from "three-stdlib"
 import { useThree } from "src/react-three/ThreeContext"
 import ContainerWithTooltip from "src/ContainerWithTooltip"
+import { useGlobalGltfLoader } from "src/hooks/use-global-gltf-loader"
 import { getDefaultEnvironmentMap } from "src/react-three/getDefaultEnvironmentMap"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
 import { useCadModelTransformGraph } from "./useCadModelTransformGraph"
@@ -39,8 +39,8 @@ export function GltfModel({
   isTranslucent?: boolean
 }) {
   const { renderer } = useThree()
-  const [model, setModel] = useState<THREE.Group | null>(null)
-  const [loadError, setLoadError] = useState<Error | null>(null)
+  const loadedModel = useGlobalGltfLoader(gltfUrl)
+  const model = loadedModel instanceof Error ? null : loadedModel
   const { boardTransformGroup } = useCadModelTransformGraph({
     model,
     position,
@@ -54,51 +54,27 @@ export function GltfModel({
   })
 
   useEffect(() => {
-    if (!gltfUrl) return
-    const loader = new GLTFLoader()
-    let isMounted = true
-    loader.load(
-      gltfUrl,
-      (gltf) => {
-        if (!isMounted) return
-        const scene = gltf.scene
+    if (!model) return
 
-        scene.traverse((child) => {
-          if (child instanceof THREE.Mesh && child.material) {
-            const setMaterialTransparency = (mat: THREE.Material) => {
-              mat.transparent = isTranslucent
-              mat.opacity = isTranslucent ? 0.5 : 1
-              mat.depthWrite = !isTranslucent
-              mat.needsUpdate = true
-            }
+    model.traverse((child) => {
+      if (child instanceof THREE.Mesh && child.material) {
+        const setMaterialTransparency = (mat: THREE.Material) => {
+          mat.transparent = isTranslucent
+          mat.opacity = isTranslucent ? 0.5 : 1
+          mat.depthWrite = !isTranslucent
+          mat.needsUpdate = true
+        }
 
-            if (Array.isArray(child.material)) {
-              child.material.forEach(setMaterialTransparency)
-            } else {
-              setMaterialTransparency(child.material)
-            }
+        if (Array.isArray(child.material)) {
+          child.material.forEach(setMaterialTransparency)
+        } else {
+          setMaterialTransparency(child.material)
+        }
 
-            child.renderOrder = isTranslucent ? 2 : 1
-          }
-        })
-
-        setModel(scene)
-      },
-      undefined,
-      (error) => {
-        if (!isMounted) return
-        console.error(`An error happened loading ${gltfUrl}`, error)
-        const err =
-          error instanceof Error
-            ? error
-            : new Error(`Failed to load glTF model from ${gltfUrl}`)
-        setLoadError(err)
-      },
-    )
-    return () => {
-      isMounted = false
-    }
-  }, [gltfUrl, isTranslucent])
+        child.renderOrder = isTranslucent ? 2 : 1
+      }
+    })
+  }, [model, isTranslucent])
 
   useEffect(() => {
     if (!model || !renderer) return
@@ -170,8 +146,8 @@ export function GltfModel({
     })
   }, [isHovered, model])
 
-  if (loadError) {
-    throw loadError
+  if (loadedModel instanceof Error) {
+    throw loadedModel
   }
 
   if (!model) return null

--- a/src/utils/clone-object3d-with-materials.ts
+++ b/src/utils/clone-object3d-with-materials.ts
@@ -1,0 +1,19 @@
+import * as THREE from "three"
+
+export function cloneObject3DWithMaterials<T extends THREE.Object3D>(
+  object: T,
+): T {
+  const clone = object.clone(true) as T
+
+  clone.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+
+    if (Array.isArray(child.material)) {
+      child.material = child.material.map((material) => material.clone())
+    } else if (child.material) {
+      child.material = child.material.clone()
+    }
+  })
+
+  return clone
+}

--- a/tests/clone-object3d-with-materials.test.ts
+++ b/tests/clone-object3d-with-materials.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import * as THREE from "three"
+import { cloneObject3DWithMaterials } from "../src/utils/clone-object3d-with-materials"
+
+function getFirstMaterial(object: THREE.Object3D): THREE.Material {
+  let material: THREE.Material | undefined
+
+  object.traverse((child) => {
+    if (material || !(child instanceof THREE.Mesh)) return
+
+    material = Array.isArray(child.material)
+      ? child.material[0]
+      : child.material
+  })
+
+  if (!material) {
+    throw new Error("Expected mesh material")
+  }
+
+  return material
+}
+
+test("clones meshes with independent material instances", () => {
+  const sourceMaterial = new THREE.MeshStandardMaterial({ opacity: 1 })
+  const source = new THREE.Group()
+  source.add(new THREE.Mesh(new THREE.BoxGeometry(), sourceMaterial))
+
+  const cloneA = cloneObject3DWithMaterials(source)
+  const cloneB = cloneObject3DWithMaterials(source)
+  const materialA = getFirstMaterial(cloneA)
+  const materialB = getFirstMaterial(cloneB)
+
+  expect(materialA).not.toBe(sourceMaterial)
+  expect(materialB).not.toBe(sourceMaterial)
+  expect(materialA).not.toBe(materialB)
+
+  materialA.opacity = 0.25
+
+  expect(materialB.opacity).toBe(1)
+  expect(sourceMaterial.opacity).toBe(1)
+})


### PR DESCRIPTION
## Summary

- add a global glTF/GLB loader cache that mirrors the existing global OBJ cache
- return fresh Object3D clones with cloned material instances for each consumer
- reuse the clone helper in the OBJ/WRL cache so transparency, hover, and env-map mutations do not leak into cached source objects or duplicate model instances

Fixes #93.

## Validation

- `npm install --legacy-peer-deps --package-lock=false`
- `biome format --write src/hooks/use-global-gltf-loader.ts src/utils/clone-object3d-with-materials.ts src/hooks/use-global-obj-loader.ts src/three-components/GltfModel.tsx tests/clone-object3d-with-materials.test.ts`
- `tsc --noEmit`
- `npm run build`
- `bun test tests/clone-object3d-with-materials.test.ts`
- `bun test tests/clone-object3d-with-materials.test.ts tests/cad-model-transform.test.ts tests/resolve-model-url.test.ts tests/vrml-loader.test.ts`
- `npm run test:node-bundle`

Note: the full `bun test` suite still has unrelated pre-existing failures in outline-bounds and preprocess-circuit-json assertions.