### PR TITLE
fix: honor board solder_mask_color in the 3D render (#957)

### DIFF
--- a/src/convert-circuit-json-to-3d-svg.ts
+++ b/src/convert-circuit-json-to-3d-svg.ts
@@ -8,6 +8,7 @@ import { createBoardMaterial } from "./utils/create-board-material"
 import { createGeometryFromPolygons } from "./utils/create-geometry-from-polygons"
 import { renderComponent } from "./utils/render-component"
 import { colors } from "./geoms/constants"
+import { resolveSolderMaskColor } from "./utils/resolve-solder-mask-color"
 
 interface CircuitToSvgOptions {
   width?: number
@@ -98,8 +99,10 @@ export async function convertCircuitJsonTo3dSvg(
   // Add board geometry after components
   const boardGeom = createSimplifiedBoardGeom(circuitJson)
   if (boardGeom) {
-    // Use green solder mask color for the board
-    const solderMaskColor = colors.fr4SolderMaskGreen
+    // Honor the board's solder_mask_color, falling back to the default green
+    const solderMaskColor =
+      resolveSolderMaskColor(boardData?.solder_mask_color) ??
+      colors.fr4SolderMaskGreen
     const baseColor = new THREE.Color(
       solderMaskColor[0],
       solderMaskColor[1],

--- a/src/geoms/constants.ts
+++ b/src/geoms/constants.ts
@@ -30,3 +30,44 @@ export const soldermaskColors: Record<PcbBoard["material"], RGB> = {
   fr1: colors.fr1SolderMaskGreen,
   fr4: colors.fr4SolderMaskGreen,
 }
+
+/**
+ * Solder mask coatings for the `solder_mask_color` presets accepted by
+ * `<board solderMaskColor="..." />`.
+ *
+ * Each entry is a pair of `[mask over bare substrate, mask over copper]`.
+ * Solder mask is a translucent coating, so copper underneath lifts the
+ * coating's brightness — that is what makes traces readable through the mask.
+ */
+export const solderMaskColorPresets = {
+  green: {
+    soldermask: colors.fr4SolderMaskGreen,
+    soldermaskOverCopper: colors.fr4TracesWithMaskGreen,
+  },
+  red: {
+    soldermask: [0.18, 0.02, 0.02],
+    soldermaskOverCopper: [0.32, 0.05, 0.04],
+  },
+  blue: {
+    soldermask: [0.02, 0.04, 0.18],
+    soldermaskOverCopper: [0.04, 0.09, 0.32],
+  },
+  purple: {
+    soldermask: [0.09, 0.02, 0.15],
+    soldermaskOverCopper: [0.17, 0.06, 0.27],
+  },
+  black: {
+    soldermask: [0.02, 0.02, 0.02],
+    soldermaskOverCopper: [0.07, 0.07, 0.07],
+  },
+  white: {
+    soldermask: [0.88, 0.88, 0.86],
+    soldermaskOverCopper: [0.72, 0.7, 0.64],
+  },
+  yellow: {
+    soldermask: [0.55, 0.47, 0.05],
+    soldermaskOverCopper: [0.68, 0.58, 0.08],
+  },
+} satisfies Record<string, { soldermask: RGB; soldermaskOverCopper: RGB }>
+
+export type SolderMaskColorPreset = keyof typeof solderMaskColorPresets

--- a/src/textures/create-soldermask-texture-for-layer.ts
+++ b/src/textures/create-soldermask-texture-for-layer.ts
@@ -42,6 +42,7 @@ export function createSoldermaskTextureForLayer({
     bounds,
     elements,
     boardMaterial: boardData.material,
+    solderMaskColor: boardData.solder_mask_color,
   })
 
   const texture = new THREE.CanvasTexture(canvas)

--- a/src/textures/soldermask/soldermask-drawing.ts
+++ b/src/textures/soldermask/soldermask-drawing.ts
@@ -9,6 +9,7 @@ import {
   colors as defaultColors,
   soldermaskColors,
 } from "../../geoms/constants"
+import { resolveSolderMaskPreset } from "../../utils/resolve-solder-mask-color"
 import type { OutlineBounds } from "../../utils/outline-bounds"
 
 const toRgb = (colorArr: number[]) => {
@@ -27,7 +28,18 @@ type SoldermaskPalette = {
 
 const getSoldermaskPalette = (
   material: PcbBoard["material"],
+  solderMaskColor?: PcbBoard["solder_mask_color"],
 ): SoldermaskPalette => {
+  const preset = resolveSolderMaskPreset(solderMaskColor)
+  if (preset) {
+    return {
+      soldermask: toRgb(preset.soldermask),
+      soldermaskOverCopper: toRgb(preset.soldermaskOverCopper),
+      copper: toRgb(defaultColors.copper),
+      transparent: "rgba(0,0,0,0)",
+    }
+  }
+
   const soldermask = toRgb(
     soldermaskColors[material] ?? defaultColors.fr4SolderMaskGreen,
   )
@@ -62,14 +74,16 @@ export const drawSoldermaskLayer = ({
   bounds,
   elements,
   boardMaterial,
+  solderMaskColor,
 }: {
   ctx: CanvasRenderingContext2D
   layer: "top" | "bottom"
   bounds: OutlineBounds
   elements: AnyCircuitElement[]
   boardMaterial: PcbBoard["material"]
+  solderMaskColor?: PcbBoard["solder_mask_color"]
 }) => {
-  const palette = getSoldermaskPalette(boardMaterial)
+  const palette = getSoldermaskPalette(boardMaterial, solderMaskColor)
   const copperRenderLayer: PcbRenderLayer =
     layer === "top" ? "top_copper" : "bottom_copper"
 

--- a/src/utils/resolve-solder-mask-color.ts
+++ b/src/utils/resolve-solder-mask-color.ts
@@ -1,0 +1,25 @@
+import type { PcbBoard } from "circuit-json"
+import { solderMaskColorPresets } from "../geoms/constants"
+
+/**
+ * Resolve `pcb_board.solder_mask_color` to a solder mask coating preset.
+ *
+ * Returns `undefined` when no usable color is set (missing, empty, or
+ * `not_specified`) so callers keep their existing material-derived default
+ * instead of forcing a color the user never requested.
+ */
+export const resolveSolderMaskPreset = (
+  solderMaskColor?: PcbBoard["solder_mask_color"],
+) => {
+  if (!solderMaskColor) return undefined
+  const normalized = solderMaskColor.trim().toLowerCase()
+  if (normalized === "" || normalized === "not_specified") return undefined
+  return solderMaskColorPresets[
+    normalized as keyof typeof solderMaskColorPresets
+  ]
+}
+
+/** Convenience accessor for the coating color over bare substrate. */
+export const resolveSolderMaskColor = (
+  solderMaskColor?: PcbBoard["solder_mask_color"],
+) => resolveSolderMaskPreset(solderMaskColor)?.soldermask

--- a/tests/solder-mask-color.test.ts
+++ b/tests/solder-mask-color.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { colors, solderMaskColorPresets } from "../src/geoms/constants"
+import {
+  resolveSolderMaskColor,
+  resolveSolderMaskPreset,
+} from "../src/utils/resolve-solder-mask-color"
+
+test("resolves each documented solderMaskColor preset", () => {
+  for (const preset of [
+    "green",
+    "red",
+    "blue",
+    "purple",
+    "black",
+    "white",
+    "yellow",
+  ] as const) {
+    expect(resolveSolderMaskPreset(preset)).toBe(solderMaskColorPresets[preset])
+  }
+})
+
+test("a black mask does not render green", () => {
+  const black = resolveSolderMaskColor("black")
+  expect(black).toBeDefined()
+  expect(black).not.toEqual(colors.fr4SolderMaskGreen)
+
+  // A black mask should be dark on every channel, and specifically not
+  // dominated by green the way the hard-coded FR4 mask is.
+  const [r = 0, g = 0, b = 0] = black!
+  expect(Math.max(r, g, b)).toBeLessThan(0.1)
+  expect(g).toBeLessThanOrEqual(Math.max(r, b) + 0.01)
+})
+
+test("falls back to the material default when no color is specified", () => {
+  expect(resolveSolderMaskPreset(undefined)).toBeUndefined()
+  expect(resolveSolderMaskPreset("")).toBeUndefined()
+  expect(resolveSolderMaskPreset("not_specified")).toBeUndefined()
+})
+
+test("ignores casing and surrounding whitespace", () => {
+  expect(resolveSolderMaskPreset("  BLACK ")).toBe(solderMaskColorPresets.black)
+})
+
+test("unknown colors fall back instead of throwing", () => {
+  expect(resolveSolderMaskPreset("chartreuse")).toBeUndefined()
+})
+
+test("solder mask over copper stays distinguishable from bare mask", () => {
+  for (const [name, preset] of Object.entries(solderMaskColorPresets)) {
+    expect(preset.soldermask, name).not.toEqual(preset.soldermaskOverCopper)
+  }
+})


### PR DESCRIPTION
Fixes #957.

### Problem

The 3D viewer hard-coded the FR4 green solder mask, so a board built with `solderMaskColor="black"` still rendered green even though the Circuit JSON carried `solder_mask_color` correctly. This made the 3D preview misleading for any board that isn't green.

Two independent code paths had the same hard-coding:

- `soldermask-drawing.ts` — the textured mask layer derived its palette from `material` only.
- `convert-circuit-json-to-3d-svg.ts` — literally `const solderMaskColor = colors.fr4SolderMaskGreen`.

### Change

- Added `solderMaskColorPresets` covering the documented presets (`green`, `red`, `blue`, `purple`, `black`, `white`, `yellow`). Each preset is a pair of `[mask over bare substrate, mask over copper]`, since solder mask is translucent and copper underneath lifts the coating — that's what keeps traces readable through the mask.
- Added a shared `resolveSolderMaskPreset` helper so both render paths agree instead of duplicating the lookup.
- Threaded `boardData.solder_mask_color` through `createSoldermaskTextureForLayer` → `drawSoldermaskLayer`, and applied it in the SVG path too.

### Backwards compatibility

Boards with no color, an empty string, or `not_specified` resolve to `undefined` and keep the existing material-derived default (FR4 green / FR1), so nothing changes for current boards. Unrecognized values fall back rather than throwing.

### Verification

- `bunx tsc --noEmit` — clean
- `bun run format:check` — clean
- `bun test tests/solder-mask-color.test.ts` — 6 pass / 0 fail

Note: `bun test` has 3 pre-existing failures on `main` (2 faux-board z-offset tests + the Atari outline SVG test). I confirmed they fail identically on the unmodified checkout, so they're untouched by this change.