### PR TITLE
Add Show Grid context menu toggle

### DIFF
--- a/src/CadViewerContainer.tsx
+++ b/src/CadViewerContainer.tsx
@@ -9,6 +9,7 @@ import type { CameraController } from "./hooks/cameraAnimation"
 import { CameraAnimatorWithContext } from "./hooks/cameraAnimation"
 import { useCameraSession } from "./hooks/useCameraSession"
 import { Canvas } from "./react-three/Canvas"
+import { Grid } from "./react-three/Grid"
 import { Lights } from "./react-three/Lights"
 import { OrbitControls } from "./react-three/OrbitControls"
 import { useFrame, useThree } from "./react-three/ThreeContext"
@@ -65,7 +66,8 @@ export const CadViewerContainer = forwardRef<
 
     const { mainCameraRef, handleControlsChange, controller } =
       useCameraController()
-    const { darkBackgroundEnabled, lightingEnabled } = useAppearance()
+    const { darkBackgroundEnabled, gridEnabled, lightingEnabled } =
+      useAppearance()
     const {
       handleCameraCreated,
       handleControlsChange: handleSessionControlsChange,
@@ -76,6 +78,13 @@ export const CadViewerContainer = forwardRef<
         onCameraControllerReady(controller)
       }
     }, [controller, onCameraControllerReady])
+
+    const gridSectionSize = useMemo(() => {
+      if (!boardDimensions) return 10
+      const width = boardDimensions.width ?? 0
+      const height = boardDimensions.height ?? 0
+      return Math.max(Math.max(width, height) * 1.5, 10)
+    }, [boardDimensions])
 
     const orbitTarget = useMemo(() => {
       if (!boardCenter) return undefined
@@ -119,6 +128,14 @@ export const CadViewerContainer = forwardRef<
             darkBackgroundEnabled={darkBackgroundEnabled}
             shadowsEnabled={lightingEnabled}
           />
+          {gridEnabled && (
+            <Grid
+              rotation={[Math.PI / 2, 0, 0]}
+              infiniteGrid
+              cellSize={3}
+              sectionSize={gridSectionSize}
+            />
+          )}
           {children}
         </Canvas>
         <div

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -4,6 +4,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import { AppearanceMenu } from "./AppearanceMenu"
 import type { CameraPreset } from "../hooks/cameraAnimation"
 import { useCameraController } from "../contexts/CameraControllerContext"
+import { useAppearance } from "../contexts/appearance-context"
 import packageJson from "../../package.json"
 import { CheckIcon, ChevronRightIcon, DotIcon } from "./Icons"
 import { zIndexMap } from "../../lib/utils/z-index-map"
@@ -112,6 +113,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   onOpenKeyboardShortcuts,
 }) => {
   const { cameraType, setCameraType } = useCameraController()
+  const { gridEnabled, setGridEnabled } = useAppearance()
   const [cameraSubOpen, setCameraSubOpen] = useState(false)
   const [hoveredItem, setHoveredItem] = useState<string | null>(null)
 
@@ -256,6 +258,30 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
               </span>
               <span style={{ display: "flex", alignItems: "center" }}>
                 Orthographic Camera
+              </span>
+            </DropdownMenu.Item>
+
+            {/* Grid Toggle */}
+            <DropdownMenu.Item
+              style={{
+                ...itemStyles,
+                backgroundColor:
+                  hoveredItem === "grid" ? "#404040" : "transparent",
+              }}
+              onSelect={(e) => e.preventDefault()}
+              onPointerDown={(e) => {
+                e.preventDefault()
+                setGridEnabled(!gridEnabled)
+              }}
+              onMouseEnter={() => setHoveredItem("grid")}
+              onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("grid")}
+            >
+              <span style={iconContainerStyles}>
+                {gridEnabled && <CheckIcon />}
+              </span>
+              <span style={{ display: "flex", alignItems: "center" }}>
+                Show Grid
               </span>
             </DropdownMenu.Item>
 

--- a/src/contexts/appearance-context.tsx
+++ b/src/contexts/appearance-context.tsx
@@ -4,6 +4,8 @@ import { createContext, useContext, useEffect, useMemo, useState } from "react"
 interface AppearanceContextType {
   darkBackgroundEnabled: boolean
   setDarkBackgroundEnabled: (enabled: boolean) => void
+  gridEnabled: boolean
+  setGridEnabled: (enabled: boolean) => void
   lightingEnabled: boolean
   setLightingEnabled: (enabled: boolean) => void
 }
@@ -25,6 +27,7 @@ export const AppearanceProvider: React.FC<{ children: React.ReactNode }> = ({
   // Transparent is the default. The dark studio backdrop is an opt-in review
   // aid and intentionally does not persist between new viewer sessions.
   const [darkBackgroundEnabled, setDarkBackgroundEnabled] = useState(false)
+  const [gridEnabled, setGridEnabled] = useState(false)
   const [lightingEnabled, setLightingEnabled] = useState<boolean>(
     readStoredLightingEnabled,
   )
@@ -40,10 +43,12 @@ export const AppearanceProvider: React.FC<{ children: React.ReactNode }> = ({
     () => ({
       darkBackgroundEnabled,
       setDarkBackgroundEnabled,
+      gridEnabled,
+      setGridEnabled,
       lightingEnabled,
       setLightingEnabled,
     }),
-    [darkBackgroundEnabled, lightingEnabled],
+    [darkBackgroundEnabled, gridEnabled, lightingEnabled],
   )
 
   return (

--- a/tests/grid-toggle.test.tsx
+++ b/tests/grid-toggle.test.tsx
@@ -1,0 +1,123 @@
+import { expect, test } from "bun:test"
+import { JSDOM } from "jsdom"
+import { createRef } from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import * as THREE from "three"
+import {
+  AppearanceProvider,
+  useAppearance,
+} from "../src/contexts/appearance-context"
+import { CameraControllerProvider } from "../src/contexts/CameraControllerContext"
+import { LayerVisibilityProvider } from "../src/contexts/LayerVisibilityContext"
+
+const GridStateProbe = () => {
+  const { gridEnabled } = useAppearance()
+  return <div data-grid-enabled={gridEnabled} />
+}
+
+test("Show Grid toggles the grid appearance setting", async () => {
+  const dom = new JSDOM('<div id="root"></div>', {
+    url: "http://localhost",
+  })
+  const previousGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    Element: globalThis.Element,
+    Event: globalThis.Event,
+    CustomEvent: globalThis.CustomEvent,
+    HTMLElement: globalThis.HTMLElement,
+    MutationObserver: globalThis.MutationObserver,
+    Node: globalThis.Node,
+    getComputedStyle: globalThis.getComputedStyle,
+  }
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    Element: dom.window.Element,
+    Event: dom.window.Event,
+    CustomEvent: dom.window.CustomEvent,
+    HTMLElement: dom.window.HTMLElement,
+    MutationObserver: dom.window.MutationObserver,
+    Node: dom.window.Node,
+    getComputedStyle: dom.window.getComputedStyle,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })
+
+  const { ContextMenu } = await import("../src/components/ContextMenu")
+
+  const container = document.getElementById("root")!
+  const reactRoot = createRoot(container)
+
+  try {
+    await act(async () => {
+      reactRoot.render(
+        <CameraControllerProvider defaultTarget={new THREE.Vector3()}>
+          <LayerVisibilityProvider>
+            <AppearanceProvider>
+              <ContextMenu
+                menuRef={createRef<HTMLDivElement>()}
+                menuPos={{ x: 0, y: 0 }}
+                engine="manifold"
+                cameraPreset="Custom"
+                autoRotate={false}
+                onEngineSwitch={() => {}}
+                onCameraPresetSelect={() => {}}
+                onAutoRotateToggle={() => {}}
+                onDownloadGltf={() => {}}
+                onOpenKeyboardShortcuts={() => {}}
+              />
+              <GridStateProbe />
+            </AppearanceProvider>
+          </LayerVisibilityProvider>
+        </CameraControllerProvider>,
+      )
+    })
+
+    const stateProbe = document.querySelector("[data-grid-enabled]")!
+    expect(stateProbe.getAttribute("data-grid-enabled")).toBe("false")
+
+    await act(
+      () => new Promise<void>((resolve) => dom.window.setTimeout(resolve, 0)),
+    )
+
+    const showGridLabel = Array.from(document.querySelectorAll("span")).find(
+      (element) => element.textContent === "Show Grid",
+    )
+    expect(showGridLabel).toBeDefined()
+
+    const showGridItem = showGridLabel!.closest('[role="menuitem"]')!
+    await act(async () => {
+      showGridItem.dispatchEvent(
+        new dom.window.Event("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    })
+
+    expect(stateProbe.getAttribute("data-grid-enabled")).toBe("true")
+    expect(showGridItem.querySelector("svg")).not.toBeNull()
+
+    await act(async () => {
+      showGridItem.dispatchEvent(
+        new dom.window.Event("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    })
+
+    expect(stateProbe.getAttribute("data-grid-enabled")).toBe("false")
+    expect(showGridItem.querySelector("svg")).toBeNull()
+  } finally {
+    await act(async () => reactRoot.unmount())
+    await new Promise<void>((resolve) => dom.window.setTimeout(resolve, 0))
+    Object.assign(globalThis, {
+      ...previousGlobals,
+      IS_REACT_ACT_ENVIRONMENT: false,
+    })
+    dom.window.close()
+  }
+})


### PR DESCRIPTION
## Summary
- restore the existing adaptive 3D grid as an opt-in viewer appearance setting
- add a checked Show Grid item to the right-click context menu
- keep the grid disabled by default and share it across both rendering engines
- cover enabling and disabling the setting with an interaction test

## Validation
- bun test tests/grid-toggle.test.tsx
- bunx tsc --noEmit
- bun run build
- Biome formatting and git diff checks

## Test-suite note
The complete suite currently reports 28 passing and 5 unrelated failures. The same faux-board and SVG snapshot failures reproduce on a clean main checkout with the currently resolved dependencies.