### PR TITLE
Clip 3D trace textures at copper pour boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
     "circuit-json": "^0.0.446",
-    "circuit-to-canvas": "^0.0.111",
+    "circuit-to-canvas": "^0.0.118",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",
     "three-stdlib": "^2.36.0",

--- a/src/utils/trace-texture.ts
+++ b/src/utils/trace-texture.ts
@@ -98,6 +98,7 @@ export function createTraceTextureForLayer({
   })
   drawer.drawElements(elementsToDraw, {
     layers: [pcbRenderLayer],
+    clipContextElements: circuitJson,
     drawSoldermask: false,
     drawSoldermaskTop: false,
     drawSoldermaskBottom: false,


### PR DESCRIPTION
## Summary
- bump circuit-to-canvas to 0.0.118
- provide full circuit context when generating the trace-only texture
- preserve the existing independent copper-pour texture pass while removing traces beneath finalized pour geometry

## Verification
- bun run build
- bun run format:check
- bun test: 27 pass; 5 existing failures from unpinned dependency/snapshot drift (faux-board thickness and 3D SVG colors)