### PR TITLE
Migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/pver-release.yml
+++ b/.github/workflows/pver-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
   UPSTREAM_REPO: "runframe" # for example: "eval"
   PACKAGE_NAMES: "@tscircuit/3d-viewer" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/props"
@@ -17,16 +23,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install
       - run: bun run build
       - run: pver release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
       - name: Trigger upstream repo update
         if: env.UPSTREAM_REPO && env.PACKAGE_NAMES

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@tscircuit/3d-viewer",
   "version": "0.0.593",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/3d-viewer"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- use npm trusted publishing with GitHub Actions OIDC instead of a long-lived NPM_TOKEN
- grant id-token: write and run Node 24 with npm 11+ support
- declare an explicit GitHub repository URL in package metadata where needed

## Required npm configuration
Before merge, the npm package must trust:
- GitHub repository: tscircuit/3d-viewer
- Workflow: pver-release.yml
- Allowed action: npm publish

## Validation
- package.json parsed successfully
- release workflow parsed successfully
- git diff --check