### PR TITLE
Fix WebGL context leak on Canvas unmount

### DIFF
--- a/src/react-three/Canvas.tsx
+++ b/src/react-three/Canvas.tsx
@@ -184,6 +184,7 @@ export const Canvas = forwardRef<THREE.Object3D, CanvasProps>(
           mountRef.current.removeChild(renderer.domElement)
         }
         renderer.dispose()
+        renderer.forceContextLoss()
         scene.remove(rootObject.current)
         if (window.__TSCIRCUIT_THREE_OBJECT === rootObject.current) {
           window.__TSCIRCUIT_THREE_OBJECT = undefined


### PR DESCRIPTION
The main viewer's unmount cleanup called `renderer.dispose()` but never `renderer.forceContextLoss()`, so each tab switch stranded a WebGL context until the browser hit its ~16-context limit and evicted the oldest. `dispose()` only frees GPU resources; `forceContextLoss()` releases the context itself. `OrientationCubeCanvas` already did this correctly.