### PR TITLE
Fix Manifold PCB textures disappearing in StrictMode iframes

### DIFF
--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -26,7 +26,7 @@ declare global {
   }
 }
 
-const BoardMeshes = ({
+export const BoardMeshes = ({
   geometryMeshes,
   textureMeshes,
 }: {
@@ -65,7 +65,8 @@ const BoardMeshes = ({
         const texture = typedMaterial[prop]
         if (texture && texture instanceof THREE.Texture) {
           texture.dispose()
-          typedMaterial[prop] = null
+          // StrictMode can immediately replay this effect with the same
+          // memoized mesh. Keep the map attached so Three.js can re-upload it.
         }
       }
 

--- a/tests/manifold-board-textures-strict-mode.test.tsx
+++ b/tests/manifold-board-textures-strict-mode.test.tsx
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { JSDOM } from "jsdom"
+import { StrictMode } from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import * as THREE from "three"
+import { BoardMeshes } from "../src/CadViewerManifold"
+import { LayerVisibilityProvider } from "../src/contexts/LayerVisibilityContext"
+import {
+  ThreeContext,
+  type ThreeContextState,
+} from "../src/react-three/ThreeContext"
+
+test("Manifold board textures survive a StrictMode effect replay", async () => {
+  const dom = new JSDOM('<div id="root"></div>')
+  const previousWindow = globalThis.window
+  const previousDocument = globalThis.document
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })
+
+  const container = document.getElementById("root")!
+  const rootObject = new THREE.Object3D()
+  const texture = new THREE.CanvasTexture(document.createElement("canvas"))
+  const textureMesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(10, 10),
+    new THREE.MeshBasicMaterial({ map: texture }),
+  )
+  const context: ThreeContextState = {
+    scene: new THREE.Scene(),
+    camera: new THREE.PerspectiveCamera(),
+    renderer: {} as THREE.WebGLRenderer,
+    rootObject,
+    addFrameListener: () => {},
+    removeFrameListener: () => {},
+  }
+  const reactRoot = createRoot(container)
+
+  try {
+    await act(async () => {
+      reactRoot.render(
+        <StrictMode>
+          <ThreeContext.Provider value={context}>
+            <LayerVisibilityProvider>
+              <BoardMeshes geometryMeshes={[]} textureMeshes={[textureMesh]} />
+            </LayerVisibilityProvider>
+          </ThreeContext.Provider>
+        </StrictMode>,
+      )
+    })
+
+    expect(rootObject.children).toEqual([textureMesh])
+    expect((textureMesh.material as THREE.MeshBasicMaterial).map).toBe(texture)
+  } finally {
+    await act(async () => reactRoot.unmount())
+    Object.assign(globalThis, {
+      window: previousWindow,
+      document: previousDocument,
+      IS_REACT_ACT_ENVIRONMENT: false,
+    })
+    dom.window.close()
+  }
+})


### PR DESCRIPTION
## Summary

Fixes a subtle Manifold rendering bug where PCB soldermask, copper, traces, pads, and silkscreen disappeared inside React StrictMode-based iframes, leaving the board flat gray.

## Root cause

The Manifold mesh cleanup disposed each texture and also cleared its material reference. React StrictMode immediately replays effects using the same memoized mesh, so the texture could no longer be re-uploaded.

JSCAD did not exhibit the issue because it recreates its texture meshes during effect setup.

## Fix

- Preserve material texture references during cleanup
- Continue disposing GPU texture resources
- Allow Three.js to re-upload textures during StrictMode effect replay
- Add a regression test that reproduces the iframe lifecycle and verifies the fix

## User impact

Manifold now renders complete PCB surface details in StrictMode-based consumers such as the Runframe iframe instead of displaying an untextured gray board.

## Verification

- `bun test tests/manifold-board-textures-strict-mode.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
- Verified both Manifold board texture planes retain live material maps after StrictMode effect replay

## Verified in runframe repo using bun link 

<img width="500" height="700" alt="manifold-texture-strict-mode-proof" src="https://github.com/user-attachments/assets/193b84ea-8066-453e-a9dc-cf192aa7ed38" />

