### PR TITLE
fix: add mirrored underside light rig so bottom board views are no longer near-black

### DIFF
--- a/src/react-three/Lights.tsx
+++ b/src/react-three/Lights.tsx
@@ -3,6 +3,10 @@ import { useEffect, useMemo } from "react"
 import * as THREE from "three"
 import { useThree } from "./ThreeContext"
 
+// Underside lights mirror the top rig across the board plane so the bottom view is
+// legible. Kept below 1 so the top stays the hero side.
+const UNDERSIDE_LIGHT_FACTOR = 0.75
+
 type LightsProps = {
   boardDimensions?: { width?: number; height?: number }
   boardCenter?: { x: number; y: number }
@@ -102,6 +106,31 @@ export const Lights: React.FC<LightsProps> = ({
       lightDistance * 0.85,
       lightDistance * 0.95,
     ])
+
+    // A directional light below the board contributes nothing to the upward facing
+    // normals, so these only affect the bottom view and grazing side faces.
+    addDirectionalLight(
+      "cad-viewer-underside-key-light",
+      0xfff8ee,
+      1.35 * UNDERSIDE_LIGHT_FACTOR,
+      [
+        keyLightDistance * 0.68,
+        -keyLightDistance * 0.8,
+        -keyLightDistance * 1.08,
+      ],
+    )
+    addDirectionalLight(
+      "cad-viewer-underside-fill-light",
+      0xdce8f2,
+      0.25 * UNDERSIDE_LIGHT_FACTOR,
+      [-lightDistance * 0.85, lightDistance * 0.55, -lightDistance * 0.75],
+    )
+    addDirectionalLight(
+      "cad-viewer-underside-rim-light",
+      0xb9ead3,
+      0.5 * UNDERSIDE_LIGHT_FACTOR,
+      [-lightDistance * 0.35, lightDistance * 0.85, -lightDistance * 0.95],
+    )
 
     return rig
   }, [boardCenter, boardDimensions, shadowsEnabled])


### PR DESCRIPTION
## Problem

Viewing a board from below rendered the solder mask as near-black, with bottom-layer traces, silkscreen, and pads effectively invisible.

The light rig in `src/react-three/Lights.tsx` is top-side only — all three directional lights (key/fill/rim) sit at positive Z. This was harmless while the board surface planes used an unlit `MeshBasicMaterial`, but once they became `MeshPhysicalMaterial` the faces are genuinely lit, and a `-Z` normal receives zero directional contribution.

Measured, using the normalized Z component of each light:

| Light | intensity | `dir.z` | contribution to a `+Z` normal |
|---|---|---|---|
| key `[0.68, -0.8, 1.08]` | 1.35 | 0.717 | 0.968 |
| fill `[-0.85, 0.55, 0.75]` | 0.25 | 0.595 | 0.149 |
| rim `[-0.35, 0.85, 0.95]` | 0.50 | 0.719 | 0.359 |
| **total** | | | **≈ 1.48** |

A `-Z` normal got **0** from all three, leaving the underside lit only by ambient (0.22) plus hemisphere (~0.1) — roughly a 5.6x gap against the top face.

## Fix

### Before
<img width="1214" height="900" alt="image" src="https://github.com/user-attachments/assets/e6e0c505-848c-479a-8a10-74568c58fa47" />

### After
<img width="1214" height="881" alt="image" src="https://github.com/user-attachments/assets/21afebb7-9a39-4c0c-aa14-7902c1405e6d" />
 
Add three directional lights mirroring the existing key/fill/rim across the board plane: same azimuth and colors, negated Z, scaled by a single `UNDERSIDE_LIGHT_FACTOR = 0.75`.

Because a light below the board contributes nothing to `+Z` normals, this is a no-op for the top face by construction. The underside lands at `1.476 x 0.75 = 1.107` of directional light versus `1.476` on top (0.79x), so the bottom is legible while the top stays the hero side.

Reuses the existing `addDirectionalLight` helper (board-center offset, target aiming, rig parenting). `castShadow` is left at its default `false` — the top key light remains the only shadow caster, so there is no second shadow map and no competing shadow direction.

## Verification

Measured in-browser by toggling only the new lights at a fixed camera (mean luma, 0-255):

| View | Before | After | Change |
|---|---|---|---|
| Straight-on bottom | 23.82 | 70.91 | **2.98x** |
| Near-vertical top | 36.78 | 36.87 | +0.09 (0.04%) |
| Three-quarter, tall components | 48.00 | 53.13 | +5.13 (+10.7%) |

The three-quarter lift is confined to downward-facing bevels on component bodies and the `DoubleSide` plated-hole barrels; only 0.22% of opaque pixels change by more than 60/255, so it reads as reduced crushed shadow rather than a wash. `UNDERSIDE_LIGHT_FACTOR` is the single knob if a softer result is preferred.

`tsc --noEmit` and `biome format` are clean. Test suite is unchanged versus `main` (27 pass / 5 fail, all 5 pre-existing) — no test touches `Lights.tsx`, and the SVG snapshot tests use their own light setup in `src/convert-circuit-json-to-3d-svg.ts`.

## Out of scope

- `HemisphereLight` takes its direction from the light's world position, which defaults to `(0,1,0)` — perpendicular to both faces in this Z-up scene, so top and bottom currently get an identical 50/50 sky/ground mix. Correcting it to `(0,0,1)` would push the bottom to the raw ground color and needs a `groundColor` re-tune alongside it.
- `scene.environment` is deliberately nulled, which makes the `envMapIntensity: 0.18` on both board-plane materials inert. Re-enabling it would also address this, but it changes every view.
