### PR TITLE
Fix reference object toggle

### DIFF
--- a/src/CadViewer.tsx
+++ b/src/CadViewer.tsx
@@ -35,7 +35,10 @@ import {
   registerHotkeyViewer,
   useRegisteredHotkey,
 } from "./hooks/useRegisteredHotkey"
-import type { ReferenceObjectType } from "./reference-objects/reference-object"
+import {
+  type ReferenceObjectType,
+  toggleReferenceObject,
+} from "./reference-objects/reference-object"
 
 const CadViewerInner = (props: any) => {
   const [engine, setEngine] = useState<"jscad" | "manifold">(() => {
@@ -294,7 +297,12 @@ const CadViewerInner = (props: any) => {
             closeMenu()
           }}
           onReferenceObjectSelect={(nextReferenceObject) => {
-            setReferenceObject(nextReferenceObject)
+            setReferenceObject((currentReferenceObject) =>
+              toggleReferenceObject(
+                currentReferenceObject,
+                nextReferenceObject,
+              ),
+            )
             setAutoRotate(false)
             setAutoRotateUserToggled(true)
             setCameraPreset("Custom")

--- a/src/reference-objects/reference-object.ts
+++ b/src/reference-objects/reference-object.ts
@@ -66,6 +66,11 @@ export const REFERENCE_OBJECT_SPECS: Record<
 
 export const REFERENCE_OBJECT_OPTIONS = Object.values(REFERENCE_OBJECT_SPECS)
 
+export const toggleReferenceObject = (
+  current: ReferenceObjectType | null,
+  selected: ReferenceObjectType,
+): ReferenceObjectType | null => (current === selected ? null : selected)
+
 const safeDimension = (dimension: number | undefined) =>
   Number.isFinite(dimension) ? Math.max(dimension ?? 0, 0) : 0
 

--- a/tests/reference-object.test.ts
+++ b/tests/reference-object.test.ts
@@ -11,6 +11,7 @@ import {
   REFERENCE_OBJECT_CLEARANCE_MM,
   REFERENCE_OBJECT_OPTIONS,
   REFERENCE_OBJECT_SPECS,
+  toggleReferenceObject,
 } from "../src/reference-objects/reference-object"
 
 describe("reference object placement", () => {
@@ -23,6 +24,12 @@ describe("reference object placement", () => {
       "Show Credit Card",
       "Show 14in Macbook",
     ])
+  })
+
+  test("toggles the selected reference object", () => {
+    expect(toggleReferenceObject(null, "banana")).toBe("banana")
+    expect(toggleReferenceObject("banana", "banana")).toBeNull()
+    expect(toggleReferenceObject("banana", "credit-card")).toBe("credit-card")
   })
 
   for (const option of REFERENCE_OBJECT_OPTIONS) {


### PR DESCRIPTION
## Summary

- toggle the active reference object off when its menu item is selected again
- keep switching directly between different reference objects working
- add regression coverage for enable, disable, and switch transitions

## Root cause

The reference-object selection handler always replaced state with the selected type. Selecting the already-active type therefore left the state unchanged instead of clearing it.

## Impact

Users can now click the active reference object option a second time to remove it from the 3D viewer.

## Validation

- `bun test tests/reference-object.test.ts tests/reference-object-scene.test.tsx tests/grid-toggle.test.tsx` (12 pass)
- `./node_modules/.bin/tsc --noEmit`
- `bun run format:check`
- `bun run build`
- Full `bun test`: 39 pass, 5 unrelated failures in existing faux-board offset and SVG snapshot expectations under the freshly resolved dependency set