### PR TITLE
update circuit-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
-    "circuit-json": "^0.0.446",
+    "circuit-json": "^0.0.465",
     "circuit-to-canvas": "^0.0.118",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",

--- a/src/textures/copper-text/copper-text-drawing.ts
+++ b/src/textures/copper-text/copper-text-drawing.ts
@@ -46,6 +46,8 @@ export const drawCopperTextLayer = ({
         inner4: copperColor,
         inner5: copperColor,
         inner6: copperColor,
+        inner7: copperColor,
+        inner8: copperColor,
       },
     },
   })
@@ -78,6 +80,8 @@ export const drawCopperTextLayer = ({
         inner4: "rgb(255,255,255)",
         inner5: "rgb(255,255,255)",
         inner6: "rgb(255,255,255)",
+        inner7: "rgb(255,255,255)",
+        inner8: "rgb(255,255,255)",
       },
     },
   })

--- a/src/textures/create-copper-pour-texture-for-layer.ts
+++ b/src/textures/create-copper-pour-texture-for-layer.ts
@@ -107,6 +107,8 @@ export function createCopperPourTextureForLayer({
           inner4: copperPourColor,
           inner5: copperPourColor,
           inner6: copperPourColor,
+          inner7: copperPourColor,
+          inner8: copperPourColor,
         },
         copperPour: {
           top: transparent,

--- a/src/textures/fabrication-note/fabrication-note-drawing.ts
+++ b/src/textures/fabrication-note/fabrication-note-drawing.ts
@@ -83,6 +83,8 @@ export const drawFabricationNoteLayer = ({
         inner4: TRANSPARENT,
         inner5: TRANSPARENT,
         inner6: TRANSPARENT,
+        inner7: TRANSPARENT,
+        inner8: TRANSPARENT,
       },
       copperPour: {
         top: TRANSPARENT,

--- a/src/textures/pcb-note/pcb-note-drawing.ts
+++ b/src/textures/pcb-note/pcb-note-drawing.ts
@@ -110,6 +110,8 @@ export const drawPcbNoteLayer = ({
         inner4: TRANSPARENT,
         inner5: TRANSPARENT,
         inner6: TRANSPARENT,
+        inner7: TRANSPARENT,
+        inner8: TRANSPARENT,
       },
       copperPour: { top: TRANSPARENT, bottom: TRANSPARENT },
       drill: TRANSPARENT,

--- a/src/textures/silkscreen/silkscreen-drawing.ts
+++ b/src/textures/silkscreen/silkscreen-drawing.ts
@@ -45,6 +45,8 @@ export const drawSilkscreenLayer = ({
         inner4: TRANSPARENT,
         inner5: TRANSPARENT,
         inner6: TRANSPARENT,
+        inner7: TRANSPARENT,
+        inner8: TRANSPARENT,
       },
       copperPour: {
         top: TRANSPARENT,

--- a/src/textures/soldermask/soldermask-drawing.ts
+++ b/src/textures/soldermask/soldermask-drawing.ts
@@ -85,6 +85,8 @@ export const drawSoldermaskLayer = ({
         inner4: palette.transparent,
         inner5: palette.transparent,
         inner6: palette.transparent,
+        inner7: palette.transparent,
+        inner8: palette.transparent,
       },
       drill: palette.transparent,
       boardOutline: palette.transparent,
@@ -138,6 +140,8 @@ export const drawSoldermaskLayer = ({
           inner4: palette.copper,
           inner5: palette.copper,
           inner6: palette.copper,
+          inner7: palette.copper,
+          inner8: palette.copper,
         },
       },
     })

--- a/src/textures/through-hole/through-hole-drawing.ts
+++ b/src/textures/through-hole/through-hole-drawing.ts
@@ -43,6 +43,8 @@ export const drawThroughHoleLayer = ({
         inner4: copperColor,
         inner5: copperColor,
         inner6: copperColor,
+        inner7: copperColor,
+        inner8: copperColor,
       },
       drill: transparent,
       boardOutline: transparent,

--- a/src/utils/pad-texture.ts
+++ b/src/utils/pad-texture.ts
@@ -65,6 +65,8 @@ export function createPadTextureForLayer({
         inner4: copperColor,
         inner5: copperColor,
         inner6: copperColor,
+        inner7: copperColor,
+        inner8: copperColor,
       },
       copperPour: { top: transparent, bottom: transparent },
       drill: transparent,

--- a/src/utils/trace-texture.ts
+++ b/src/utils/trace-texture.ts
@@ -70,6 +70,8 @@ export function createTraceTextureForLayer({
         inner4: traceColor,
         inner5: traceColor,
         inner6: traceColor,
+        inner7: traceColor,
+        inner8: traceColor,
       },
       copperPour: { top: transparent, bottom: transparent },
       drill: transparent,


### PR DESCRIPTION
motivation: 

ref: https://github.com/tscircuit/tscircuit.com/pull/4325


We updated circuit-json because the older version caused a dependency mismatch and broke the tscircuit.com build. The latest version supports PCB boards with up to eight inner copper layers, so it requires color settings for inner7 and inner8; those two entries were added to make 3d-viewer compatible with the updated types and render those layers consistently.