### PR TITLE
fix: stop shrinking CAD models rotated off-axis

### DIFF
--- a/src/utils/cad-model-fit.ts
+++ b/src/utils/cad-model-fit.ts
@@ -22,9 +22,16 @@ function getObjectBoundsRelativeToParent(
       }
 
       if (node.geometry.boundingBox) {
+        // Compose into a single matrix before applying it. `Box3.applyMatrix4`
+        // re-derives an axis-aligned box around the transformed corners, so it
+        // is not invertible: transforming to world and back again would widen
+        // the box twice for any rotation that is not a multiple of 90 degrees,
+        // and the caller would then shrink the model to fit that phantom size.
+        const localMatrix = parentInverseMatrix
+          .clone()
+          .multiply(node.matrixWorld)
         const transformedBounds = node.geometry.boundingBox.clone()
-        transformedBounds.applyMatrix4(node.matrixWorld)
-        transformedBounds.applyMatrix4(parentInverseMatrix)
+        transformedBounds.applyMatrix4(localMatrix)
 
         if (!hasBounds) {
           bounds.copy(transformedBounds)

--- a/stories/Bugs/RotatedModelFitScale.stories.tsx
+++ b/stories/Bugs/RotatedModelFitScale.stories.tsx
@@ -1,0 +1,145 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { CadViewer } from "src/CadViewer"
+
+/**
+ * A model whose declared `size` already matches its mesh must render 1:1 at
+ * every angle. It used to shrink at any rotation that was not a multiple of
+ * 90 degrees.
+ *
+ * `getObjectBoundsRelativeToParent` measured each mesh by transforming its
+ * bounding box into world space and then back into the parent's frame with two
+ * separate `Box3.applyMatrix4` calls. That call re-derives an axis-aligned box
+ * around the transformed corners, so it does not invert: the round trip widened
+ * the box twice instead of cancelling. This 9.5 x 6.05mm switch measured
+ * 14.74 x 14.28 at 30 degrees, and the fit then shrank it to 0.42 to squeeze
+ * that phantom size into its declared `size`.
+ *
+ * Right angles were always fine -- an axis-aligned box is rotation-invariant
+ * there -- so the tell is comparing the rotated parts against the 0 degree one.
+ *
+ * Each switch must declare `size` to reproduce this: both renderers skip the
+ * fit entirely when it is absent, which is why the same part in core's own
+ * fixtures never showed the defect.
+ */
+
+// KH-6X6X15H-SMT-FS-D, package SW-SMD_4P-L6.0-W6.0-P4.50-LS9.5-H15.0: a 6x6mm
+// body on gull-wing leads spanning 9.5mm, with a 15mm plunger.
+const MODEL_URL =
+  "https://modelcdn.tscircuit.com/easyeda_models/assets/C18186519.obj?uuid=152d242aeb424b63a926a84b518edee1"
+const MESH_SIZE = { x: 9.5, y: 6.0501, z: 15 }
+const PAD_OFFSETS = [
+  { x: -4.2, y: 2.2498 },
+  { x: 4.2, y: 2.2498 },
+  { x: -4.2, y: -2.2498 },
+  { x: 4.2, y: -2.2498 },
+]
+const BODY_HALF = 3.048
+
+const rotate = (x: number, y: number, degrees: number) => {
+  const radians = (degrees * Math.PI) / 180
+  const cos = Math.cos(radians)
+  const sin = Math.sin(radians)
+  return { x: x * cos - y * sin, y: x * sin + y * cos }
+}
+
+/**
+ * One switch, rotated. The pads and the silkscreen outline turn with it, so a
+ * shrunken model visibly pulls away from both.
+ */
+const switchAt = (
+  index: number,
+  center: { x: number; y: number },
+  degrees: number,
+): AnyCircuitElement[] => {
+  const id = `sw${index}`
+  return [
+    {
+      type: "source_component",
+      source_component_id: `source_${id}`,
+      name: `SW${index}`,
+      ftype: "simple_chip",
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: `pcb_${id}`,
+      source_component_id: `source_${id}`,
+      center,
+      width: 10.25,
+      height: 6.05,
+      rotation: degrees,
+      layer: "top",
+    } as any,
+    ...PAD_OFFSETS.map((offset, padIndex) => {
+      const spun = rotate(offset.x, offset.y, degrees)
+      return {
+        type: "pcb_smtpad",
+        pcb_smtpad_id: `pad_${id}_${padIndex}`,
+        pcb_component_id: `pcb_${id}`,
+        shape: "rotated_rect",
+        x: center.x + spun.x,
+        y: center.y + spun.y,
+        width: 1.85,
+        height: 1.1,
+        ccw_rotation: degrees,
+        layer: "top",
+      } as any
+    }),
+    {
+      type: "pcb_silkscreen_path",
+      pcb_silkscreen_path_id: `silk_${id}`,
+      pcb_component_id: `pcb_${id}`,
+      layer: "top",
+      stroke_width: 0.1,
+      route: [
+        [-BODY_HALF, -BODY_HALF],
+        [BODY_HALF, -BODY_HALF],
+        [BODY_HALF, BODY_HALF],
+        [-BODY_HALF, BODY_HALF],
+        [-BODY_HALF, -BODY_HALF],
+      ].map(([x, y]) => {
+        const spun = rotate(x!, y!, degrees)
+        return { x: center.x + spun.x, y: center.y + spun.y }
+      }),
+    } as any,
+    {
+      type: "cad_component",
+      cad_component_id: `cad_${id}`,
+      pcb_component_id: `pcb_${id}`,
+      source_component_id: `source_${id}`,
+      position: { x: center.x, y: center.y, z: 0.6 },
+      rotation: { x: 0, y: 0, z: degrees },
+      layer: "top",
+      model_obj_url: MODEL_URL,
+      model_origin_position: { x: 0, y: 0, z: 0 },
+      // Without this the fit is skipped and the bug cannot appear.
+      size: MESH_SIZE,
+      model_object_fit: "contain_within_bounds",
+      anchor_alignment: "center_of_component_on_board_surface",
+    } as any,
+  ]
+}
+
+const ROTATIONS = [0, 30, 45, 90]
+
+const circuitJson: AnyCircuitElement[] = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "pcb_board_0",
+    center: { x: 0, y: 0 },
+    width: 70,
+    height: 20,
+    thickness: 1.2,
+    num_layers: 2,
+    material: "fr4",
+  } as any,
+  ...ROTATIONS.flatMap((degrees, index) =>
+    switchAt(index, { x: -24 + index * 16, y: 0 }, degrees),
+  ),
+]
+
+export const Default = () => <CadViewer circuitJson={circuitJson} />
+
+export default {
+  title: "Bugs/Rotated Model Fit Scale",
+  component: Default,
+}

--- a/tests/cad-model-fit.test.ts
+++ b/tests/cad-model-fit.test.ts
@@ -55,3 +55,33 @@ test("fit includes loader transform group rotation in measured bounds", () => {
   expect(scale[1]).toBeCloseTo(1.25)
   expect(scale[2]).toBeCloseTo(2.5)
 })
+
+test("a rotated ancestor does not shrink the model", () => {
+  // Mirrors the viewer's graph: the board group carries the component's
+  // rotation, and the fit measures the model subtree beneath it. A model whose
+  // declared size already matches its mesh must render 1:1 at every angle --
+  // the fit is meant to cancel the ancestor transform, not accumulate it.
+  const natural: [number, number, number] = [9.5, 6.05, 15]
+
+  for (const degrees of [0, 15, 30, 45, 90, 180]) {
+    const boardGroup = new THREE.Group()
+    const fitGroup = new THREE.Group()
+    const modelGroup = new THREE.Group()
+    boardGroup.add(fitGroup)
+    fitGroup.add(modelGroup)
+    modelGroup.add(new THREE.Mesh(new THREE.BoxGeometry(...natural)))
+
+    boardGroup.rotation.z = (degrees * Math.PI) / 180
+    fitGroup.updateWorldMatrix(true, true)
+
+    const scale = getCadModelFitScale(
+      modelGroup,
+      natural,
+      "contain_within_bounds",
+    )
+
+    expect(scale[0]).toBeCloseTo(1)
+    expect(scale[1]).toBeCloseTo(1)
+    expect(scale[2]).toBeCloseTo(1)
+  }
+})


### PR DESCRIPTION
## Problem

A CAD model that declares a `size` matching its own mesh is shrunk whenever its component sits at a rotation that is not a multiple of 90°.

This 6×6mm tactile switch (9.5mm lead span) is the same part four times, at 0°, 30°, 45° and 90°. Only the right-angle ones meet their pads:

| rotation | rendered scale |
| --- | --- |
| 0° | 1.00 |
| 15° | 0.56 |
| 30° | 0.42 |
| 45° | 0.39 |
| 90°, 180° | 1.00 |

## Cause

`getObjectBoundsRelativeToParent` measured each mesh by transforming its bounding box into world space and then back into the parent's frame, as two separate calls:

```js
transformedBounds.applyMatrix4(node.matrixWorld)
transformedBounds.applyMatrix4(parentInverseMatrix)
```

`Box3.applyMatrix4` re-derives an axis-aligned box around the eight transformed corners, so it is **not invertible**. Applying a rotation and then its inverse doesn't cancel — each call grows the box:

```
9.50 × 6.05  ──rotate +30°──►  11.25 × 9.99  ──rotate −30°──►  14.74 × 14.28
```

`getCadModelFitScale` then divides the declared `size` by that inflated measurement and shrinks the model to 0.42 to make it "fit".

Right angles are unaffected because an axis-aligned box is rotation-invariant there.

## Fix

Compose the two matrices and apply them once, so the ancestor transform genuinely cancels:

```js
const localMatrix = parentInverseMatrix.clone().multiply(node.matrixWorld)
transformedBounds.applyMatrix4(localMatrix)
```

Rotations at or below the measured object are still included — the existing `fit includes loader transform group rotation in measured bounds` test covers that and still passes.

## Why this went unnoticed

Two things hid it:

- **`size` is optional, and the fit is skipped without it** (`if (!targetSize) return [1,1,1]`). Parts that don't declare one were never affected.
- **The headless pipeline is correct.** `circuit-json-to-gltf` applies component rotation as a scene-graph property *after* `fitMeshToCadBounds`, so its fit always measures an unrotated mesh. I confirmed it returns `9.500 × 15.000 × 6.050` at 0°, 30° and 45°. Snapshot tests, `tsci build` and poppygl renders are all correct — so no existing test could have caught this. It is visible only in the browser viewer.

## Tests

- `tests/cad-model-fit.test.ts` — asserts scale 1.0 at 0/15/30/45/90/180°. Verified it fails without the fix.
- `stories/Bugs/RotatedModelFitScale.stories.tsx` — visual regression. Pads use `rotated_rect` with `ccw_rotation` and the silkscreen outline is rotated point-by-point, so both turn exactly with the part and a shrunken model visibly pulls away from them. Each instance declares `size` deliberately, since the fit is skipped without it.

Full suite matches `main` exactly: the 4 pre-existing failures (faux-board z defaults, Atari SVG outline) are unchanged, and the fit tests go 4 → 5 passing.

No new Circuit JSON properties are used; everything is in the pinned `circuit-json@0.0.446`.
