### PR TITLE
Preserve STEP face colors in GLB exports

### DIFF
--- a/src/three-components/GltfModel.tsx
+++ b/src/three-components/GltfModel.tsx
@@ -156,15 +156,20 @@ export function GltfModel({
   useEffect(() => {
     if (!model) return
     model.traverse((child) => {
-      if (
-        child instanceof THREE.Mesh &&
-        child.material instanceof THREE.MeshStandardMaterial
-      ) {
+      if (!(child instanceof THREE.Mesh)) return
+
+      const materials = Array.isArray(child.material)
+        ? child.material
+        : [child.material]
+
+      for (const material of materials) {
+        if (!(material instanceof THREE.MeshStandardMaterial)) continue
+
         if (isHovered) {
-          child.material.emissive.setHex(0x0000ff)
-          child.material.emissiveIntensity = 0.2
+          material.emissive.setHex(0x0000ff)
+          material.emissiveIntensity = 0.2
         } else {
-          child.material.emissiveIntensity = 0
+          material.emissiveIntensity = 0
         }
       }
     })

--- a/src/three-components/StepModel.tsx
+++ b/src/three-components/StepModel.tsx
@@ -1,31 +1,14 @@
 import { useEffect, useState } from "react"
-import {
-  BufferGeometry,
-  Color,
-  Float32BufferAttribute,
-  Group,
-  Mesh,
-  MeshStandardMaterial,
-} from "three"
 import { GLTFExporter } from "three-stdlib"
 import { GltfModel } from "./GltfModel"
 import type { CadModelFitMode, CadModelSize } from "src/utils/cad-model-fit"
+import { occtMeshesToGroup, type OcctMesh } from "./step-mesh-to-group"
 
 type OcctImportParams = {
   linearUnit?: "millimeter" | "centimeter" | "meter" | "inch" | "foot"
   linearDeflectionType?: "bounding_box_ratio" | "absolute_value"
   linearDeflection?: number
   angularDeflection?: number
-}
-
-type OcctMesh = {
-  name: string
-  color?: [number, number, number]
-  attributes: {
-    position: { array: number[] }
-    normal?: { array: number[] }
-  }
-  index: { array: number[] }
 }
 
 type OcctImportResult = {
@@ -80,35 +63,6 @@ async function loadOcctImport(): Promise<OcctImport> {
   return occtImportPromise
 }
 
-function occtMeshesToGroup(meshes: OcctMesh[]): Group {
-  const group = new Group()
-  for (const mesh of meshes) {
-    const positions = mesh.attributes.position?.array ?? []
-    const indices = mesh.index?.array ?? []
-    if (!positions.length || !indices.length) {
-      continue
-    }
-    const geometry = new BufferGeometry()
-    geometry.setAttribute("position", new Float32BufferAttribute(positions, 3))
-    const normals = mesh.attributes.normal?.array ?? []
-    if (normals.length) {
-      geometry.setAttribute("normal", new Float32BufferAttribute(normals, 3))
-    } else {
-      geometry.computeVertexNormals()
-    }
-    geometry.setIndex(indices)
-    const material = new MeshStandardMaterial({
-      color: mesh.color
-        ? new Color(mesh.color[0], mesh.color[1], mesh.color[2])
-        : new Color(0.82, 0.82, 0.82),
-    })
-    const threeMesh = new Mesh(geometry, material)
-    threeMesh.name = mesh.name
-    group.add(threeMesh)
-  }
-  return group
-}
-
 async function convertStepUrlToGlb(stepUrl: string): Promise<ArrayBuffer> {
   const response = await fetch(stepUrl)
   if (!response.ok) {
@@ -141,7 +95,7 @@ async function convertStepUrlToGlb(stepUrl: string): Promise<ArrayBuffer> {
   return glb
 }
 
-const CACHE_PREFIX = "step-glb-cache:"
+const CACHE_PREFIX = "step-glb-cache:v2:"
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer)

--- a/src/three-components/step-mesh-to-group.ts
+++ b/src/three-components/step-mesh-to-group.ts
@@ -1,0 +1,130 @@
+import {
+  BufferGeometry,
+  Color,
+  Float32BufferAttribute,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+} from "three"
+
+export type OcctBrepFace = {
+  first: number
+  last: number
+  color: [number, number, number] | null
+}
+
+export type OcctMesh = {
+  name: string
+  color?: [number, number, number]
+  brep_faces?: OcctBrepFace[]
+  attributes: {
+    position: { array: number[] }
+    normal?: { array: number[] }
+  }
+  index: { array: number[] }
+}
+
+const DEFAULT_COLOR = new Color(0.82, 0.82, 0.82)
+
+const createMaterial = (color?: [number, number, number] | null) =>
+  new MeshStandardMaterial({
+    color: color ? new Color(color[0], color[1], color[2]) : DEFAULT_COLOR,
+  })
+
+function applyFaceColorGroups(
+  geometry: BufferGeometry,
+  mesh: OcctMesh,
+): MeshStandardMaterial[] {
+  const defaultMaterial = createMaterial(mesh.color)
+  const brepFaces = mesh.brep_faces ?? []
+  if (brepFaces.length === 0) {
+    return [defaultMaterial]
+  }
+
+  const sortedBrepFaces =
+    brepFaces.length > 1
+      ? [...brepFaces].sort((a, b) => a.first - b.first)
+      : brepFaces
+
+  const materials = [defaultMaterial]
+  const materialIndexByColor = new Map<string, number>()
+  const triangleCount = mesh.index.array.length / 3
+
+  let triangleIndex = 0
+  let faceIndex = 0
+
+  const getMaterialIndexForFace = (color: [number, number, number] | null) => {
+    if (!color) return 0
+    const key = color.join(",")
+    const existingIndex = materialIndexByColor.get(key)
+    if (existingIndex !== undefined) {
+      return existingIndex
+    }
+    const nextIndex = materials.length
+    materials.push(createMaterial(color))
+    materialIndexByColor.set(key, nextIndex)
+    return nextIndex
+  }
+
+  while (triangleIndex < triangleCount) {
+    const currentFace = sortedBrepFaces[faceIndex]
+    let lastTriangleExclusive = triangleCount
+    let materialIndex = 0
+
+    if (currentFace) {
+      if (triangleIndex < currentFace.first) {
+        lastTriangleExclusive = currentFace.first
+      } else {
+        lastTriangleExclusive = currentFace.last + 1
+        materialIndex = getMaterialIndexForFace(currentFace.color)
+        faceIndex += 1
+      }
+    }
+
+    if (lastTriangleExclusive > triangleIndex) {
+      geometry.addGroup(
+        triangleIndex * 3,
+        (lastTriangleExclusive - triangleIndex) * 3,
+        materialIndex,
+      )
+    }
+
+    triangleIndex = lastTriangleExclusive
+  }
+
+  return materials
+}
+
+export function occtMeshesToGroup(meshes: OcctMesh[]): Group {
+  const group = new Group()
+  for (const mesh of meshes) {
+    const positions = mesh.attributes.position?.array ?? []
+    const indices = mesh.index?.array ?? []
+    if (!positions.length || !indices.length) {
+      continue
+    }
+
+    const geometry = new BufferGeometry()
+    geometry.setAttribute("position", new Float32BufferAttribute(positions, 3))
+
+    const normals = mesh.attributes.normal?.array ?? []
+    if (normals.length) {
+      geometry.setAttribute("normal", new Float32BufferAttribute(normals, 3))
+    } else {
+      geometry.computeVertexNormals()
+    }
+
+    geometry.setIndex(indices)
+    geometry.clearGroups()
+
+    const materials = applyFaceColorGroups(geometry, mesh)
+    const threeMesh = new Mesh(
+      geometry,
+      materials.length > 1 ? materials : materials[0],
+    )
+    threeMesh.name = mesh.name
+    group.add(threeMesh)
+  }
+
+  return group
+}


### PR DESCRIPTION
This updates the STEP-to-GLB pipeline so per-face colors from OCCT meshes are preserved in the exported model.
test https://3d-viewer-ozg9r4jk4-tscircuit.vercel.app/?path=/story/bugs-kicad-tl3342-step-face-colors--step-only-local-fixture
## Changes

- extract STEP mesh -> Three.js group conversion into `step-mesh-to-group.ts`
- support `brep_faces` by creating geometry groups and per-face materials
- keep the mesh-level color as the default material when no face override exists
- update `GltfModel` hover highlighting to handle meshes with multiple materials
- bump the STEP GLB cache key so older cached single-material exports are invalidated
