### PR TITLE
Add None reference object option

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -7,7 +7,7 @@ import { useAppearance } from "../contexts/appearance-context"
 import { useCameraController } from "../contexts/CameraControllerContext"
 import type { CameraPreset } from "../hooks/cameraAnimation"
 import {
-  REFERENCE_OBJECT_OPTIONS,
+  REFERENCE_OBJECT_MENU_OPTIONS,
   type ReferenceObjectType,
 } from "../reference-objects/reference-object"
 import { AppearanceMenu } from "./AppearanceMenu"
@@ -23,7 +23,9 @@ interface ContextMenuProps {
   onEngineSwitch: (engine: "jscad" | "manifold") => void
   onCameraPresetSelect: (preset: CameraPreset) => void
   onAutoRotateToggle: () => void
-  onReferenceObjectSelect?: (referenceObject: ReferenceObjectType) => void
+  onReferenceObjectSelect?: (
+    referenceObject: ReferenceObjectType | null,
+  ) => void
   onDownloadGltf: () => void
   onOpenKeyboardShortcuts: () => void
 }
@@ -308,33 +310,36 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
                   collisionPadding={10}
                   avoidCollisions={true}
                 >
-                  {REFERENCE_OBJECT_OPTIONS.map((option) => (
-                    <DropdownMenu.Item
-                      key={option.type}
-                      style={{
-                        ...itemStyles,
-                        backgroundColor:
-                          hoveredItem === option.type
-                            ? "#404040"
-                            : "transparent",
-                      }}
-                      onSelect={(event) => event.preventDefault()}
-                      onPointerDown={(event) => {
-                        event.preventDefault()
-                        onReferenceObjectSelect(option.type)
-                      }}
-                      onMouseEnter={() => setHoveredItem(option.type)}
-                      onMouseLeave={() => setHoveredItem(null)}
-                      onTouchStart={() => setHoveredItem(option.type)}
-                    >
-                      <span style={iconContainerStyles}>
-                        {referenceObject === option.type && <DotIcon />}
-                      </span>
-                      <span style={{ display: "flex", alignItems: "center" }}>
-                        {option.label}
-                      </span>
-                    </DropdownMenu.Item>
-                  ))}
+                  {REFERENCE_OBJECT_MENU_OPTIONS.map((option) => {
+                    const optionKey = option.type ?? "none"
+                    return (
+                      <DropdownMenu.Item
+                        key={optionKey}
+                        style={{
+                          ...itemStyles,
+                          backgroundColor:
+                            hoveredItem === optionKey
+                              ? "#404040"
+                              : "transparent",
+                        }}
+                        onSelect={(event) => event.preventDefault()}
+                        onPointerDown={(event) => {
+                          event.preventDefault()
+                          onReferenceObjectSelect(option.type)
+                        }}
+                        onMouseEnter={() => setHoveredItem(optionKey)}
+                        onMouseLeave={() => setHoveredItem(null)}
+                        onTouchStart={() => setHoveredItem(optionKey)}
+                      >
+                        <span style={iconContainerStyles}>
+                          {referenceObject === option.type && <DotIcon />}
+                        </span>
+                        <span style={{ display: "flex", alignItems: "center" }}>
+                          {option.label}
+                        </span>
+                      </DropdownMenu.Item>
+                    )
+                  })}
                 </DropdownMenu.SubContent>
               </DropdownMenu.Portal>
             </DropdownMenu.Sub>

--- a/src/reference-objects/reference-object.ts
+++ b/src/reference-objects/reference-object.ts
@@ -66,9 +66,14 @@ export const REFERENCE_OBJECT_SPECS: Record<
 
 export const REFERENCE_OBJECT_OPTIONS = Object.values(REFERENCE_OBJECT_SPECS)
 
+export const REFERENCE_OBJECT_MENU_OPTIONS: Array<{
+  type: ReferenceObjectType | null
+  label: string
+}> = [{ type: null, label: "None" }, ...REFERENCE_OBJECT_OPTIONS]
+
 export const toggleReferenceObject = (
   current: ReferenceObjectType | null,
-  selected: ReferenceObjectType,
+  selected: ReferenceObjectType | null,
 ): ReferenceObjectType | null => (current === selected ? null : selected)
 
 const safeDimension = (dimension: number | undefined) =>

--- a/tests/reference-object.test.ts
+++ b/tests/reference-object.test.ts
@@ -9,6 +9,7 @@ import {
   getComparisonBounds,
   getReferenceObjectPosition,
   REFERENCE_OBJECT_CLEARANCE_MM,
+  REFERENCE_OBJECT_MENU_OPTIONS,
   REFERENCE_OBJECT_OPTIONS,
   REFERENCE_OBJECT_SPECS,
   toggleReferenceObject,
@@ -19,7 +20,8 @@ describe("reference object placement", () => {
   const boardCenter = { x: 12, y: -8 }
 
   test("exposes the requested context menu choices", () => {
-    expect(REFERENCE_OBJECT_OPTIONS.map(({ label }) => label)).toEqual([
+    expect(REFERENCE_OBJECT_MENU_OPTIONS.map(({ label }) => label)).toEqual([
+      "None",
       "Show Banana",
       "Show Credit Card",
       "Show 14in Macbook",
@@ -30,6 +32,7 @@ describe("reference object placement", () => {
     expect(toggleReferenceObject(null, "banana")).toBe("banana")
     expect(toggleReferenceObject("banana", "banana")).toBeNull()
     expect(toggleReferenceObject("banana", "credit-card")).toBe("credit-card")
+    expect(toggleReferenceObject("banana", null)).toBeNull()
   })
 
   for (const option of REFERENCE_OBJECT_OPTIONS) {


### PR DESCRIPTION
## Summary

- add a `None` entry to the **Show Reference Object** submenu
- allow reference-object selection callbacks to clear the selected object
- show the selection indicator next to `None` when no reference object is visible
- cover the new menu entry and clear behavior in the reference-object tests

## Why

The viewer already represented a hidden reference object with `null`, but the menu only exposed concrete objects. Users had to reselect the active object to hide it, which was not discoverable. The explicit `None` option makes hiding the comparison object clear and consistent.

## Validation

- `bun test tests/reference-object.test.ts tests/reference-object-scene.test.tsx tests/grid-toggle.test.tsx` — 12 passed
- `bun run build` — passed
- `bunx biome format src/components/ContextMenu.tsx src/reference-objects/reference-object.ts tests/reference-object.test.ts` — passed

The full `bun test` run has 5 unrelated failures in existing preprocessing and SVG snapshot tests under the freshly resolved dependency set; 39 tests pass.