### PR TITLE
Update circuit-to-canvas to 0.0.123

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@jscad/regl-renderer": "^2.6.12",
     "@jscad/stl-serializer": "^2.1.20",
     "circuit-json": "^0.0.465",
-    "circuit-to-canvas": "^0.0.119",
+    "circuit-to-canvas": "^0.0.123",
     "react-hot-toast": "^2.6.0",
     "three": "^0.165.0",
     "three-stdlib": "^2.36.0",


### PR DESCRIPTION
## Summary

- update `circuit-to-canvas` to `0.0.123`
- refresh the resolved dependency or generated type bundle where tracked

## Why

Recent canvas-rendering fixes were published to npm, but this consumer was still constrained to an older `0.0.x` release. Because caret ranges for `0.0.x` do not advance to the next patch, the latest fixes were not reaching downstream users.

## Validation

- formatting check passes
- production build passes
- repository tests pass where local platform prerequisites are available
