### PR TITLE
Fix PCB cutouts failing to clip overlapping SMT pad copper

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
     "circuit-json": "^0.0.421",
-    "circuit-to-canvas": "^0.0.110",
+    "circuit-to-canvas": "^0.0.111",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",
     "three-stdlib": "^2.36.0",

--- a/src/utils/pad-texture.ts
+++ b/src/utils/pad-texture.ts
@@ -1,15 +1,8 @@
 // Utility for creating SMT pad textures for PCB layers
 
 import { su } from "@tscircuit/circuit-json-util"
+import type { AnyCircuitElement, PcbBoard, PcbRenderLayer } from "circuit-json"
 import { CircuitToCanvasDrawer } from "circuit-to-canvas"
-import type {
-  AnyCircuitElement,
-  PcbBoard,
-  PcbHole,
-  PcbPlatedHole,
-  PcbRenderLayer,
-  PcbVia,
-} from "circuit-json"
 import * as THREE from "three"
 import { calculateOutlineBounds } from "./outline-bounds"
 
@@ -36,6 +29,7 @@ export function createPadTextureForLayer({
   const viasOnLayer = su(circuitJson)
     .pcb_via.list()
     .filter((e) => !Array.isArray(e.layers) || e.layers.includes(layer))
+  const cutouts = su(circuitJson).pcb_cutout.list()
   const drillElements = [...holes, ...platedHolesOnLayer, ...viasOnLayer]
 
   const pcbRenderLayer: PcbRenderLayer =
@@ -97,7 +91,7 @@ export function createPadTextureForLayer({
     minY: boardOutlineBounds.minY,
     maxY: boardOutlineBounds.maxY,
   })
-  drawer.drawElements([...smtPadsOnLayer, ...drillElements], {
+  drawer.drawElements([...smtPadsOnLayer, ...drillElements, ...cutouts], {
     layers: [pcbRenderLayer],
     drawSoldermask: false,
     drawSoldermaskTop: false,

--- a/stories/CutoutsCutThroughCopper.stories.tsx
+++ b/stories/CutoutsCutThroughCopper.stories.tsx
@@ -1,0 +1,151 @@
+import { CadViewer } from "src/CadViewer"
+import { Circuit } from "@tscircuit/core"
+
+// The cutout positions come from a reference image of the original board.
+// The reference frame spans x 102.8..137.6 (34.8mm board width) with y
+// increasing downward, so these helpers convert to centered board coords.
+const REF_CENTER_X = 120.2
+const REF_CENTER_Y = 78.95
+
+const modulePadPosition = (x: number, y: number) => ({
+  pcbX: Number((x - 120.2).toFixed(3)),
+  pcbY: Number((79 - y).toFixed(3)),
+})
+
+const edgeHole = (x: number, y: number) => ({
+  pcbX: x - REF_CENTER_X,
+  pcbY: REF_CENTER_Y - y,
+  radius: 0.6,
+})
+
+const ModulePad = ({
+  name,
+  label,
+  pcbX,
+  pcbY,
+  side,
+}: {
+  name: string
+  label: string
+  pcbX: number
+  pcbY: number
+  side: "left" | "right"
+}) => {
+  const padX = side === "left" ? -0.5 : 0.5
+
+  return (
+    <chip
+      name={name}
+      pcbX={pcbX}
+      pcbY={pcbY}
+      footprint={
+        <footprint>
+          <smtpad
+            layer="top"
+            shape="rect"
+            pcbX={`${padX}mm`}
+            pcbY="0mm"
+            width="2mm"
+            height="6mm"
+            portHints={["pin1"]}
+          />
+          <smtpad
+            layer="bottom"
+            shape="rect"
+            pcbX={`${padX}mm`}
+            pcbY="0mm"
+            width="2mm"
+            height="6mm"
+            portHints={["pin1"]}
+          />
+        </footprint>
+      }
+      pinLabels={{ pin1: label }}
+    />
+  )
+}
+
+const createCircuit = () => {
+  const circuit = new Circuit()
+
+  circuit.add(
+    <board
+      width="34.8mm"
+      height="30mm"
+      autorouterVersion="v4"
+      layers={2}
+      minViaPadDiameter={0.45}
+      minViaHoleDiameter={0.3}
+    >
+      <ModulePad
+        name="J8"
+        label="VIN"
+        {...modulePadPosition(104.5, 67.7)}
+        side="left"
+      />
+      <ModulePad
+        name="J1"
+        label="nCE"
+        {...modulePadPosition(104.6, 75.2)}
+        side="left"
+      />
+      <ModulePad
+        name="J6"
+        label="ON_OFF"
+        {...modulePadPosition(104.6, 82.6)}
+        side="left"
+      />
+      <ModulePad
+        name="J7"
+        label="ALM"
+        {...modulePadPosition(104.5, 90.2)}
+        side="left"
+      />
+      <ModulePad
+        name="J2"
+        label="VOUT"
+        {...modulePadPosition(135.7, 67.7)}
+        side="right"
+      />
+      <ModulePad
+        name="J3"
+        label="GND"
+        {...modulePadPosition(135.9, 75.1)}
+        side="right"
+      />
+      <ModulePad
+        name="J5"
+        label="SDA"
+        {...modulePadPosition(135.9, 82.9)}
+        side="right"
+      />
+      <ModulePad
+        name="J4"
+        label="SCL"
+        {...modulePadPosition(135.8, 90.2)}
+        side="right"
+      />
+
+      <cutout shape="circle" {...edgeHole(102.8, 67.7)} />
+      <cutout shape="circle" {...edgeHole(102.9, 75.2)} />
+      <cutout shape="circle" {...edgeHole(102.9, 82.6)} />
+      <cutout shape="circle" {...edgeHole(102.8, 90.2)} />
+      <cutout shape="circle" {...edgeHole(137.4, 67.7)} />
+      <cutout shape="circle" {...edgeHole(137.6, 75.2)} />
+      <cutout shape="circle" {...edgeHole(137.6, 82.8)} />
+      <cutout shape="circle" {...edgeHole(137.5, 90.2)} />
+    </board>,
+  )
+
+  return circuit.getCircuitJson()
+}
+
+export const edgeCutoutsCutThroughSmtPadsStory = () => {
+  const circuitJson = createCircuit()
+  return <CadViewer circuitJson={circuitJson as any} />
+}
+
+export default {
+  title: "Edge Cutouts Cut Through SMT Pads",
+  component: edgeCutoutsCutThroughSmtPadsStory,
+}

--- a/stories/CutoutsCutThroughCopper.stories.tsx
+++ b/stories/CutoutsCutThroughCopper.stories.tsx
@@ -8,8 +8,8 @@ const REF_CENTER_X = 120.2
 const REF_CENTER_Y = 78.95
 
 const modulePadPosition = (x: number, y: number) => ({
-  pcbX: Number((x - 120.2).toFixed(3)),
-  pcbY: Number((79 - y).toFixed(3)),
+  pcbX: Number((x - REF_CENTER_X).toFixed(3)),
+  pcbY: Number((REF_CENTER_Y - y).toFixed(3)),
 })
 
 const edgeHole = (x: number, y: number) => ({


### PR DESCRIPTION
## Summary

- update `circuit-to-canvas` to `0.0.111`
- pass `pcb_cutout` elements into the isolated SMT pad texture render
- add a reproduction story with edge cutouts overlapping top and bottom SMT pads

## Problem

The 3D viewer renders SMT pads in a dedicated texture pass. That pass only forwarded pads and drill elements to `CircuitToCanvasDrawer`, so the drawer never received the board cutouts required to clip overlapping pad copper. Updating the dependency alone therefore did not activate the upstream fix.

## Fix

Include board cutouts in the SMT pad texture element set. This allows the drawer to subtract intersecting circular, rectangular, and polygonal cutouts from pad copper on both PCB layers.

<img width="730" height="614" alt="image" src="https://github.com/user-attachments/assets/2870416a-268c-4747-82bb-c760a6b6da06" />


## Cross-repository context

This completes the 3D viewer integration for [tscircuit/circuit-to-canvas#253](https://github.com/tscircuit/circuit-to-canvas/pull/253), which added the underlying SMT-pad cutout clipping support released in `circuit-to-canvas@0.0.111`.

## Before

SMT pad copper remained visible across overlapping PCB cutouts.

## After

PCB cutouts correctly remove overlapping SMT pad copper in the 3D viewer.

## Verification

- `bunx biome check src/utils/pad-texture.ts`
- `bun run build`
- `bun run build-storybook`
- reproduction and fix are included in the same PR
