### PR TITLE
Add keepout layer visibility toggle to 3D viewer appearance menu

### DIFF
--- a/src/components/AppearanceMenu.tsx
+++ b/src/components/AppearanceMenu.tsx
@@ -176,6 +176,29 @@ export const AppearanceMenu = () => {
               style={{
                 ...itemStyles,
                 backgroundColor:
+                  hoveredItem === "keepout" ? "#404040" : "transparent",
+              }}
+              onSelect={(e) => e.preventDefault()}
+              onPointerDown={(e) => {
+                e.preventDefault()
+                setLayerVisibility("keepout", !visibility.keepout)
+              }}
+              onMouseEnter={() => setHoveredItem("keepout")}
+              onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("keepout")}
+            >
+              <span style={iconContainerStyles}>
+                {visibility.keepout && <CheckIcon />}
+              </span>
+              <span style={{ display: "flex", alignItems: "center" }}>
+                Keepout
+              </span>
+            </DropdownMenu.Item>
+
+            <DropdownMenu.Item
+              style={{
+                ...itemStyles,
+                backgroundColor:
                   hoveredItem === "topSilkscreen" ? "#404040" : "transparent",
               }}
               onSelect={(e) => e.preventDefault()}

--- a/src/contexts/LayerVisibilityContext.tsx
+++ b/src/contexts/LayerVisibilityContext.tsx
@@ -11,6 +11,7 @@ export interface LayerVisibilityState {
   boardBody: boolean
   topCopper: boolean
   bottomCopper: boolean
+  keepout: boolean
   adhesive: boolean
   solderPaste: boolean
   topSilkscreen: boolean
@@ -42,6 +43,7 @@ const defaultVisibility: LayerVisibilityState = {
   boardBody: true,
   topCopper: true,
   bottomCopper: true,
+  keepout: true,
   adhesive: false,
   solderPaste: false,
   topSilkscreen: true,

--- a/src/textures/create-combined-board-textures.ts
+++ b/src/textures/create-combined-board-textures.ts
@@ -97,6 +97,7 @@ export function createCombinedBoardTextures({
       (layer === "top"
         ? visibility?.topSilkscreen
         : visibility?.bottomSilkscreen) ?? true
+    const showKeepout = visibility?.keepout ?? true
 
     const soldermaskTexture = showMask
       ? createSoldermaskTextureForLayer({
@@ -194,12 +195,14 @@ export function createCombinedBoardTextures({
         })
       : null
 
-    const keepoutTexture = createKeepoutTextureForLayer({
-      layer,
-      circuitJson,
-      boardData,
-      traceTextureResolution,
-    })
+    const keepoutTexture = showKeepout
+      ? createKeepoutTextureForLayer({
+          layer,
+          circuitJson,
+          boardData,
+          traceTextureResolution,
+        })
+      : null
 
     return createCombinedTexture({
       textures: [


### PR DESCRIPTION
## Summary

The 3D viewer's Appearance menu lets users toggle every board layer — board body, top/bottom copper, silkscreen, soldermask, solder paste, PCB notes, and component models — except **keepout**. The keepout texture was generated and composited onto the board unconditionally, so keepout regions were always visible with no way to hide them.

This PR adds a **Keepout** entry to the Appearance menu and makes the keepout texture respect that visibility flag, bringing it in line with every other layer.

<img width="1010" height="658" alt="image" src="https://github.com/user-attachments/assets/dc68aea4-0e55-482c-ae1f-21d612bc5f94" />


## What changed

- **`LayerVisibilityContext`** — add a `keepout` field to `LayerVisibilityState` (defaults to `true`, preserving current behavior on first load).
- **`AppearanceMenu`** — add a toggleable "Keepout" menu item that drives `setLayerVisibility("keepout", …)`, matching the interaction pattern of the other layer toggles.
- **`create-combined-board-textures`** — only build and composite `createKeepoutTextureForLayer(...)` when `visibility.keepout` is set, instead of always generating it.

## Before / After

|  | Before | After |
|---|---|---|
| Keepout in Appearance menu | ❌ missing | ✅ toggleable |
| Hide keepout regions | ❌ impossible | ✅ supported |
| Texture work when hidden | always generated | skipped |

## Why it matters

Keepout was the only un-hideable layer, an inconsistency in the layer controls. Beyond the UX fix, skipping the keepout texture when it's hidden avoids unnecessary per-layer texture generation and compositing.

## Testing

- Opened the Appearance menu and confirmed the new **Keepout** toggle shows/hides keepout regions on both top and bottom layers.
- Verified default-on behavior is unchanged for existing boards.
- `tsc --noEmit` and `biome format` pass clean.
