### PR TITLE
fix: render rounded smt pad textures

### DIFF
--- a/src/utils/pad-texture.ts
+++ b/src/utils/pad-texture.ts
@@ -1,17 +1,119 @@
 // Utility for creating SMT pad textures for PCB layers
 
 import { su } from "@tscircuit/circuit-json-util"
+import type { AnyCircuitElement, PcbBoard, PcbRenderLayer } from "circuit-json"
 import { CircuitToCanvasDrawer } from "circuit-to-canvas"
-import type {
-  AnyCircuitElement,
-  PcbBoard,
-  PcbHole,
-  PcbPlatedHole,
-  PcbRenderLayer,
-  PcbVia,
-} from "circuit-json"
 import * as THREE from "three"
 import { calculateOutlineBounds } from "./outline-bounds"
+import {
+  clampRectBorderRadius,
+  extractRectBorderRadius,
+} from "./rect-border-radius"
+
+type PcbSmtPad = Extract<AnyCircuitElement, { type: "pcb_smtpad" }>
+type BoardOutlineBounds = ReturnType<typeof calculateOutlineBounds>
+
+export interface RoundedSmtPadDrawParams {
+  centerX: number
+  centerY: number
+  width: number
+  height: number
+  radius: number
+  rotationRadians: number
+}
+
+export function getRoundedSmtPadDrawParams({
+  pad,
+  boardOutlineBounds,
+  canvasWidth,
+  canvasHeight,
+}: {
+  pad: PcbSmtPad
+  boardOutlineBounds: BoardOutlineBounds
+  canvasWidth: number
+  canvasHeight: number
+}): RoundedSmtPadDrawParams | null {
+  if (pad.shape !== "rect" && pad.shape !== "rotated_rect") return null
+
+  const width = (pad as any).width
+  const height = (pad as any).height
+  if (
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return null
+  }
+
+  const radius = clampRectBorderRadius(
+    width,
+    height,
+    extractRectBorderRadius(pad),
+  )
+  if (radius <= 0) return null
+
+  const pixelsPerXUnit = canvasWidth / boardOutlineBounds.width
+  const pixelsPerYUnit = canvasHeight / boardOutlineBounds.height
+  const pixelsPerUnit = Math.min(pixelsPerXUnit, pixelsPerYUnit)
+
+  return {
+    centerX:
+      ((pad.x - boardOutlineBounds.minX) / boardOutlineBounds.width) *
+      canvasWidth,
+    centerY:
+      canvasHeight -
+      ((pad.y - boardOutlineBounds.minY) / boardOutlineBounds.height) *
+        canvasHeight,
+    width: width * pixelsPerXUnit,
+    height: height * pixelsPerYUnit,
+    radius: radius * pixelsPerUnit,
+    rotationRadians:
+      pad.shape === "rotated_rect"
+        ? -(((pad as any).ccw_rotation ?? 0) * Math.PI) / 180
+        : 0,
+  }
+}
+
+function drawRoundedRectPath(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  const halfWidth = width / 2
+  const halfHeight = height / 2
+  const left = -halfWidth
+  const right = halfWidth
+  const top = -halfHeight
+  const bottom = halfHeight
+
+  ctx.beginPath()
+  ctx.moveTo(left + radius, top)
+  ctx.lineTo(right - radius, top)
+  ctx.quadraticCurveTo(right, top, right, top + radius)
+  ctx.lineTo(right, bottom - radius)
+  ctx.quadraticCurveTo(right, bottom, right - radius, bottom)
+  ctx.lineTo(left + radius, bottom)
+  ctx.quadraticCurveTo(left, bottom, left, bottom - radius)
+  ctx.lineTo(left, top + radius)
+  ctx.quadraticCurveTo(left, top, left + radius, top)
+  ctx.closePath()
+}
+
+function drawRoundedSmtPad(
+  ctx: CanvasRenderingContext2D,
+  params: RoundedSmtPadDrawParams,
+  copperColor: string,
+) {
+  ctx.save()
+  ctx.translate(params.centerX, params.centerY)
+  ctx.rotate(params.rotationRadians)
+  ctx.fillStyle = copperColor
+  drawRoundedRectPath(ctx, params.width, params.height, params.radius)
+  ctx.fill()
+  ctx.restore()
+}
 
 export function createPadTextureForLayer({
   layer,
@@ -97,12 +199,39 @@ export function createPadTextureForLayer({
     minY: boardOutlineBounds.minY,
     maxY: boardOutlineBounds.maxY,
   })
-  drawer.drawElements([...smtPadsOnLayer, ...drillElements], {
+
+  const roundedSmtPads = smtPadsOnLayer
+    .map((pad) => ({
+      pad,
+      params: getRoundedSmtPadDrawParams({
+        pad,
+        boardOutlineBounds,
+        canvasWidth,
+        canvasHeight,
+      }),
+    }))
+    .filter(
+      (entry): entry is { pad: PcbSmtPad; params: RoundedSmtPadDrawParams } =>
+        entry.params !== null,
+    )
+  const roundedSmtPadIds = new Set(
+    roundedSmtPads.map(({ pad }) => pad.pcb_smtpad_id),
+  )
+  const roundedSmtPadDrawParams = roundedSmtPads.map(({ params }) => params)
+  const rectangularSmtPads = smtPadsOnLayer.filter(
+    (pad) => !roundedSmtPadIds.has(pad.pcb_smtpad_id),
+  )
+
+  drawer.drawElements([...rectangularSmtPads, ...drillElements], {
     layers: [pcbRenderLayer],
     drawSoldermask: false,
     drawSoldermaskTop: false,
     drawSoldermaskBottom: false,
   })
+
+  for (const params of roundedSmtPadDrawParams) {
+    drawRoundedSmtPad(ctx, params, copperColor)
+  }
 
   const texture = new THREE.CanvasTexture(canvas)
   texture.generateMipmaps = true

--- a/tests/pad-texture.test.ts
+++ b/tests/pad-texture.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { getRoundedSmtPadDrawParams } from "../src/utils/pad-texture"
+
+const boardOutlineBounds = {
+  minX: -5,
+  maxX: 5,
+  minY: -2.5,
+  maxY: 2.5,
+  width: 10,
+  height: 5,
+  centerX: 0,
+  centerY: 0,
+}
+
+test("getRoundedSmtPadDrawParams maps rounded rect SMT pads to texture space", () => {
+  const params = getRoundedSmtPadDrawParams({
+    pad: {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "rotated_rect",
+      layer: "top",
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 2,
+      ccw_rotation: 90,
+      rectBorderRadius: 0.75,
+    } as any,
+    boardOutlineBounds,
+    canvasWidth: 1000,
+    canvasHeight: 500,
+  })
+
+  expect(params).toEqual({
+    centerX: 500,
+    centerY: 250,
+    width: 400,
+    height: 200,
+    radius: 75,
+    rotationRadians: -Math.PI / 2,
+  })
+})
+
+test("getRoundedSmtPadDrawParams ignores non-rounded SMT pads", () => {
+  const params = getRoundedSmtPadDrawParams({
+    pad: {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "rect",
+      layer: "top",
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 2,
+    } as any,
+    boardOutlineBounds,
+    canvasWidth: 1000,
+    canvasHeight: 500,
+  })
+
+  expect(params).toBeNull()
+})


### PR DESCRIPTION
Fixes #500

## Summary
- Render `rect` and `rotated_rect` SMT pads with positive `rectBorderRadius`/`corner_radius` as rounded canvas paths in the pad texture.
- Keep non-rounded SMT pads on the existing `circuit-to-canvas` path.
- Add coverage for texture-space mapping, radius scaling, rotation, and non-rounded pad fallback.

## Verification
- `bun run build`
- `bun x biome check src\utils\pad-texture.ts tests\pad-texture.test.ts`
- Direct `bun` helper verification for rounded and plain SMT pads
- `git diff --check`

Note: `bun test tests\pad-texture.test.ts` is blocked on this Windows machine by the repo preload `bun-match-svg` importing `looks-same`/`sharp`; `sharp` fails to install/link locally.