### PR TITLE
Update jscad-electronics to 0.0.155

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bun-match-svg": "^0.0.9",
     "bun-types": "1.2.1",
     "debug": "^4.4.0",
-    "jscad-electronics": "^0.0.146",
+    "jscad-electronics": "^0.0.155",
     "jscad-planner": "^0.0.13",
     "jsdom": "^26.0.0",
     "manifold-3d": "^3.2.1",


### PR DESCRIPTION
Picks up jscad-electronics#333, which mounts through-hole pin headers on top
of the board instead of beneath it. Every `<pinheader>` renders through this
package — core resolves them to `pinrow…` footprint strings — so until this
bump the viewer draws them hanging under the PCB with 2mm of pin poking up
through the holes.

Also 32 part bodies that previously rendered as nothing: the SOT and SC-70
families, TO-252/263, electrolytics, potentiometers, SMD switches, BGA. A
footprint with no body is not a cosmetic gap in a viewer that measures
things — it has no height at all.

No test outcome changes: 41 pass and 5 fail both before and after, and the
five are the same five (faux-board z defaults, and three 3d-view-to-svg
snapshots). They fail on main today, unrelated to this dependency.

Noticed while checking that: `bun test` fails on main here, 5 of 46 — the
faux-board z defaults and three 3d-view-to-svg snapshots — and no workflow in
this repo runs `bun test`, so CI has never seen them. Untouched by this
change and left alone; flagging because a suite that nothing runs stops being
true quite quickly.
