### PR TITLE
Add appearance controls for the assembled enclosure

### DIFF
--- a/src/AnyCadComponent.tsx
+++ b/src/AnyCadComponent.tsx
@@ -23,6 +23,7 @@ import {
   getCadModelType,
   getRenderedCadModelType,
 } from "./utils/get-cad-model-type"
+import { isLegacyFdmEnclosure } from "./utils/is-legacy-fdm-enclosure"
 import { resolveModelUrl } from "./utils/resolve-model-url"
 import { tuple } from "./utils/tuple"
 import { ThreeErrorBoundary } from "./three-components/ThreeErrorBoundary"
@@ -117,6 +118,13 @@ export const AnyCadComponent = ({
       elm.source_component_id === cad_component.source_component_id,
   ) as PcbComponent | undefined
   const layer = pcbComponent?.layer ?? "top"
+  const isEnclosure = useMemo(
+    () => isLegacyFdmEnclosure(cad_component, circuitJson),
+    [cad_component, circuitJson],
+  )
+  const isTranslucent = isEnclosure
+    ? visibility.enclosure === "translucent"
+    : Boolean(cad_component.show_as_translucent_model)
   const sourceModelType = getCadModelType(cad_component)
   const renderedModelType = getRenderedCadModelType(sourceModelType)
   const gltfModelType: CadModelType = cad_component.model_glb_url
@@ -162,7 +170,7 @@ export const AnyCadComponent = ({
           onHover={handleHover}
           onUnhover={handleUnhover}
           isHovered={isHovered}
-          isTranslucent={cad_component.show_as_translucent_model}
+          isTranslucent={isTranslucent}
         />,
       )
     }
@@ -185,7 +193,7 @@ export const AnyCadComponent = ({
           onHover={handleHover}
           onUnhover={handleUnhover}
           isHovered={isHovered}
-          isTranslucent={cad_component.show_as_translucent_model}
+          isTranslucent={isTranslucent}
         />,
       )
     }
@@ -212,7 +220,7 @@ export const AnyCadComponent = ({
           onHover={handleHover}
           onUnhover={handleUnhover}
           isHovered={isHovered}
-          isTranslucent={cad_component.show_as_translucent_model}
+          isTranslucent={isTranslucent}
         />,
       )
     }
@@ -223,7 +231,7 @@ export const AnyCadComponent = ({
     cad_component.cad_component_id,
     cad_component.footprinter_string,
     cad_component.model_jscad,
-    cad_component.show_as_translucent_model,
+    isTranslucent,
     gltfUrl,
     gltfModelType,
     handleHover,
@@ -287,7 +295,7 @@ export const AnyCadComponent = ({
         onHover={handleHover}
         onUnhover={handleUnhover}
         isHovered={isHovered}
-        isTranslucent={cad_component.show_as_translucent_model}
+        isTranslucent={isTranslucent}
       />
     )
   } else if (cad_component.footprinter_string) {
@@ -300,25 +308,20 @@ export const AnyCadComponent = ({
         onHover={handleHover}
         onUnhover={handleUnhover}
         isHovered={isHovered}
-        isTranslucent={cad_component.show_as_translucent_model}
+        isTranslucent={isTranslucent}
       />
     )
   }
 
-  // Check if models should be visible
-  // Translucent models are controlled only by translucent visibility
-  if (cad_component.show_as_translucent_model) {
-    if (!visibility.translucentModels) {
-      return null
-    }
+  // The generated enclosure gets its own three-state display control. Other CAD
+  // models retain the existing translucent/SMT/through-hole category toggles.
+  if (isEnclosure) {
+    if (visibility.enclosure === "hidden") return null
+  } else if (cad_component.show_as_translucent_model) {
+    if (!visibility.translucentModels) return null
   } else {
-    // Non-translucent models are controlled by SMT/through-hole visibility
-    if (isThroughHole && !visibility.throughHoleModels) {
-      return null
-    }
-    if (!isThroughHole && !visibility.smtModels) {
-      return null
-    }
+    if (isThroughHole && !visibility.throughHoleModels) return null
+    if (!isThroughHole && !visibility.smtModels) return null
   }
 
   // Render the model and the tooltip if hovered

--- a/src/components/AppearanceMenu.tsx
+++ b/src/components/AppearanceMenu.tsx
@@ -3,8 +3,11 @@ import type React from "react"
 import { useState } from "react"
 import { zIndexMap } from "../../lib/utils/z-index-map"
 import { useAppearance } from "../contexts/appearance-context"
-import { useLayerVisibility } from "../contexts/LayerVisibilityContext"
-import { CheckIcon, ChevronRightIcon } from "./Icons"
+import {
+  nextEnclosureVisibility,
+  useLayerVisibility,
+} from "../contexts/LayerVisibilityContext"
+import { CheckIcon, CheckMinusIcon, ChevronRightIcon } from "./Icons"
 
 const itemStyles: React.CSSProperties = {
   padding: "6px 8px",
@@ -418,6 +421,36 @@ export const AppearanceMenu = () => {
               </span>
               <span style={{ display: "flex", alignItems: "center" }}>
                 Through-Hole Components
+              </span>
+            </DropdownMenu.Item>
+
+            <DropdownMenu.Separator style={separatorStyles} />
+
+            <DropdownMenu.Item
+              style={{
+                ...itemStyles,
+                backgroundColor:
+                  hoveredItem === "enclosure" ? "#404040" : "transparent",
+              }}
+              onSelect={(e) => e.preventDefault()}
+              onPointerDown={(e) => {
+                e.preventDefault()
+                setLayerVisibility(
+                  "enclosure",
+                  nextEnclosureVisibility(visibility.enclosure),
+                )
+              }}
+              onMouseEnter={() => setHoveredItem("enclosure")}
+              onMouseLeave={() => setHoveredItem(null)}
+              onTouchStart={() => setHoveredItem("enclosure")}
+              title={`Enclosure: ${visibility.enclosure}`}
+            >
+              <span style={iconContainerStyles}>
+                {visibility.enclosure === "opaque" && <CheckIcon />}
+                {visibility.enclosure === "translucent" && <CheckMinusIcon />}
+              </span>
+              <span style={{ display: "flex", alignItems: "center" }}>
+                Enclosure
               </span>
             </DropdownMenu.Item>
           </DropdownMenu.SubContent>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -37,6 +37,23 @@ export const ChevronRightIcon = ({ isOpen }: { isOpen: boolean }) => (
   </svg>
 )
 
+/** Middle state of a hidden/translucent/opaque menu item. */
+export const CheckMinusIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M5 12h14" />
+  </svg>
+)
+
 export const DotIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/src/contexts/LayerVisibilityContext.tsx
+++ b/src/contexts/LayerVisibilityContext.tsx
@@ -28,13 +28,35 @@ export interface LayerVisibilityState {
   pcbNotes: boolean
   backgroundStart: boolean
   backgroundEnd: boolean
+  /**
+   * Three-state display for the single assembled enclosure CAD entity. This is
+   * viewer state, not Circuit JSON: hidden to work unobstructed, translucent to
+   * check openings against the board, opaque to inspect the print itself.
+   */
+  enclosure: EnclosureVisibility
 }
+
+export type EnclosureVisibility = "hidden" | "translucent" | "opaque"
+
+export const ENCLOSURE_VISIBILITY_CYCLE: EnclosureVisibility[] = [
+  "translucent",
+  "opaque",
+  "hidden",
+]
+
+export const nextEnclosureVisibility = (
+  current: EnclosureVisibility,
+): EnclosureVisibility =>
+  ENCLOSURE_VISIBILITY_CYCLE[
+    (ENCLOSURE_VISIBILITY_CYCLE.indexOf(current) + 1) %
+      ENCLOSURE_VISIBILITY_CYCLE.length
+  ]!
 
 interface LayerVisibilityContextType {
   visibility: LayerVisibilityState
-  setLayerVisibility: (
-    layer: keyof LayerVisibilityState,
-    visible: boolean,
+  setLayerVisibility: <K extends keyof LayerVisibilityState>(
+    layer: K,
+    visible: LayerVisibilityState[K],
   ) => void
   resetToDefaults: () => void
 }
@@ -60,6 +82,7 @@ const defaultVisibility: LayerVisibilityState = {
   pcbNotes: false,
   backgroundStart: true,
   backgroundEnd: true,
+  enclosure: "translucent",
 }
 
 const LayerVisibilityContext = createContext<
@@ -73,7 +96,10 @@ export const LayerVisibilityProvider: React.FC<{
     useState<LayerVisibilityState>(defaultVisibility)
 
   const setLayerVisibility = useCallback(
-    (layer: keyof LayerVisibilityState, visible: boolean) => {
+    <K extends keyof LayerVisibilityState>(
+      layer: K,
+      visible: LayerVisibilityState[K],
+    ) => {
       setVisibility((prev) => ({
         ...prev,
         [layer]: visible,

--- a/src/utils/is-legacy-fdm-enclosure.ts
+++ b/src/utils/is-legacy-fdm-enclosure.ts
@@ -5,7 +5,13 @@ import type {
 } from "circuit-json"
 
 /**
- * Recognize Core's pre-`cad_fdm_enclosure` compatibility representation.
+ * Discriminate Core's assembled enclosure from ordinary `cad_component` models.
+ *
+ * Before `cad_fdm_enclosure` exists, the enclosure uses the same
+ * `cad_component.model_jscad` record as any other generated CAD model. This
+ * predicate is what lets the viewer recognize that one record as an enclosure
+ * and give it the dedicated translucent / opaque / hidden Appearance control;
+ * without it, only the global translucent-model toggle is available.
  *
  * The generated enclosure is the only current CAD component whose PCB owner is
  * deliberately a do-not-place, off-board, non-obstructing placeholder and whose

--- a/src/utils/is-legacy-fdm-enclosure.ts
+++ b/src/utils/is-legacy-fdm-enclosure.ts
@@ -1,0 +1,41 @@
+import type {
+  AnyCircuitElement,
+  CadComponent,
+  PcbComponent,
+} from "circuit-json"
+
+/**
+ * Recognize Core's pre-`cad_fdm_enclosure` compatibility representation.
+ *
+ * The generated enclosure is the only current CAD component whose PCB owner is
+ * deliberately a zero-size, do-not-place, off-board, non-obstructing placeholder
+ * and whose exact JSCAD geometry is anchored at the outside floor. Keep this
+ * structural adapter isolated so the later typed record migration deletes one
+ * helper instead of spreading name/ID heuristics through the renderer.
+ */
+export const isLegacyFdmEnclosure = (
+  cadComponent: CadComponent,
+  circuitJson: AnyCircuitElement[],
+): boolean => {
+  if (
+    !cadComponent.model_jscad ||
+    cadComponent.model_origin_alignment !== "bottom_center_of_component"
+  ) {
+    return false
+  }
+
+  const pcbComponent = circuitJson.find(
+    (element): element is PcbComponent =>
+      element.type === "pcb_component" &&
+      element.pcb_component_id === cadComponent.pcb_component_id,
+  )
+
+  return Boolean(
+    pcbComponent &&
+      pcbComponent.width === 0 &&
+      pcbComponent.height === 0 &&
+      pcbComponent.do_not_place &&
+      pcbComponent.is_allowed_to_be_off_board &&
+      pcbComponent.obstructs_within_bounds === false,
+  )
+}

--- a/src/utils/is-legacy-fdm-enclosure.ts
+++ b/src/utils/is-legacy-fdm-enclosure.ts
@@ -8,8 +8,10 @@ import type {
  * Recognize Core's pre-`cad_fdm_enclosure` compatibility representation.
  *
  * The generated enclosure is the only current CAD component whose PCB owner is
- * deliberately a zero-size, do-not-place, off-board, non-obstructing placeholder
- * and whose exact JSCAD geometry is anchored at the outside floor. Keep this
+ * deliberately a do-not-place, off-board, non-obstructing placeholder and whose
+ * exact JSCAD geometry is anchored at the outside floor. Core initially creates
+ * that owner at zero size, then updates it to the resolved enclosure footprint,
+ * so final width/height cannot be used as the discriminator. Keep this
  * structural adapter isolated so the later typed record migration deletes one
  * helper instead of spreading name/ID heuristics through the renderer.
  */
@@ -32,8 +34,6 @@ export const isLegacyFdmEnclosure = (
 
   return Boolean(
     pcbComponent &&
-      pcbComponent.width === 0 &&
-      pcbComponent.height === 0 &&
       pcbComponent.do_not_place &&
       pcbComponent.is_allowed_to_be_off_board &&
       pcbComponent.obstructs_within_bounds === false,

--- a/tests/enclosure-visibility.test.ts
+++ b/tests/enclosure-visibility.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import {
+  ENCLOSURE_VISIBILITY_CYCLE,
+  nextEnclosureVisibility,
+} from "../src/contexts/LayerVisibilityContext"
+
+/** One assembled enclosure needs hidden, see-through and print-inspection modes. */
+test("enclosure appearance cycles from translucent through every state", () => {
+  expect(ENCLOSURE_VISIBILITY_CYCLE).toEqual([
+    "translucent",
+    "opaque",
+    "hidden",
+  ])
+
+  let current = ENCLOSURE_VISIBILITY_CYCLE[0]!
+  for (let i = 0; i < ENCLOSURE_VISIBILITY_CYCLE.length; i++) {
+    current = nextEnclosureVisibility(current)
+  }
+  expect(current).toBe("translucent")
+  expect(nextEnclosureVisibility("unknown" as any)).toBe("translucent")
+})

--- a/tests/legacy-fdm-enclosure-detection.test.ts
+++ b/tests/legacy-fdm-enclosure-detection.test.ts
@@ -20,8 +20,10 @@ test("recognizes only the existing synthetic enclosure CAD representation", () =
     pcb_component_id: "pcb_case",
     source_component_id: "source_case",
     center: { x: 0, y: 0 },
-    width: 0,
-    height: 0,
+    // Core updates the initial zero-size placeholder to the resolved enclosure
+    // footprint before Circuit JSON reaches the viewer.
+    width: 44,
+    height: 28,
     layer: "top",
     rotation: 0,
     do_not_place: true,
@@ -32,7 +34,12 @@ test("recognizes only the existing synthetic enclosure CAD representation", () =
   expect(isLegacyFdmEnclosure(cad, [owner])).toBe(true)
   expect(
     isLegacyFdmEnclosure(cad, [
-      { ...owner, width: 10, do_not_place: false } as AnyCircuitElement,
+      { ...owner, width: 0, height: 0 } as AnyCircuitElement,
+    ]),
+  ).toBe(true)
+  expect(
+    isLegacyFdmEnclosure(cad, [
+      { ...owner, do_not_place: false } as AnyCircuitElement,
     ]),
   ).toBe(false)
   expect(

--- a/tests/legacy-fdm-enclosure-detection.test.ts
+++ b/tests/legacy-fdm-enclosure-detection.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, CadComponent } from "circuit-json"
+import { isLegacyFdmEnclosure } from "../src/utils/is-legacy-fdm-enclosure"
+
+/** Classification is structural and does not depend on an enclosure name or ID. */
+test("recognizes only the existing synthetic enclosure CAD representation", () => {
+  const cad = {
+    type: "cad_component",
+    cad_component_id: "cad_case",
+    source_component_id: "source_case",
+    pcb_component_id: "pcb_case",
+    position: { x: 0, y: 0, z: -6 },
+    model_jscad: { type: "cuboid", size: [44, 28, 16] },
+    model_origin_alignment: "bottom_center_of_component",
+    model_object_fit: "contain_within_bounds",
+    anchor_alignment: "center",
+  } as CadComponent
+  const owner = {
+    type: "pcb_component",
+    pcb_component_id: "pcb_case",
+    source_component_id: "source_case",
+    center: { x: 0, y: 0 },
+    width: 0,
+    height: 0,
+    layer: "top",
+    rotation: 0,
+    do_not_place: true,
+    is_allowed_to_be_off_board: true,
+    obstructs_within_bounds: false,
+  } as AnyCircuitElement
+
+  expect(isLegacyFdmEnclosure(cad, [owner])).toBe(true)
+  expect(
+    isLegacyFdmEnclosure(cad, [
+      { ...owner, width: 10, do_not_place: false } as AnyCircuitElement,
+    ]),
+  ).toBe(false)
+  expect(
+    isLegacyFdmEnclosure({ ...cad, model_jscad: undefined }, [owner]),
+  ).toBe(false)
+})


### PR DESCRIPTION
Adds an independent hidden/translucent/opaque display state for the single assembled enclosure entity Core emits today.

## Compatibility representation

This PR does not consume `cad_fdm_enclosure` and does not render separate base/lid records. It structurally recognizes the current compatibility shape:

`source_component → zero-size do-not-place pcb_component → cad_component.model_jscad`

The adapter is isolated in `isLegacyFdmEnclosure`, so the later typed per-part migration can delete it without spreading ID/name heuristics through the renderer.

## Appearance

- translucent by default, so the enclosure does not hide the board it surrounds
- opaque for inspecting the generated print
- hidden for unobstructed board work
- one `Enclosure` item in the Appearance menu, matching the current single CAD entity
- viewer-owned state only; no Circuit JSON display property is added

## Validation

- TypeScript, format, build, focused visibility/detection tests and duplicate-helper gates pass
- the full local suite has the same five pre-existing failures reproduced on upstream main in a clean worktree: two faux-board Z expectations and three headless SVG baselines; this branch changes none of those paths

This belongs to the focused `merge-fdm-enclosure` effort alongside Core #3152. Typed multi-part rendering remains a later Circuit JSON migration.

## Resolved-owner detection

Core initially creates the synthetic PCB owner at zero size, then updates its width/height to the resolved enclosure footprint. The compatibility adapter therefore identifies the final record by its generated JSCAD floor anchor plus do-not-place, off-board and non-obstructing ownership flags; it does not rely on the initial zero dimensions.

## Storybook follow-up

The existing-record Storybook fixture is staged separately for focused review: https://github.com/addibble/3d-viewer/pull/1. It will be opened upstream after this appearance layer merges.
