### PR TITLE
fix: support realistic solder mask colors

### DIFF
--- a/src/textures/create-soldermask-texture-for-layer.ts
+++ b/src/textures/create-soldermask-texture-for-layer.ts
@@ -1,8 +1,8 @@
-import * as THREE from "three"
 import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import * as THREE from "three"
 import { TRACE_TEXTURE_RESOLUTION } from "../geoms/constants"
-import { drawSoldermaskLayer } from "./soldermask/soldermask-drawing"
 import { getSoldermaskRenderBounds } from "./soldermask/soldermask-bounds"
+import { drawSoldermaskLayer } from "./soldermask/soldermask-drawing"
 
 export function createSoldermaskTextureForLayer({
   layer,
@@ -42,6 +42,7 @@ export function createSoldermaskTextureForLayer({
     bounds,
     elements,
     boardMaterial: boardData.material,
+    solderMaskColor: boardData.solder_mask_color,
   })
 
   const texture = new THREE.CanvasTexture(canvas)

--- a/src/textures/soldermask/soldermask-drawing.ts
+++ b/src/textures/soldermask/soldermask-drawing.ts
@@ -1,10 +1,10 @@
-import { CircuitToCanvasDrawer } from "circuit-to-canvas"
 import type {
   AnyCircuitElement,
   PcbBoard,
   PcbCopperPour,
   PcbRenderLayer,
 } from "circuit-json"
+import { CircuitToCanvasDrawer } from "circuit-to-canvas"
 import {
   colors as defaultColors,
   soldermaskColors,
@@ -25,16 +25,37 @@ type SoldermaskPalette = {
   transparent: string
 }
 
+// Named PCB colors are intentionally less saturated than CSS colors. Real
+// solder masks are translucent coatings over copper/FR4, not pure RGB ink.
+const NAMED_SOLDER_MASK_COLORS: Record<
+  string,
+  { mask: string; maskOverCopper: string }
+> = {
+  green: { mask: "#0b5d3b", maskOverCopper: "#2f7a4f" },
+  purple: { mask: "#56317d", maskOverCopper: "#77549a" },
+  red: { mask: "#8f1f2d", maskOverCopper: "#b04b54" },
+  yellow: { mask: "#b49a00", maskOverCopper: "#c9b633" },
+  blue: { mask: "#145da0", maskOverCopper: "#3d7fb8" },
+  white: { mask: "#d5d7db", maskOverCopper: "#e2b84a" },
+  black: { mask: "#161b22", maskOverCopper: "#62666b" },
+}
+
 const getSoldermaskPalette = (
   material: PcbBoard["material"],
+  solderMaskColor?: string,
 ): SoldermaskPalette => {
-  const soldermask = toRgb(
-    soldermaskColors[material] ?? defaultColors.fr4SolderMaskGreen,
-  )
+  const namedColor = solderMaskColor
+    ? NAMED_SOLDER_MASK_COLORS[solderMaskColor.trim().toLowerCase()]
+    : undefined
+  const soldermask =
+    namedColor?.mask ??
+    solderMaskColor ??
+    toRgb(soldermaskColors[material] ?? defaultColors.fr4SolderMaskGreen)
   const soldermaskOverCopper =
-    material === "fr1"
+    namedColor?.maskOverCopper ??
+    (material === "fr1"
       ? toRgb(defaultColors.fr1TracesWithMaskCopper)
-      : toRgb(defaultColors.fr4TracesWithMaskGreen)
+      : toRgb(defaultColors.fr4TracesWithMaskGreen))
 
   return {
     soldermask,
@@ -62,14 +83,16 @@ export const drawSoldermaskLayer = ({
   bounds,
   elements,
   boardMaterial,
+  solderMaskColor,
 }: {
   ctx: CanvasRenderingContext2D
   layer: "top" | "bottom"
   bounds: OutlineBounds
   elements: AnyCircuitElement[]
   boardMaterial: PcbBoard["material"]
+  solderMaskColor?: string
 }) => {
-  const palette = getSoldermaskPalette(boardMaterial)
+  const palette = getSoldermaskPalette(boardMaterial, solderMaskColor)
   const copperRenderLayer: PcbRenderLayer =
     layer === "top" ? "top_copper" : "bottom_copper"
 

--- a/stories/solder-mask-color.stories.tsx
+++ b/stories/solder-mask-color.stories.tsx
@@ -1,0 +1,38 @@
+import { Circuit } from "@tscircuit/core"
+import { CadViewer } from "src/CadViewer"
+
+type PcbColor =
+  | "green"
+  | "purple"
+  | "red"
+  | "yellow"
+  | "blue"
+  | "white"
+  | "black"
+
+const createColorBoardCircuit = (color: PcbColor) => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board width="20mm" height="20mm" solderMaskColor={color}>
+      <resistor name="R1" footprint="0402" resistance="1k" pcbX={0} pcbY={0} />
+    </board>,
+  )
+  return circuit.getCircuitJson()
+}
+
+const ColorBoard = ({ color }: { color: PcbColor }) => (
+  <CadViewer circuitJson={createColorBoardCircuit(color) as any} />
+)
+
+export const GreenSolderMask = () => <ColorBoard color="green" />
+export const PurpleSolderMask = () => <ColorBoard color="purple" />
+export const RedSolderMask = () => <ColorBoard color="red" />
+export const YellowSolderMask = () => <ColorBoard color="yellow" />
+export const BlueSolderMask = () => <ColorBoard color="blue" />
+export const WhiteSolderMask = () => <ColorBoard color="white" />
+export const BlackSolderMask = () => <ColorBoard color="black" />
+
+export default {
+  title: "SolderMaskColor",
+  component: BlueSolderMask,
+}


### PR DESCRIPTION
Adds support for realistic solder mask colors so `<board solderMaskColor="..." />` renders with a true-to-life laminate finish instead of a flat fill.

### What changed

- `soldermask-drawing.ts` — derive the mask fill from the configured color, with proper base/shade handling per color.
- `create-soldermask-texture-for-layer.ts` — pass the board's solder mask color through to the texture generator.
- `stories/solder-mask-color.stories.tsx` — a story per supported color.

### Supported colors

![PCB solder-mask color palette](https://raw.githubusercontent.com/tscircuit/3d-viewer/7c4126dcdd2babb66e315bd824c84eb02853168b/docs/solder-mask-colors.png)

### Rendered output

Captured from the new `SolderMaskColor` stories (20mm × 20mm board, single 0402 resistor).

<img width="588" height="588" alt="image" src="https://github.com/user-attachments/assets/4f6b4ec5-5448-44c3-9df7-d8725eb4f624" />

### Usage

```tsx
<board width="20mm" height="20mm" solderMaskColor="blue">
  <resistor name="R1" footprint="0402" resistance="1k" pcbX={0} pcbY={0} />
</board>
```
