### PR TITLE
Preserve embedded OBJ material colors

### DIFF
--- a/src/hooks/use-global-obj-loader.ts
+++ b/src/hooks/use-global-obj-loader.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import { loadVrml } from "src/utils/vrml"
 import type { Object3D } from "three"
 import { MTLLoader, OBJLoader } from "three-stdlib"
-import { loadVrml } from "src/utils/vrml"
 
 // Define the type for our cache
 interface CacheItem {
@@ -52,7 +52,9 @@ export function useGlobalObjLoader(
         const objLoader = new OBJLoader()
 
         if (mtlContentArr?.length) {
-          const mtlContent = mtlContentArr.join("\n").replace(/d 0\./g, "d 1.")
+          const mtlContent = mtlContentArr
+            .join("\n")
+            .replace(/^d\s+0\./gm, "d 1.")
           const objContent = text
             .replace(/newmtl[\s\S]*?endmtl/g, "")
             .replace(/^mtllib.*/gm, "")
@@ -61,13 +63,7 @@ export function useGlobalObjLoader(
           mtlLoader.setMaterialOptions({
             invertTrProperty: true,
           })
-          const materials = mtlLoader.parse(
-            mtlContent.replace(
-              /Kd\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/g,
-              "Kd $2 $2 $2",
-            ),
-            "embedded.mtl",
-          )
+          const materials = mtlLoader.parse(mtlContent, "embedded.mtl")
           objLoader.setMaterials(materials)
           return objLoader.parse(objContent)
         }

--- a/stories/A_1751251.stories.tsx
+++ b/stories/A_1751251.stories.tsx
@@ -1,0 +1,61 @@
+import "tscircuit"
+import { CadViewer } from "src/CadViewer"
+
+const objUrl =
+  "https://modelcdn.tscircuit.com/easyeda_models/assets/C91152.obj?uuid=0b4d57e4edc5417eb4c2c3fd5c88e90f"
+const stepUrl =
+  "https://modelcdn.tscircuit.com/easyeda_models/assets/C91152.step?uuid=0b4d57e4edc5417eb4c2c3fd5c88e90f"
+
+export const A_1751251 = () => (
+  <CadViewer>
+    <board width="16mm" height="12mm">
+      <chip
+        name="A_1751251"
+        footprint={
+          <footprint>
+            <platedhole
+              portHints={["pin1"]}
+              pcbX="-3.50012mm"
+              pcbY="0mm"
+              outerDiameter="2.1999956mm"
+              holeDiameter="1.400048mm"
+              shape="circle"
+            />
+            <platedhole
+              portHints={["pin2"]}
+              pcbX="0mm"
+              pcbY="0mm"
+              outerDiameter="2.1999956mm"
+              holeDiameter="1.400048mm"
+              shape="circle"
+            />
+            <platedhole
+              portHints={["pin3"]}
+              pcbX="3.50012mm"
+              pcbY="0mm"
+              outerDiameter="2.1999956mm"
+              holeDiameter="1.400048mm"
+              shape="circle"
+            />
+          </footprint>
+        }
+        cadModel={{
+          objUrl,
+          stepUrl,
+          pcbRotationOffset: 0,
+          modelOriginPosition: {
+            x: 3.5,
+            y: 0.000012700000070253736,
+            z: -4.250007,
+          },
+        }}
+      />
+    </board>
+  </CadViewer>
+)
+
+A_1751251.storyName = "A_1751251 Color Preservation"
+
+export default {
+  title: "Bugs/Embedded OBJ Material Colors",
+}


### PR DESCRIPTION
## Summary

- Preserve embedded OBJ `Kd` RGB values in the live 3D viewer.
- Restrict alpha normalization to standalone MTL `d` directives.
- Add an `A_1751251` Storybook regression story for embedded OBJ material colors.
  
### Before
<img width="621" height="499" alt="image" src="https://github.com/user-attachments/assets/90ad7708-6edd-417a-8462-2329156fd1bd" />

### After
<img width="879" height="690" alt="image" src="https://github.com/user-attachments/assets/1ded0b46-d2b8-442b-b61b-8f71f8581b74" />


## Root cause

The previous unanchored `d 0.` replacement also matched the `d 0.` substring inside `Kd 0.`, changing the red channel and turning the cyan model light pink. The earlier RGB-to-grayscale rewrite is removed as well.

## Validation

- `bunx biome check src/hooks/use-global-obj-loader.ts stories/A_1751251.stories.tsx`
- `bun run build`
- `bun test tests/cad-model-transform.test.ts` — 11 passed
- `bun test` — 39 passed, 5 existing snapshot/outline and faux-board Z-offset failures remain
