### PR TITLE
Add real-world scale reference objects to 3D viewer

### DIFF
--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -35,6 +35,7 @@ import {
   registerHotkeyViewer,
   useRegisteredHotkey,
 } from "./hooks/useRegisteredHotkey"
+import type { ReferenceObjectType } from "./reference-objects/reference-object"
 
 const CadViewerInner = (props: any) => {
   const [engine, setEngine] = useState<"jscad" | "manifold">(() => {
@@ -53,6 +54,8 @@ const CadViewerInner = (props: any) => {
     return stored === "true"
   })
   const [cameraPreset, setCameraPreset] = useState<CameraPreset>("Custom")
+  const [referenceObject, setReferenceObject] =
+    useState<ReferenceObjectType | null>(null)
   const { cameraType } = useCameraController()
   const { visibility, setLayerVisibility } = useLayerVisibility()
   const { showToast } = useToast()
@@ -245,6 +248,7 @@ const CadViewerInner = (props: any) => {
           cameraType={cameraType}
           onUserInteraction={handleUserInteraction}
           onCameraControllerReady={handleCameraControllerReady}
+          referenceObject={referenceObject}
         />
       ) : (
         <CadViewerManifold
@@ -253,6 +257,7 @@ const CadViewerInner = (props: any) => {
           cameraType={cameraType}
           onUserInteraction={handleUserInteraction}
           onCameraControllerReady={handleCameraControllerReady}
+          referenceObject={referenceObject}
         />
       )}
       <div
@@ -278,6 +283,7 @@ const CadViewerInner = (props: any) => {
           engine={engine}
           cameraPreset={cameraPreset}
           autoRotate={autoRotate}
+          referenceObject={referenceObject}
           onEngineSwitch={(newEngine) => {
             setEngine(newEngine)
             closeMenu()
@@ -285,6 +291,13 @@ const CadViewerInner = (props: any) => {
           onCameraPresetSelect={handleCameraPresetSelect}
           onAutoRotateToggle={() => {
             toggleAutoRotate()
+            closeMenu()
+          }}
+          onReferenceObjectSelect={(nextReferenceObject) => {
+            setReferenceObject(nextReferenceObject)
+            setAutoRotate(false)
+            setAutoRotateUserToggled(true)
+            setCameraPreset("Custom")
             closeMenu()
           }}
           onDownloadGltf={() => {

--- a/src/CadViewerContainer.tsx
+++ b/src/CadViewerContainer.tsx
@@ -12,7 +12,15 @@ import { Canvas } from "./react-three/Canvas"
 import { Lights } from "./react-three/Lights"
 import { OrbitControls } from "./react-three/OrbitControls"
 import { useFrame, useThree } from "./react-three/ThreeContext"
+import {
+  getComparisonBounds,
+  type ReferenceObjectType,
+} from "./reference-objects/reference-object"
 import { OrientationCubeCanvas } from "./three-components/OrientationCubeCanvas"
+import {
+  FitCameraToComparison,
+  ReferenceObject,
+} from "./three-components/reference-object"
 
 export type {
   CameraController,
@@ -38,6 +46,7 @@ interface Props {
   clickToInteractEnabled?: boolean
   boardDimensions?: { width?: number; height?: number }
   boardCenter?: { x: number; y: number }
+  referenceObject?: ReferenceObjectType | null
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
 }
@@ -54,6 +63,7 @@ export const CadViewerContainer = forwardRef<
       clickToInteractEnabled = false,
       boardDimensions,
       boardCenter,
+      referenceObject,
       onUserInteraction,
       onCameraControllerReady,
     },
@@ -77,10 +87,22 @@ export const CadViewerContainer = forwardRef<
       }
     }, [controller, onCameraControllerReady])
 
+    const comparisonBounds = useMemo(() => {
+      if (!referenceObject) return undefined
+      return getComparisonBounds(referenceObject, boardDimensions, boardCenter)
+    }, [referenceObject, boardDimensions, boardCenter])
+
     const orbitTarget = useMemo(() => {
+      if (comparisonBounds) {
+        return [
+          (comparisonBounds.minX + comparisonBounds.maxX) / 2,
+          (comparisonBounds.minY + comparisonBounds.maxY) / 2,
+          (comparisonBounds.minZ + comparisonBounds.maxZ) / 2,
+        ] as [number, number, number]
+      }
       if (!boardCenter) return undefined
       return [boardCenter.x, boardCenter.y, 0] as [number, number, number]
-    }, [boardCenter])
+    }, [boardCenter, comparisonBounds])
 
     return (
       <div style={{ position: "relative", width: "100%", height: "100%" }}>
@@ -119,6 +141,16 @@ export const CadViewerContainer = forwardRef<
             darkBackgroundEnabled={darkBackgroundEnabled}
             shadowsEnabled={lightingEnabled}
           />
+          {referenceObject && (
+            <ReferenceObject
+              type={referenceObject}
+              boardDimensions={boardDimensions}
+              boardCenter={boardCenter}
+            />
+          )}
+          {comparisonBounds && (
+            <FitCameraToComparison bounds={comparisonBounds} />
+          )}
           {children}
         </Canvas>
         <div

--- a/src/CadViewerJscad.tsx
+++ b/src/CadViewerJscad.tsx
@@ -10,10 +10,12 @@ import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to
 import { useStlsFromGeom } from "./hooks/use-stls-from-geom"
 import { useBoardGeomBuilder } from "./hooks/useBoardGeomBuilder"
 import { usePcbThickness } from "./hooks/usePcbThickness"
+import type { ReferenceObjectType } from "./reference-objects/reference-object"
 import { Error3d } from "./three-components/Error3d"
-import { VisibleSTLModel } from "./three-components/VisibleSTLModel"
-import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
 import { JscadBoardTextures } from "./three-components/JscadBoardTextures"
+import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
+import { VisibleSTLModel } from "./three-components/VisibleSTLModel"
+import { calculateOutlineBounds } from "./utils/outline-bounds"
 import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json"
 
 interface Props {
@@ -28,6 +30,7 @@ interface Props {
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
   resolveStaticAsset?: (modelUrl: string) => string
+  referenceObject?: ReferenceObjectType | null
 }
 
 export const CadViewerJscad = forwardRef<
@@ -43,6 +46,7 @@ export const CadViewerJscad = forwardRef<
       onUserInteraction,
       onCameraControllerReady,
       resolveStaticAsset,
+      referenceObject,
     },
     ref,
   ) => {
@@ -98,7 +102,8 @@ export const CadViewerJscad = forwardRef<
       try {
         const board = su(internalCircuitJson as any).pcb_board.list()[0]
         if (!board) return undefined
-        return { width: board.width ?? 0, height: board.height ?? 0 }
+        const bounds = calculateOutlineBounds(board)
+        return { width: bounds.width, height: bounds.height }
       } catch (e) {
         console.error(e)
         return undefined
@@ -109,8 +114,9 @@ export const CadViewerJscad = forwardRef<
       if (!internalCircuitJson) return undefined
       try {
         const board = su(internalCircuitJson as any).pcb_board.list()[0]
-        if (!board || !board.center) return undefined
-        return { x: board.center.x, y: board.center.y }
+        if (!board) return undefined
+        const bounds = calculateOutlineBounds(board)
+        return { x: bounds.centerX, y: bounds.centerY }
       } catch (e) {
         console.error(e)
         return undefined
@@ -132,6 +138,7 @@ export const CadViewerJscad = forwardRef<
         clickToInteractEnabled={clickToInteractEnabled}
         boardDimensions={boardDimensions}
         boardCenter={boardCenter}
+        referenceObject={referenceObject}
         onUserInteraction={onUserInteraction}
         onCameraControllerReady={onCameraControllerReady}
       >

--- a/src/CadViewerManifold.tsx
+++ b/src/CadViewerManifold.tsx
@@ -11,10 +11,12 @@ import type { CameraController } from "./hooks/cameraAnimation"
 import { useConvertChildrenToCircuitJson } from "./hooks/use-convert-children-to-soup"
 import { useManifoldBoardBuilder } from "./hooks/useManifoldBoardBuilder"
 import { useThree } from "./react-three/ThreeContext"
+import type { ReferenceObjectType } from "./reference-objects/reference-object"
 import { createTextureMeshes } from "./textures"
 import { Error3d } from "./three-components/Error3d"
 import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
 import { createGeometryMeshes } from "./utils/manifold/create-three-geometry-meshes"
+import { calculateOutlineBounds } from "./utils/outline-bounds"
 import { addFauxBoardIfNeeded } from "./utils/preprocess-circuit-json"
 
 declare global {
@@ -129,6 +131,7 @@ type CadViewerManifoldProps = {
   onUserInteraction?: () => void
   onCameraControllerReady?: (controller: CameraController | null) => void
   resolveStaticAsset?: (modelUrl: string) => string
+  referenceObject?: ReferenceObjectType | null
 } & (
   | { circuitJson: AnyCircuitElement[]; children?: React.ReactNode }
   | { circuitJson?: never; children: React.ReactNode }
@@ -144,6 +147,7 @@ const CadViewerManifold: React.FC<CadViewerManifoldProps> = ({
   children,
   onCameraControllerReady,
   resolveStaticAsset,
+  referenceObject,
 }) => {
   const childrenCircuitJson = useConvertChildrenToCircuitJson(children)
   const circuitJson = useMemo(() => {
@@ -257,15 +261,14 @@ try {
 
   const boardDimensions = useMemo(() => {
     if (!boardData) return undefined
-    const { width = 0, height = 0 } = boardData
-    return { width, height }
+    const bounds = calculateOutlineBounds(boardData)
+    return { width: bounds.width, height: bounds.height }
   }, [boardData])
 
   const boardCenter = useMemo(() => {
     if (!boardData) return undefined
-    const { center } = boardData
-    if (!center) return undefined
-    return { x: center.x, y: center.y }
+    const bounds = calculateOutlineBounds(boardData)
+    return { x: bounds.centerX, y: bounds.centerY }
   }, [boardData])
 
   const initialCameraPosition = useMemo(() => {
@@ -323,6 +326,7 @@ try {
       clickToInteractEnabled={clickToInteractEnabled}
       boardDimensions={boardDimensions}
       boardCenter={boardCenter}
+      referenceObject={referenceObject}
       onUserInteraction={onUserInteraction}
       onCameraControllerReady={onCameraControllerReady}
     >

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,12 +1,16 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import type React from "react"
 import { useState } from "react"
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
-import { AppearanceMenu } from "./AppearanceMenu"
-import type { CameraPreset } from "../hooks/cameraAnimation"
-import { useCameraController } from "../contexts/CameraControllerContext"
-import packageJson from "../../package.json"
-import { CheckIcon, ChevronRightIcon, DotIcon } from "./Icons"
 import { zIndexMap } from "../../lib/utils/z-index-map"
+import packageJson from "../../package.json"
+import { useCameraController } from "../contexts/CameraControllerContext"
+import type { CameraPreset } from "../hooks/cameraAnimation"
+import {
+  REFERENCE_OBJECT_OPTIONS,
+  type ReferenceObjectType,
+} from "../reference-objects/reference-object"
+import { AppearanceMenu } from "./AppearanceMenu"
+import { CheckIcon, ChevronRightIcon, DotIcon } from "./Icons"
 
 interface ContextMenuProps {
   menuRef: React.RefObject<HTMLDivElement | null>
@@ -14,9 +18,11 @@ interface ContextMenuProps {
   engine: "jscad" | "manifold"
   cameraPreset: CameraPreset
   autoRotate: boolean
+  referenceObject: ReferenceObjectType | null
   onEngineSwitch: (engine: "jscad" | "manifold") => void
   onCameraPresetSelect: (preset: CameraPreset) => void
   onAutoRotateToggle: () => void
+  onReferenceObjectSelect: (referenceObject: ReferenceObjectType) => void
   onDownloadGltf: () => void
   onOpenKeyboardShortcuts: () => void
 }
@@ -105,14 +111,17 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   engine,
   cameraPreset,
   autoRotate,
+  referenceObject,
   onEngineSwitch,
   onCameraPresetSelect,
   onAutoRotateToggle,
+  onReferenceObjectSelect,
   onDownloadGltf,
   onOpenKeyboardShortcuts,
 }) => {
   const { cameraType, setCameraType } = useCameraController()
   const [cameraSubOpen, setCameraSubOpen] = useState(false)
+  const [referenceObjectSubOpen, setReferenceObjectSubOpen] = useState(false)
   const [hoveredItem, setHoveredItem] = useState<string | null>(null)
 
   return (
@@ -258,6 +267,75 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
                 Orthographic Camera
               </span>
             </DropdownMenu.Item>
+
+            {/* Reference Object Submenu */}
+            <DropdownMenu.Sub onOpenChange={setReferenceObjectSubOpen}>
+              <DropdownMenu.SubTrigger
+                style={{
+                  ...itemStyles,
+                  ...itemPaddingStyles,
+                  backgroundColor:
+                    referenceObjectSubOpen || hoveredItem === "reference-object"
+                      ? "#404040"
+                      : "transparent",
+                }}
+                onMouseEnter={() => setHoveredItem("reference-object")}
+                onMouseLeave={() => setHoveredItem(null)}
+                onTouchStart={() => setHoveredItem("reference-object")}
+              >
+                <span
+                  style={{ flex: 1, display: "flex", alignItems: "center" }}
+                >
+                  Show Reference Object
+                </span>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "flex-end",
+                    gap: 6,
+                    marginLeft: "auto",
+                  }}
+                >
+                  <ChevronRightIcon isOpen={referenceObjectSubOpen} />
+                </div>
+              </DropdownMenu.SubTrigger>
+
+              <DropdownMenu.Portal>
+                <DropdownMenu.SubContent
+                  style={{ ...contentStyles, marginLeft: -2 }}
+                  collisionPadding={10}
+                  avoidCollisions={true}
+                >
+                  {REFERENCE_OBJECT_OPTIONS.map((option) => (
+                    <DropdownMenu.Item
+                      key={option.type}
+                      style={{
+                        ...itemStyles,
+                        backgroundColor:
+                          hoveredItem === option.type
+                            ? "#404040"
+                            : "transparent",
+                      }}
+                      onSelect={(event) => event.preventDefault()}
+                      onPointerDown={(event) => {
+                        event.preventDefault()
+                        onReferenceObjectSelect(option.type)
+                      }}
+                      onMouseEnter={() => setHoveredItem(option.type)}
+                      onMouseLeave={() => setHoveredItem(null)}
+                      onTouchStart={() => setHoveredItem(option.type)}
+                    >
+                      <span style={iconContainerStyles}>
+                        {referenceObject === option.type && <DotIcon />}
+                      </span>
+                      <span style={{ display: "flex", alignItems: "center" }}>
+                        {option.label}
+                      </span>
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Sub>
 
             {/* Appearance Menu */}
             <AppearanceMenu />

--- a/src/reference-objects/create-reference-object.ts
+++ b/src/reference-objects/create-reference-object.ts
@@ -156,7 +156,7 @@ const createBananaGeometry = () => {
       const b = rowSize * segment + (side - 1)
       const c = rowSize * segment + side
       const d = rowSize * (segment - 1) + side
-      indices.push(a, b, d, b, c, d)
+      indices.push(a, d, b, b, d, c)
     }
   }
 

--- a/src/reference-objects/create-reference-object.ts
+++ b/src/reference-objects/create-reference-object.ts
@@ -54,57 +54,97 @@ const createRoundedPrismGeometry = (
   depth: number,
   radius: number,
 ) => {
-  const geometry = new THREE.ExtrudeGeometry(
+  return createPrismGeometryFromShape(
     createRoundedRectangleShape(width, height, radius),
-    {
-      depth,
-      bevelEnabled: false,
-      curveSegments: 24,
-    },
+    depth,
   )
+}
+
+const createPrismGeometryFromShape = (shape: THREE.Shape, depth: number) => {
+  const geometry = new THREE.ExtrudeGeometry(shape, {
+    depth,
+    bevelEnabled: false,
+    curveSegments: 24,
+  })
   geometry.translate(0, 0, -depth / 2)
   geometry.computeVertexNormals()
   return geometry
 }
 
+const normalizeObjectToSpec = (
+  object: THREE.Object3D,
+  type: ReferenceObjectType,
+) => {
+  const spec = REFERENCE_OBJECT_SPECS[type]
+  object.updateMatrixWorld(true)
+  const initialBounds = new THREE.Box3().setFromObject(object)
+  const initialSize = initialBounds.getSize(new THREE.Vector3())
+  object.scale.set(
+    spec.width / initialSize.x,
+    spec.height / initialSize.y,
+    spec.depth / initialSize.z,
+  )
+  object.updateMatrixWorld(true)
+
+  const scaledBounds = new THREE.Box3().setFromObject(object)
+  const scaledCenter = scaledBounds.getCenter(new THREE.Vector3())
+  object.position.set(
+    -scaledCenter.x,
+    -scaledCenter.y,
+    spec.zCenter - scaledCenter.z,
+  )
+  object.updateMatrixWorld(true)
+}
+
 const createBananaGeometry = () => {
   const curve = new THREE.CatmullRomCurve3([
-    new THREE.Vector3(-88, 9, 12),
-    new THREE.Vector3(-60, -1, 12),
-    new THREE.Vector3(-30, -7, 12),
-    new THREE.Vector3(0, -9, 12),
-    new THREE.Vector3(30, -7, 12),
-    new THREE.Vector3(60, -1, 12),
-    new THREE.Vector3(88, 9, 12),
+    new THREE.Vector3(-82, 18, 16),
+    new THREE.Vector3(-67, 7, 15),
+    new THREE.Vector3(-43, -9, 14),
+    new THREE.Vector3(-15, -18, 14),
+    new THREE.Vector3(16, -18, 14),
+    new THREE.Vector3(47, -8, 14.5),
+    new THREE.Vector3(72, 8, 16),
+    new THREE.Vector3(84, 19, 17),
   ])
-  const tubularSegments = 72
-  const radialSegments = 24
+  const tubularSegments = 84
+  const radialSegments = 30
   const frames = curve.computeFrenetFrames(tubularSegments, false)
   const positions: number[] = []
   const normals: number[] = []
+  const colors: number[] = []
   const uvs: number[] = []
   const indices: number[] = []
+  const ripeYellow = new THREE.Color(0xffd447)
+  const stemGreen = new THREE.Color(0xb7b335)
 
   for (let segment = 0; segment <= tubularSegments; segment++) {
     const t = segment / tubularSegments
     const point = curve.getPointAt(t)
     const normal = frames.normals[segment]!
     const binormal = frames.binormals[segment]!
-    const taper = Math.sin(Math.PI * t) ** 0.55
-    const radius = 3.2 + 8.5 * taper
+    const taper = Math.sin(Math.PI * t) ** 0.48
+    const radius = 3.4 + 12.4 * taper
+    const stemBlend = Math.max(0, (t - 0.82) / 0.18) * 0.38
+    const ringColor = ripeYellow.clone().lerp(stemGreen, stemBlend)
 
     for (let side = 0; side <= radialSegments; side++) {
       const angle = (side / radialSegments) * Math.PI * 2
       const sin = Math.sin(angle)
       const cos = Math.cos(angle)
+      const ridgeScale = 1 + Math.cos(angle * 5 + 0.35) * 0.035
       const radialNormal = new THREE.Vector3()
         .addScaledVector(normal, cos)
-        .addScaledVector(binormal, sin)
+        .addScaledVector(binormal, sin * 0.9)
         .normalize()
-      const vertex = point.clone().addScaledVector(radialNormal, radius)
+      const vertex = point
+        .clone()
+        .addScaledVector(normal, cos * radius * ridgeScale)
+        .addScaledVector(binormal, sin * radius * 0.9 * ridgeScale)
 
       positions.push(vertex.x, vertex.y, vertex.z)
       normals.push(radialNormal.x, radialNormal.y, radialNormal.z)
+      colors.push(ringColor.r, ringColor.g, ringColor.b)
       uvs.push(t, side / radialSegments)
     }
   }
@@ -127,6 +167,7 @@ const createBananaGeometry = () => {
     new THREE.Float32BufferAttribute(positions, 3),
   )
   geometry.setAttribute("normal", new THREE.Float32BufferAttribute(normals, 3))
+  geometry.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3))
   geometry.setAttribute("uv", new THREE.Float32BufferAttribute(uvs, 2))
   geometry.computeBoundingBox()
   geometry.computeBoundingSphere()
@@ -136,34 +177,96 @@ const createBananaGeometry = () => {
 
 const createBanana = () => {
   const group = new THREE.Group()
+  const banana = new THREE.Group()
   const { geometry, curve } = createBananaGeometry()
   const peel = new THREE.Mesh(
     geometry,
     new THREE.MeshStandardMaterial({
-      color: 0xf4ce2f,
-      roughness: 0.76,
+      color: 0xffffff,
+      roughness: 0.72,
       metalness: 0,
+      vertexColors: true,
     }),
   )
   peel.name = "banana-peel"
-  group.add(peel)
+  banana.add(peel)
 
-  const tipMaterial = new THREE.MeshStandardMaterial({
-    color: 0x70501e,
-    roughness: 0.9,
-  })
-  for (const t of [0, 1]) {
-    const tip = new THREE.Mesh(
-      new THREE.SphereGeometry(3.7, 20, 12),
-      tipMaterial,
-    )
-    tip.position.copy(curve.getPointAt(t))
-    tip.scale.set(1.25, 0.8, 0.8)
-    tip.name = "banana-tip"
-    group.add(tip)
-  }
+  const blossomTip = new THREE.Mesh(
+    new THREE.SphereGeometry(3.4, 20, 12),
+    new THREE.MeshStandardMaterial({
+      color: 0x5f421c,
+      roughness: 0.92,
+    }),
+  )
+  blossomTip.position.copy(curve.getPointAt(0))
+  blossomTip.scale.set(1.15, 0.78, 0.78)
+  blossomTip.name = "banana-blossom-tip"
+  banana.add(blossomTip)
+
+  const stemLength = 11
+  const stemTangent = curve.getTangentAt(1).normalize()
+  const stem = new THREE.Mesh(
+    new THREE.CylinderGeometry(2.5, 4.1, stemLength, 18),
+    new THREE.MeshStandardMaterial({
+      color: 0x817329,
+      roughness: 0.82,
+    }),
+  )
+  stem.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), stemTangent)
+  stem.position
+    .copy(curve.getPointAt(1))
+    .addScaledVector(stemTangent, stemLength / 2)
+  stem.name = "banana-stem"
+  banana.add(stem)
+
+  const stemTip = new THREE.Mesh(
+    new THREE.SphereGeometry(2.55, 18, 10),
+    new THREE.MeshStandardMaterial({
+      color: 0x5b451e,
+      roughness: 0.9,
+    }),
+  )
+  stemTip.position
+    .copy(curve.getPointAt(1))
+    .addScaledVector(stemTangent, stemLength)
+  stemTip.name = "banana-stem-tip"
+  banana.add(stemTip)
+
+  normalizeObjectToSpec(banana, "banana")
+  group.add(banana)
 
   return group
+}
+
+const createMacbookLidGeometry = (
+  width: number,
+  height: number,
+  depth: number,
+  radius: number,
+  indentRadius: number,
+) => {
+  const lidShape = createRoundedRectangleShape(width, height, radius)
+  const indent = new THREE.Path()
+  indent.absarc(0, 0, indentRadius, 0, Math.PI * 2, true)
+  lidShape.holes.push(indent)
+  return createPrismGeometryFromShape(lidShape, depth)
+}
+
+const createMacbookIndent = (topZ: number, radius: number) => {
+  const indentDepth = 0.35
+  const diskDepth = 0.25
+  const disk = new THREE.Mesh(
+    new THREE.CylinderGeometry(radius - 0.15, radius - 0.15, diskDepth, 48),
+    new THREE.MeshStandardMaterial({
+      color: 0x9ba0a2,
+      roughness: 0.48,
+      metalness: 0.28,
+    }),
+  )
+  disk.rotation.x = Math.PI / 2
+  disk.position.z = topZ - indentDepth - diskDepth / 2
+  disk.name = "macbook-lid-indent"
+  return disk
 }
 
 const createCreditCard = () => {
@@ -227,11 +330,21 @@ const createMacbook = () => {
   body.name = "macbook-body"
   group.add(body)
 
+  const lidDepth = 2
+  const lidCenterZ = 6.75
+  const lidTopZ = lidCenterZ + lidDepth / 2
+  const indentRadius = 12
   const lid = new THREE.Mesh(
-    createRoundedPrismGeometry(spec.width - 1.8, spec.height - 1.8, 2, 8.2),
+    createMacbookLidGeometry(
+      spec.width - 1.8,
+      spec.height - 1.8,
+      lidDepth,
+      8.2,
+      indentRadius,
+    ),
     aluminumMaterial.clone(),
   )
-  lid.position.z = 6.75
+  lid.position.z = lidCenterZ
   lid.name = "macbook-lid"
   group.add(lid)
 
@@ -247,18 +360,7 @@ const createMacbook = () => {
   hinge.name = "macbook-hinge"
   group.add(hinge)
 
-  const lidMark = new THREE.Mesh(
-    new THREE.CircleGeometry(13, 40),
-    new THREE.MeshStandardMaterial({
-      color: 0x92979b,
-      roughness: 0.34,
-      metalness: 0.82,
-      side: THREE.DoubleSide,
-    }),
-  )
-  lidMark.position.z = 7.77
-  lidMark.name = "macbook-lid-mark"
-  group.add(lidMark)
+  group.add(createMacbookIndent(lidTopZ, indentRadius))
 
   const frontNotch = new THREE.Mesh(
     new THREE.BoxGeometry(54, 1.2, 0.8),

--- a/src/reference-objects/create-reference-object.ts
+++ b/src/reference-objects/create-reference-object.ts
@@ -1,0 +1,306 @@
+import * as THREE from "three"
+import { configureObjectShadows } from "../utils/configure-object-shadows"
+import {
+  REFERENCE_OBJECT_SPECS,
+  type ReferenceObjectType,
+} from "./reference-object"
+
+const createRoundedRectangleShape = (
+  width: number,
+  height: number,
+  radius: number,
+) => {
+  const halfWidth = width / 2
+  const halfHeight = height / 2
+  const safeRadius = Math.min(radius, halfWidth, halfHeight)
+  const shape = new THREE.Shape()
+
+  shape.moveTo(-halfWidth + safeRadius, -halfHeight)
+  shape.lineTo(halfWidth - safeRadius, -halfHeight)
+  shape.quadraticCurveTo(
+    halfWidth,
+    -halfHeight,
+    halfWidth,
+    -halfHeight + safeRadius,
+  )
+  shape.lineTo(halfWidth, halfHeight - safeRadius)
+  shape.quadraticCurveTo(
+    halfWidth,
+    halfHeight,
+    halfWidth - safeRadius,
+    halfHeight,
+  )
+  shape.lineTo(-halfWidth + safeRadius, halfHeight)
+  shape.quadraticCurveTo(
+    -halfWidth,
+    halfHeight,
+    -halfWidth,
+    halfHeight - safeRadius,
+  )
+  shape.lineTo(-halfWidth, -halfHeight + safeRadius)
+  shape.quadraticCurveTo(
+    -halfWidth,
+    -halfHeight,
+    -halfWidth + safeRadius,
+    -halfHeight,
+  )
+
+  return shape
+}
+
+const createRoundedPrismGeometry = (
+  width: number,
+  height: number,
+  depth: number,
+  radius: number,
+) => {
+  const geometry = new THREE.ExtrudeGeometry(
+    createRoundedRectangleShape(width, height, radius),
+    {
+      depth,
+      bevelEnabled: false,
+      curveSegments: 24,
+    },
+  )
+  geometry.translate(0, 0, -depth / 2)
+  geometry.computeVertexNormals()
+  return geometry
+}
+
+const createBananaGeometry = () => {
+  const curve = new THREE.CatmullRomCurve3([
+    new THREE.Vector3(-88, 9, 12),
+    new THREE.Vector3(-60, -1, 12),
+    new THREE.Vector3(-30, -7, 12),
+    new THREE.Vector3(0, -9, 12),
+    new THREE.Vector3(30, -7, 12),
+    new THREE.Vector3(60, -1, 12),
+    new THREE.Vector3(88, 9, 12),
+  ])
+  const tubularSegments = 72
+  const radialSegments = 24
+  const frames = curve.computeFrenetFrames(tubularSegments, false)
+  const positions: number[] = []
+  const normals: number[] = []
+  const uvs: number[] = []
+  const indices: number[] = []
+
+  for (let segment = 0; segment <= tubularSegments; segment++) {
+    const t = segment / tubularSegments
+    const point = curve.getPointAt(t)
+    const normal = frames.normals[segment]!
+    const binormal = frames.binormals[segment]!
+    const taper = Math.sin(Math.PI * t) ** 0.55
+    const radius = 3.2 + 8.5 * taper
+
+    for (let side = 0; side <= radialSegments; side++) {
+      const angle = (side / radialSegments) * Math.PI * 2
+      const sin = Math.sin(angle)
+      const cos = Math.cos(angle)
+      const radialNormal = new THREE.Vector3()
+        .addScaledVector(normal, cos)
+        .addScaledVector(binormal, sin)
+        .normalize()
+      const vertex = point.clone().addScaledVector(radialNormal, radius)
+
+      positions.push(vertex.x, vertex.y, vertex.z)
+      normals.push(radialNormal.x, radialNormal.y, radialNormal.z)
+      uvs.push(t, side / radialSegments)
+    }
+  }
+
+  for (let segment = 1; segment <= tubularSegments; segment++) {
+    for (let side = 1; side <= radialSegments; side++) {
+      const rowSize = radialSegments + 1
+      const a = rowSize * (segment - 1) + (side - 1)
+      const b = rowSize * segment + (side - 1)
+      const c = rowSize * segment + side
+      const d = rowSize * (segment - 1) + side
+      indices.push(a, b, d, b, c, d)
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry()
+  geometry.setIndex(indices)
+  geometry.setAttribute(
+    "position",
+    new THREE.Float32BufferAttribute(positions, 3),
+  )
+  geometry.setAttribute("normal", new THREE.Float32BufferAttribute(normals, 3))
+  geometry.setAttribute("uv", new THREE.Float32BufferAttribute(uvs, 2))
+  geometry.computeBoundingBox()
+  geometry.computeBoundingSphere()
+
+  return { geometry, curve }
+}
+
+const createBanana = () => {
+  const group = new THREE.Group()
+  const { geometry, curve } = createBananaGeometry()
+  const peel = new THREE.Mesh(
+    geometry,
+    new THREE.MeshStandardMaterial({
+      color: 0xf4ce2f,
+      roughness: 0.76,
+      metalness: 0,
+    }),
+  )
+  peel.name = "banana-peel"
+  group.add(peel)
+
+  const tipMaterial = new THREE.MeshStandardMaterial({
+    color: 0x70501e,
+    roughness: 0.9,
+  })
+  for (const t of [0, 1]) {
+    const tip = new THREE.Mesh(
+      new THREE.SphereGeometry(3.7, 20, 12),
+      tipMaterial,
+    )
+    tip.position.copy(curve.getPointAt(t))
+    tip.scale.set(1.25, 0.8, 0.8)
+    tip.name = "banana-tip"
+    group.add(tip)
+  }
+
+  return group
+}
+
+const createCreditCard = () => {
+  const spec = REFERENCE_OBJECT_SPECS["credit-card"]
+  const group = new THREE.Group()
+  const body = new THREE.Mesh(
+    createRoundedPrismGeometry(spec.width, spec.height, spec.depth, 3.18),
+    new THREE.MeshStandardMaterial({
+      color: 0x245da8,
+      roughness: 0.38,
+      metalness: 0.08,
+    }),
+  )
+  body.name = "credit-card-body"
+  group.add(body)
+
+  const surfaceZ = spec.depth / 2 + 0.08
+  const chip = new THREE.Mesh(
+    createRoundedPrismGeometry(12, 9, 0.14, 1.2),
+    new THREE.MeshStandardMaterial({
+      color: 0xd5ad45,
+      roughness: 0.3,
+      metalness: 0.62,
+    }),
+  )
+  chip.position.set(-21, 3, surfaceZ)
+  chip.name = "credit-card-chip"
+  group.add(chip)
+
+  const stripeMaterial = new THREE.MeshStandardMaterial({
+    color: 0xe9eef5,
+    roughness: 0.45,
+    metalness: 0.05,
+  })
+  for (let index = 0; index < 4; index++) {
+    const stripe = new THREE.Mesh(
+      new THREE.BoxGeometry(index === 3 ? 8 : 12, 0.8, 0.1),
+      stripeMaterial,
+    )
+    stripe.position.set(-20 + index * 14, -14, surfaceZ + 0.08)
+    stripe.name = "credit-card-detail"
+    group.add(stripe)
+  }
+
+  return group
+}
+
+const createMacbook = () => {
+  const spec = REFERENCE_OBJECT_SPECS["14in-macbook"]
+  const group = new THREE.Group()
+  const aluminumMaterial = new THREE.MeshStandardMaterial({
+    color: 0xc4c7c9,
+    roughness: 0.3,
+    metalness: 0.38,
+  })
+  const body = new THREE.Mesh(
+    createRoundedPrismGeometry(spec.width, spec.height, 13.5, 9),
+    aluminumMaterial,
+  )
+  body.position.z = -1
+  body.name = "macbook-body"
+  group.add(body)
+
+  const lid = new THREE.Mesh(
+    createRoundedPrismGeometry(spec.width - 1.8, spec.height - 1.8, 2, 8.2),
+    aluminumMaterial.clone(),
+  )
+  lid.position.z = 6.75
+  lid.name = "macbook-lid"
+  group.add(lid)
+
+  const hinge = new THREE.Mesh(
+    new THREE.BoxGeometry(spec.width - 42, 3.2, 1.2),
+    new THREE.MeshStandardMaterial({
+      color: 0x303336,
+      roughness: 0.55,
+      metalness: 0.45,
+    }),
+  )
+  hinge.position.set(0, spec.height / 2 - 2.4, 6.15)
+  hinge.name = "macbook-hinge"
+  group.add(hinge)
+
+  const lidMark = new THREE.Mesh(
+    new THREE.CircleGeometry(13, 40),
+    new THREE.MeshStandardMaterial({
+      color: 0x92979b,
+      roughness: 0.34,
+      metalness: 0.82,
+      side: THREE.DoubleSide,
+    }),
+  )
+  lidMark.position.z = 7.77
+  lidMark.name = "macbook-lid-mark"
+  group.add(lidMark)
+
+  const frontNotch = new THREE.Mesh(
+    new THREE.BoxGeometry(54, 1.2, 0.8),
+    new THREE.MeshStandardMaterial({
+      color: 0x666b6e,
+      roughness: 0.45,
+      metalness: 0.5,
+    }),
+  )
+  frontNotch.position.set(0, -spec.height / 2 + 0.5, 2.5)
+  frontNotch.name = "macbook-front-notch"
+  group.add(frontNotch)
+
+  return group
+}
+
+export const createReferenceObject = (type: ReferenceObjectType) => {
+  const group =
+    type === "banana"
+      ? createBanana()
+      : type === "credit-card"
+        ? createCreditCard()
+        : createMacbook()
+
+  group.name = `reference-object-${type}`
+  group.userData.isReferenceObject = true
+  group.userData.referenceObjectType = type
+  configureObjectShadows(group)
+  return group
+}
+
+export const disposeReferenceObject = (object: THREE.Object3D) => {
+  const geometries = new Set<THREE.BufferGeometry>()
+  const materials = new Set<THREE.Material>()
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return
+    geometries.add(child.geometry)
+    const childMaterials = Array.isArray(child.material)
+      ? child.material
+      : [child.material]
+    for (const material of childMaterials) materials.add(material)
+  })
+  for (const geometry of geometries) geometry.dispose()
+  for (const material of materials) material.dispose()
+}

--- a/src/reference-objects/fit-camera-to-bounds.ts
+++ b/src/reference-objects/fit-camera-to-bounds.ts
@@ -1,0 +1,65 @@
+import * as THREE from "three"
+import type { Bounds3d } from "./reference-object"
+
+interface CameraControlsLike {
+  target: THREE.Vector3
+  update: () => void
+}
+
+export interface FitCameraResult {
+  center: THREE.Vector3
+  radius: number
+  distance: number
+}
+
+export const fitCameraToBounds = (
+  camera: THREE.Camera,
+  controls: CameraControlsLike | null,
+  bounds: Bounds3d,
+  padding = 1.18,
+): FitCameraResult => {
+  const width = Math.max(bounds.maxX - bounds.minX, 0)
+  const height = Math.max(bounds.maxY - bounds.minY, 0)
+  const depth = Math.max(bounds.maxZ - bounds.minZ, 0)
+  const center = new THREE.Vector3(
+    (bounds.minX + bounds.maxX) / 2,
+    (bounds.minY + bounds.maxY) / 2,
+    (bounds.minZ + bounds.maxZ) / 2,
+  )
+  const radius = Math.max(Math.hypot(width, height, depth) / 2, 1)
+  const previousTarget = controls?.target ?? new THREE.Vector3()
+  // A consistent elevated three-quarter angle keeps the real-world X/Y scale
+  // legible even if the user selected a reference from a side-on view.
+  const direction = new THREE.Vector3(0, -0.75, 0.9).normalize()
+
+  let distance = Math.max(camera.position.distanceTo(previousTarget), 5)
+
+  if (camera instanceof THREE.PerspectiveCamera) {
+    const verticalFov = THREE.MathUtils.degToRad(camera.fov)
+    const horizontalFov =
+      2 * Math.atan(Math.tan(verticalFov / 2) * camera.aspect)
+    const limitingFov = Math.min(verticalFov, horizontalFov)
+    distance = (radius * padding) / Math.sin(limitingFov / 2)
+    camera.far = Math.max(camera.far, distance + radius * padding * 3)
+    camera.updateProjectionMatrix()
+  } else if (camera instanceof THREE.OrthographicCamera) {
+    const halfViewWidth = Math.abs(camera.right - camera.left) / 2
+    const halfViewHeight = Math.abs(camera.top - camera.bottom) / 2
+    camera.zoom = Math.min(
+      halfViewWidth / (radius * padding),
+      halfViewHeight / (radius * padding),
+    )
+    distance = Math.max(distance, radius * padding * 2)
+    camera.updateProjectionMatrix()
+  }
+
+  camera.position.copy(center).addScaledVector(direction, distance)
+  camera.lookAt(center)
+  camera.updateMatrixWorld()
+  if (controls) {
+    controls.target.copy(center)
+    controls.update()
+  }
+
+  return { center, radius, distance }
+}

--- a/src/reference-objects/reference-object.ts
+++ b/src/reference-objects/reference-object.ts
@@ -1,0 +1,128 @@
+export type ReferenceObjectType = "banana" | "credit-card" | "14in-macbook"
+
+export interface ReferenceObjectSpec {
+  type: ReferenceObjectType
+  label: string
+  width: number
+  height: number
+  depth: number
+  zCenter: number
+}
+
+export interface BoardDimensions {
+  width?: number
+  height?: number
+}
+
+export interface BoardCenter {
+  x: number
+  y: number
+}
+
+export interface Bounds3d {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+  minZ: number
+  maxZ: number
+}
+
+export const REFERENCE_OBJECT_CLEARANCE_MM = 10
+
+export const REFERENCE_OBJECT_SPECS: Record<
+  ReferenceObjectType,
+  ReferenceObjectSpec
+> = {
+  banana: {
+    type: "banana",
+    label: "Show Banana",
+    // Bananas vary; this represents a typical medium banana.
+    width: 190,
+    height: 65,
+    depth: 30,
+    zCenter: 15,
+  },
+  "credit-card": {
+    type: "credit-card",
+    label: "Show Credit Card",
+    // ISO/IEC 7810 ID-1 dimensions.
+    width: 85.6,
+    height: 53.98,
+    depth: 0.76,
+    zCenter: 0,
+  },
+  "14in-macbook": {
+    type: "14in-macbook",
+    label: "Show 14in Macbook",
+    // Current 14-inch MacBook Pro exterior dimensions.
+    width: 312.6,
+    height: 221.2,
+    depth: 15.5,
+    zCenter: 0,
+  },
+}
+
+export const REFERENCE_OBJECT_OPTIONS = Object.values(REFERENCE_OBJECT_SPECS)
+
+const safeDimension = (dimension: number | undefined) =>
+  Number.isFinite(dimension) ? Math.max(dimension ?? 0, 0) : 0
+
+const safeCoordinate = (coordinate: number | undefined) =>
+  Number.isFinite(coordinate) ? (coordinate ?? 0) : 0
+
+export const getReferenceObjectPosition = (
+  type: ReferenceObjectType,
+  boardDimensions?: BoardDimensions,
+  boardCenter?: BoardCenter,
+): { x: number; y: number; z: number } => {
+  const spec = REFERENCE_OBJECT_SPECS[type]
+  const boardWidth = safeDimension(boardDimensions?.width)
+  const centerX = safeCoordinate(boardCenter?.x)
+  const centerY = safeCoordinate(boardCenter?.y)
+
+  return {
+    x:
+      centerX + boardWidth / 2 + REFERENCE_OBJECT_CLEARANCE_MM + spec.width / 2,
+    y: centerY,
+    z: 0,
+  }
+}
+
+export const getComparisonBounds = (
+  type: ReferenceObjectType,
+  boardDimensions?: BoardDimensions,
+  boardCenter?: BoardCenter,
+): Bounds3d => {
+  const spec = REFERENCE_OBJECT_SPECS[type]
+  const boardWidth = safeDimension(boardDimensions?.width)
+  const boardHeight = safeDimension(boardDimensions?.height)
+  const centerX = safeCoordinate(boardCenter?.x)
+  const centerY = safeCoordinate(boardCenter?.y)
+  const referencePosition = getReferenceObjectPosition(
+    type,
+    boardDimensions,
+    boardCenter,
+  )
+
+  return {
+    minX: Math.min(
+      centerX - boardWidth / 2,
+      referencePosition.x - spec.width / 2,
+    ),
+    maxX: Math.max(
+      centerX + boardWidth / 2,
+      referencePosition.x + spec.width / 2,
+    ),
+    minY: Math.min(
+      centerY - boardHeight / 2,
+      referencePosition.y - spec.height / 2,
+    ),
+    maxY: Math.max(
+      centerY + boardHeight / 2,
+      referencePosition.y + spec.height / 2,
+    ),
+    minZ: Math.min(0, referencePosition.z + spec.zCenter - spec.depth / 2),
+    maxZ: Math.max(0, referencePosition.z + spec.zCenter + spec.depth / 2),
+  }
+}

--- a/src/reference-objects/reference-object.ts
+++ b/src/reference-objects/reference-object.ts
@@ -37,11 +37,12 @@ export const REFERENCE_OBJECT_SPECS: Record<
   banana: {
     type: "banana",
     label: "Show Banana",
-    // Bananas vary; this represents a typical medium banana.
+    // USDA describes a medium banana as 7 to 7 7/8 inches long. The 190 mm
+    // envelope is near the midpoint of that range.
     width: 190,
-    height: 65,
-    depth: 30,
-    zCenter: 15,
+    height: 60,
+    depth: 34,
+    zCenter: 17,
   },
   "credit-card": {
     type: "credit-card",

--- a/src/three-components/reference-object.tsx
+++ b/src/three-components/reference-object.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useMemo } from "react"
+import { useCameraController } from "../contexts/CameraControllerContext"
+import { useThree } from "../react-three/ThreeContext"
+import {
+  createReferenceObject,
+  disposeReferenceObject,
+} from "../reference-objects/create-reference-object"
+import { fitCameraToBounds } from "../reference-objects/fit-camera-to-bounds"
+import {
+  type BoardCenter,
+  type BoardDimensions,
+  type Bounds3d,
+  getReferenceObjectPosition,
+  type ReferenceObjectType,
+} from "../reference-objects/reference-object"
+
+interface ReferenceObjectProps {
+  type: ReferenceObjectType
+  boardDimensions?: BoardDimensions
+  boardCenter?: BoardCenter
+}
+
+export const ReferenceObject = ({
+  type,
+  boardDimensions,
+  boardCenter,
+}: ReferenceObjectProps) => {
+  const { scene } = useThree()
+  const object = useMemo(() => {
+    const nextObject = createReferenceObject(type)
+    const position = getReferenceObjectPosition(
+      type,
+      boardDimensions,
+      boardCenter,
+    )
+    nextObject.position.set(position.x, position.y, position.z)
+    return nextObject
+  }, [type, boardDimensions, boardCenter])
+
+  useEffect(() => {
+    scene.add(object)
+    return () => {
+      scene.remove(object)
+      disposeReferenceObject(object)
+    }
+  }, [scene, object])
+
+  return null
+}
+
+export const FitCameraToComparison = ({ bounds }: { bounds: Bounds3d }) => {
+  const { camera } = useThree()
+  const { controlsRef } = useCameraController()
+
+  useEffect(() => {
+    fitCameraToBounds(camera, controlsRef.current, bounds)
+  }, [bounds, camera, controlsRef])
+
+  return null
+}

--- a/tests/reference-object-scene.test.tsx
+++ b/tests/reference-object-scene.test.tsx
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { JSDOM } from "jsdom"
+import { act, StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import * as THREE from "three"
+import {
+  ThreeContext,
+  type ThreeContextState,
+} from "../src/react-three/ThreeContext"
+import { ReferenceObject } from "../src/three-components/reference-object"
+
+test("adds reference geometry to the scene but not the export root", async () => {
+  const dom = new JSDOM('<div id="root"></div>')
+  const previousWindow = globalThis.window
+  const previousDocument = globalThis.document
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })
+
+  const container = document.getElementById("root")!
+  const scene = new THREE.Scene()
+  const rootObject = new THREE.Object3D()
+  scene.add(rootObject)
+  const context: ThreeContextState = {
+    scene,
+    camera: new THREE.PerspectiveCamera(),
+    renderer: {} as THREE.WebGLRenderer,
+    rootObject,
+    addFrameListener: () => {},
+    removeFrameListener: () => {},
+  }
+  const reactRoot = createRoot(container)
+
+  try {
+    await act(async () => {
+      reactRoot.render(
+        <StrictMode>
+          <ThreeContext.Provider value={context}>
+            <ReferenceObject
+              type="credit-card"
+              boardDimensions={{ width: 30, height: 20 }}
+              boardCenter={{ x: 0, y: 0 }}
+            />
+          </ThreeContext.Provider>
+        </StrictMode>,
+      )
+    })
+
+    expect(scene.getObjectByName("reference-object-credit-card")).toBeTruthy()
+    expect(rootObject.children).toHaveLength(0)
+  } finally {
+    await act(async () => reactRoot.unmount())
+    expect(scene.getObjectByName("reference-object-credit-card")).toBeFalsy()
+    Object.assign(globalThis, {
+      window: previousWindow,
+      document: previousDocument,
+      IS_REACT_ACT_ENVIRONMENT: false,
+    })
+    dom.window.close()
+  }
+})

--- a/tests/reference-object.test.ts
+++ b/tests/reference-object.test.ts
@@ -73,6 +73,37 @@ describe("reference object placement", () => {
     expect(size.z).toBeCloseTo(spec.depth, 4)
     expect(banana.getObjectByName("banana-stem")).toBeTruthy()
     expect(banana.getObjectByName("banana-blossom-tip")).toBeTruthy()
+
+    const peel = banana.getObjectByName("banana-peel") as THREE.Mesh
+    const geometry = peel.geometry as THREE.BufferGeometry
+    const positions = geometry.getAttribute("position")
+    const normals = geometry.getAttribute("normal")
+    const indices = geometry.index!
+
+    for (let offset = 0; offset < indices.count; offset += 3) {
+      const vertexIndices = [
+        indices.getX(offset),
+        indices.getX(offset + 1),
+        indices.getX(offset + 2),
+      ]
+      const [a, b, c] = vertexIndices.map((index) =>
+        new THREE.Vector3().fromBufferAttribute(positions, index),
+      )
+      const faceNormal = new THREE.Vector3()
+        .crossVectors(b!.clone().sub(a!), c!.clone().sub(a!))
+        .normalize()
+      const averageVertexNormal = vertexIndices
+        .reduce(
+          (average, index) =>
+            average.add(
+              new THREE.Vector3().fromBufferAttribute(normals, index),
+            ),
+          new THREE.Vector3(),
+        )
+        .normalize()
+
+      expect(faceNormal.dot(averageVertexNormal)).toBeGreaterThan(0)
+    }
     disposeReferenceObject(banana)
   })
 

--- a/tests/reference-object.test.ts
+++ b/tests/reference-object.test.ts
@@ -59,6 +59,35 @@ describe("reference object placement", () => {
       depth: 15.5,
     })
   })
+
+  test("normalizes the banana mesh to its medium-banana envelope", () => {
+    const banana = createReferenceObject("banana")
+    banana.updateMatrixWorld(true)
+    const size = new THREE.Box3()
+      .setFromObject(banana)
+      .getSize(new THREE.Vector3())
+    const spec = REFERENCE_OBJECT_SPECS.banana
+
+    expect(size.x).toBeCloseTo(spec.width, 4)
+    expect(size.y).toBeCloseTo(spec.height, 4)
+    expect(size.z).toBeCloseTo(spec.depth, 4)
+    expect(banana.getObjectByName("banana-stem")).toBeTruthy()
+    expect(banana.getObjectByName("banana-blossom-tip")).toBeTruthy()
+    disposeReferenceObject(banana)
+  })
+
+  test("uses a physically recessed MacBook lid circle", () => {
+    const macbook = createReferenceObject("14in-macbook")
+    macbook.updateMatrixWorld(true)
+    const lid = macbook.getObjectByName("macbook-lid")!
+    const indent = macbook.getObjectByName("macbook-lid-indent")!
+    const lidBounds = new THREE.Box3().setFromObject(lid)
+    const indentBounds = new THREE.Box3().setFromObject(indent)
+
+    expect(macbook.getObjectByName("macbook-lid-mark")).toBeUndefined()
+    expect(indentBounds.max.z).toBeLessThan(lidBounds.max.z - 0.2)
+    disposeReferenceObject(macbook)
+  })
 })
 
 describe("comparison camera fit", () => {

--- a/tests/reference-object.test.ts
+++ b/tests/reference-object.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test"
+import * as THREE from "three"
+import {
+  createReferenceObject,
+  disposeReferenceObject,
+} from "../src/reference-objects/create-reference-object"
+import { fitCameraToBounds } from "../src/reference-objects/fit-camera-to-bounds"
+import {
+  getComparisonBounds,
+  getReferenceObjectPosition,
+  REFERENCE_OBJECT_CLEARANCE_MM,
+  REFERENCE_OBJECT_OPTIONS,
+  REFERENCE_OBJECT_SPECS,
+} from "../src/reference-objects/reference-object"
+
+describe("reference object placement", () => {
+  const boardDimensions = { width: 50, height: 40 }
+  const boardCenter = { x: 12, y: -8 }
+
+  test("exposes the requested context menu choices", () => {
+    expect(REFERENCE_OBJECT_OPTIONS.map(({ label }) => label)).toEqual([
+      "Show Banana",
+      "Show Credit Card",
+      "Show 14in Macbook",
+    ])
+  })
+
+  for (const option of REFERENCE_OBJECT_OPTIONS) {
+    test(`places the ${option.type} beside the board with clearance`, () => {
+      const position = getReferenceObjectPosition(
+        option.type,
+        boardDimensions,
+        boardCenter,
+      )
+      const boardRight = boardCenter.x + boardDimensions.width / 2
+      const referenceLeft = position.x - option.width / 2
+
+      expect(referenceLeft - boardRight).toBe(REFERENCE_OBJECT_CLEARANCE_MM)
+      expect(position.y).toBe(boardCenter.y)
+
+      const object = createReferenceObject(option.type)
+      object.position.set(position.x, position.y, position.z)
+      object.updateMatrixWorld(true)
+      const actualBounds = new THREE.Box3().setFromObject(object)
+      expect(actualBounds.min.x).toBeGreaterThan(boardRight)
+      disposeReferenceObject(object)
+    })
+  }
+
+  test("uses standard credit-card and 14-inch MacBook dimensions", () => {
+    expect(REFERENCE_OBJECT_SPECS["credit-card"]).toMatchObject({
+      width: 85.6,
+      height: 53.98,
+      depth: 0.76,
+    })
+    expect(REFERENCE_OBJECT_SPECS["14in-macbook"]).toMatchObject({
+      width: 312.6,
+      height: 221.2,
+      depth: 15.5,
+    })
+  })
+})
+
+describe("comparison camera fit", () => {
+  const bounds = getComparisonBounds(
+    "14in-macbook",
+    { width: 50, height: 40 },
+    { x: 0, y: 0 },
+  )
+
+  test("centers and backs up a perspective camera", () => {
+    const camera = new THREE.PerspectiveCamera(75, 16 / 9, 0.1, 1000)
+    camera.position.set(20, -40, 50)
+    const controls = {
+      target: new THREE.Vector3(),
+      update: () => {},
+    }
+    const result = fitCameraToBounds(camera, controls, bounds)
+
+    expect(controls.target.distanceTo(result.center)).toBeLessThan(0.0001)
+    expect(camera.position.distanceTo(result.center)).toBeCloseTo(
+      result.distance,
+      5,
+    )
+    expect(result.distance).toBeGreaterThan(result.radius)
+  })
+
+  test("zooms an orthographic camera to include the comparison", () => {
+    const camera = new THREE.OrthographicCamera(-16, 16, 10, -10, -1000, 1000)
+    camera.position.set(20, -40, 50)
+    const controls = {
+      target: new THREE.Vector3(),
+      update: () => {},
+    }
+
+    fitCameraToBounds(camera, controls, bounds)
+
+    expect(camera.zoom).toBeGreaterThan(0)
+    expect(camera.zoom).toBeLessThan(1)
+  })
+})


### PR DESCRIPTION
## Summary

- add a nested `Show Reference Object` context menu with banana, credit card, and 14-inch MacBook choices
- render procedural reference geometry at real-world millimeter scale with a fixed clearance beside the PCB
- fit the camera to a readable elevated comparison view and retain the selection across Manifold/JSCAD engine switches
- keep reference geometry outside the export root so it is not included in downloaded GLTF files
- use actual board-outline bounds when positioning the comparison object

Credit-card dimensions follow ISO/IEC 7810 ID-1. The MacBook model uses Apple's published 14-inch MacBook Pro exterior dimensions.

## Testing

- `bunx tsc --noEmit`
- `bun run build`
- focused reference-object placement, camera-fit, and scene-lifecycle tests
- interactive Storybook verification for banana, credit card, and MacBook comparisons
- interactive verification with both Manifold and JSCAD engines
